### PR TITLE
refactor: rename CLI package from @chkit/cli to chkit

### DIFF
--- a/.changeset/fix-workspace-deps.md
+++ b/.changeset/fix-workspace-deps.md
@@ -1,5 +1,5 @@
 ---
-"@chkit/cli": patch
+"chkit": patch
 "@chkit/clickhouse": patch
 "@chkit/codegen": patch
 "@chkit/core": patch

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -3,7 +3,7 @@
   "tag": "beta",
   "initialVersions": {
     "@chkit/docs": "0.0.1",
-    "@chkit/cli": "0.0.0",
+    "chkit": "0.0.0",
     "@chkit/clickhouse": "0.0.0",
     "@chkit/codegen": "0.0.0",
     "@chkit/core": "0.0.0",

--- a/.changeset/rename-plugin-codegen.md
+++ b/.changeset/rename-plugin-codegen.md
@@ -1,5 +1,5 @@
 ---
-"@chkit/cli": patch
+"chkit": patch
 "@chkit/clickhouse": patch
 "@chkit/codegen": patch
 "@chkit/core": patch

--- a/.changeset/rename-to-chkit.md
+++ b/.changeset/rename-to-chkit.md
@@ -1,5 +1,5 @@
 ---
-"@chkit/cli": patch
+"chkit": patch
 "@chkit/clickhouse": patch
 "@chkit/codegen": patch
 "@chkit/core": patch

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **ClickHouse schema and migration CLI for TypeScript projects.**
 
-[![npm version](https://img.shields.io/npm/v/@chkit/cli?label=npm)](https://www.npmjs.com/package/@chkit/cli)
+[![npm version](https://img.shields.io/npm/v/chkit?label=npm)](https://www.npmjs.com/package/chkit)
 [![CI](https://github.com/obsessiondb/chkit/actions/workflows/ci.yml/badge.svg)](https://github.com/obsessiondb/chkit/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-chkit.obsessiondb.com-blue)](https://chkit.obsessiondb.com)
 
@@ -22,7 +22,7 @@ Define your ClickHouse tables, views, and materialized views in TypeScript. chki
 ## Quick Start
 
 ```bash
-bun add -d @chkit/cli @chkit/core
+bun add -d chkit @chkit/core
 bunx chkit init
 ```
 
@@ -101,7 +101,7 @@ See the [configuration docs](https://chkit.obsessiondb.com/configuration/overvie
 
 | Package | Description |
 |---------|-------------|
-| [`@chkit/cli`](packages/cli) | CLI binary and command implementations |
+| [`chkit`](packages/cli) | CLI binary and command implementations |
 | [`@chkit/core`](packages/core) | Schema DSL, config, and diff engine |
 | [`@chkit/clickhouse`](packages/clickhouse) | ClickHouse client wrapper |
 | [`@chkit/codegen`](packages/codegen) | TypeScript type generation engine |

--- a/bun.lock
+++ b/bun.lock
@@ -25,8 +25,8 @@
       },
     },
     "packages/cli": {
-      "name": "@chkit/cli",
-      "version": "0.1.0-beta.4",
+      "name": "chkit",
+      "version": "0.1.0-beta.5",
       "bin": {
         "chkit": "./dist/bin/chkit.js",
       },
@@ -40,7 +40,7 @@
     },
     "packages/clickhouse": {
       "name": "@chkit/clickhouse",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "@clickhouse/client": "^1.11.0",
@@ -48,28 +48,28 @@
     },
     "packages/codegen": {
       "name": "@chkit/codegen",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "dependencies": {
         "@chkit/core": "workspace:*",
       },
     },
     "packages/core": {
       "name": "@chkit/core",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "dependencies": {
         "fast-glob": "^3.3.2",
       },
     },
     "packages/plugin-backfill": {
       "name": "@chkit/plugin-backfill",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "dependencies": {
         "@chkit/core": "workspace:*",
       },
     },
     "packages/plugin-codegen": {
       "name": "@chkit/plugin-codegen",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "fast-glob": "^3.3.2",
@@ -80,7 +80,7 @@
     },
     "packages/plugin-pull": {
       "name": "@chkit/plugin-pull",
-      "version": "0.1.0-beta.4",
+      "version": "0.1.0-beta.5",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -167,8 +167,6 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
-
-    "@chkit/cli": ["@chkit/cli@workspace:packages/cli"],
 
     "@chkit/clickhouse": ["@chkit/clickhouse@workspace:packages/clickhouse"],
 
@@ -523,6 +521,8 @@
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "chkit": ["chkit@workspace:packages/cli"],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @chkit/cli
+# chkit
 
 ## 0.1.0-beta.5
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-# @chkit/cli
+# chkit
 
 ClickHouse schema and migration CLI for TypeScript projects.
 
@@ -7,7 +7,7 @@ Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
 ## Install
 
 ```bash
-bun add -d @chkit/cli @chkit/core
+bun add -d chkit @chkit/core
 ```
 
 ## Usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chkit/cli",
+  "name": "chkit",
   "version": "0.1.0-beta.5",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -4,7 +4,7 @@ ClickHouse client wrapper used internally by chkit.
 
 Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
 
-> **Note:** This is an internal package. You typically don't need to install it directly -- it's used by `@chkit/cli` and other chkit packages.
+> **Note:** This is an internal package. You typically don't need to install it directly -- it's used by `chkit` and other chkit packages.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Rename the CLI package from `@chkit/cli` to `chkit` on npm for better usability and ergonomics. Users can now install and run the CLI with less typing: `npm install chkit` instead of `npm install @chkit/cli`.

## Changes

- Update `packages/cli/package.json` to change the package name from `@chkit/cli` to `chkit`
- Update `.changeset/pre.json` to reflect the new package name in Changesets configuration
- Update all changeset files (rename-plugin-codegen, fix-workspace-deps, rename-to-chkit) to reference the new package name
- Update documentation and README files across the monorepo to reference `chkit` instead of `@chkit/cli`
- Regenerate `bun.lock` to reflect the package name change

The CLI binary command (`chkit`) and all import paths for internal packages remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)