### PR TITLE
docs: add homepage, repository, and CLI cross-links to all packages

### DIFF
--- a/.changeset/add-pkg-links.md
+++ b/.changeset/add-pkg-links.md
@@ -1,0 +1,11 @@
+---
+"chkit": patch
+"@chkit/clickhouse": patch
+"@chkit/codegen": patch
+"@chkit/core": patch
+"@chkit/plugin-backfill": patch
+"@chkit/plugin-codegen": patch
+"@chkit/plugin-pull": patch
+---
+
+Add homepage and repository metadata to all packages, and link READMEs to the chkit CLI package and documentation site.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# chkit
+
+ClickHouse schema management and migration toolkit for TypeScript.
+
+## Project Structure
+
+This is a monorepo managed with Bun workspaces and Turborepo.
+
+### Main Package (Entry Point)
+
+**`chkit`** (`packages/cli`) is the CLI and the primary distribution package. Its README is the main README shown on npm. All other packages exist to support the CLI or extend it via plugins. When users install chkit, they run `bun add -d chkit`.
+
+### Packages
+
+| Package | npm name | Role |
+|---------|----------|------|
+| `packages/cli` | `chkit` | **CLI binary and main entry point** |
+| `packages/core` | `@chkit/core` | Schema DSL, config, diff engine, migration planner |
+| `packages/clickhouse` | `@chkit/clickhouse` | ClickHouse client wrapper (internal) |
+| `packages/codegen` | `@chkit/codegen` | Migration artifact generator (internal) |
+| `packages/plugin-codegen` | `@chkit/plugin-codegen` | Plugin: TypeScript type + Zod schema generation |
+| `packages/plugin-pull` | `@chkit/plugin-pull` | Plugin: introspect live ClickHouse into schema files |
+| `packages/plugin-backfill` | `@chkit/plugin-backfill` | Plugin: time-windowed data backfill with checkpoints |
+
+### Documentation
+
+- Website: https://chkit.obsessiondb.com
+- GitHub: https://github.com/obsessiondb/chkit
+
+## Key Conventions
+
+- All packages publish to npm with `homepage: "https://chkit.obsessiondb.com"` and `repository` pointing to the monorepo with the correct `directory`.
+- Every package README links to the `chkit` CLI on npm as the entry point and to the documentation website.
+- Internal packages (`@chkit/clickhouse`, `@chkit/codegen`) are not meant to be installed directly by users.
+- Plugins extend the CLI and are registered in `clickhouse.config.ts` via the `plugins` array.
+
+## CLI Commands
+
+`init`, `generate`, `migrate`, `status`, `drift`, `check`, `codegen`, `pull`, `plugin`
+
+All commands support `--json` for machine-readable output and `--config <path>` for custom config files.
+
+## Development
+
+```bash
+bun install          # install dependencies
+bun run build        # build all packages
+bun run test         # run all tests
+bun run typecheck    # type-check all packages
+bun run lint         # lint all packages
+```
+
+## Release
+
+Uses changesets. Run `bun run changeset` to create a changeset, then `bun run version-packages` to bump versions.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,12 +2,24 @@
 
 ClickHouse schema and migration CLI for TypeScript projects.
 
-Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
+Define your ClickHouse schema in TypeScript, generate migrations automatically, detect drift, and run CI checks -- all from a single CLI.
+
+## Features
+
+- **Schema-as-code** -- Define tables, views, and materialized views in TypeScript using a declarative DSL
+- **Automatic migration generation** -- Diff your schema changes and generate timestamped SQL migrations with rename detection
+- **Safe migrations** -- Destructive operations are flagged with risk levels and require explicit confirmation
+- **Drift detection** -- Compare your local schema against a live ClickHouse instance to catch out-of-band changes
+- **CI gate** -- Run `chkit check` to fail builds on pending migrations, checksum mismatches, or schema drift
+- **TypeScript codegen** -- Generate row types and optional Zod schemas from your schema definitions (`@chkit/plugin-codegen`)
+- **Schema pulling** -- Introspect an existing ClickHouse database into local schema files (`@chkit/plugin-pull`)
+- **Data backfill** -- Time-windowed, checkpointed backfill operations with retry logic (`@chkit/plugin-backfill`)
+- **JSON output** -- Every command supports `--json` for scripting and automation
 
 ## Install
 
 ```bash
-bun add -d chkit @chkit/core
+bun add -d chkit
 ```
 
 ## Usage
@@ -34,6 +46,14 @@ bunx chkit check
 
 All commands support `--json` for machine-readable output and `--config <path>` to specify a custom config file.
 
+## Plugins
+
+| Plugin | Description |
+|--------|-------------|
+| [`@chkit/plugin-codegen`](https://www.npmjs.com/package/@chkit/plugin-codegen) | Generate TypeScript row types and Zod schemas |
+| [`@chkit/plugin-pull`](https://www.npmjs.com/package/@chkit/plugin-pull) | Pull schemas from a live ClickHouse instance |
+| [`@chkit/plugin-backfill`](https://www.npmjs.com/package/@chkit/plugin-backfill) | Time-windowed data backfill with checkpoints |
+
 ## Documentation
 
 See the [chkit documentation](https://chkit.obsessiondb.com).
@@ -41,3 +61,7 @@ See the [chkit documentation](https://chkit.obsessiondb.com).
 ## License
 
 [MIT](../../LICENSE)
+
+---
+
+Sponsored by [ObsessionDB](https://obsessiondb.com)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,12 @@
 {
   "name": "chkit",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/cli"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -4,7 +4,17 @@ ClickHouse client wrapper used internally by chkit.
 
 Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
 
-> **Note:** This is an internal package. You typically don't need to install it directly -- it's used by `chkit` and other chkit packages.
+> **Note:** This is an internal package. You typically don't need to install it directly -- it's used by [`chkit`](https://www.npmjs.com/package/chkit) and other chkit packages.
+
+## Getting Started
+
+To get started with chkit, install the CLI:
+
+```bash
+bun add -d chkit
+```
+
+See the [`chkit` CLI package](https://www.npmjs.com/package/chkit) for usage instructions.
 
 ## Documentation
 

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@chkit/clickhouse",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/clickhouse"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -6,6 +6,16 @@ Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
 
 > **Note:** This is an internal package. To generate TypeScript types from your schema, use `@chkit/plugin-codegen` or run `bunx chkit codegen`.
 
+## Getting Started
+
+To get started with chkit, install the CLI:
+
+```bash
+bun add -d chkit
+```
+
+See the [`chkit` CLI package](https://www.npmjs.com/package/chkit) for usage instructions.
+
 ## Documentation
 
 See the [chkit documentation](https://chkit.obsessiondb.com).

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@chkit/codegen",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/codegen"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Schema DSL, configuration, and diff engine for chkit.
 
-Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
+Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo. This package is typically used together with the [`chkit`](https://www.npmjs.com/package/chkit) CLI.
 
 ## Install
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@chkit/core",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/core"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-backfill/README.md
+++ b/packages/plugin-backfill/README.md
@@ -2,7 +2,7 @@
 
 Plugin for data backfill operations in chkit.
 
-Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
+Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo. This plugin extends the [`chkit`](https://www.npmjs.com/package/chkit) CLI with data backfill commands.
 
 ## Install
 

--- a/packages/plugin-backfill/package.json
+++ b/packages/plugin-backfill/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@chkit/plugin-backfill",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/plugin-backfill"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-codegen/README.md
+++ b/packages/plugin-codegen/README.md
@@ -2,7 +2,7 @@
 
 Plugin to generate TypeScript row types and optional Zod schemas from your chkit schema definitions.
 
-Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
+Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo. This plugin extends the [`chkit`](https://www.npmjs.com/package/chkit) CLI with TypeScript code generation.
 
 ## Install
 

--- a/packages/plugin-codegen/package.json
+++ b/packages/plugin-codegen/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@chkit/plugin-codegen",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/plugin-codegen"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-pull/README.md
+++ b/packages/plugin-pull/README.md
@@ -2,7 +2,7 @@
 
 Plugin to pull existing ClickHouse table schemas into local chkit schema files.
 
-Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo.
+Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo. This plugin extends the [`chkit`](https://www.npmjs.com/package/chkit) CLI with schema pulling from existing ClickHouse databases.
 
 ## Install
 

--- a/packages/plugin-pull/package.json
+++ b/packages/plugin-pull/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@chkit/plugin-pull",
   "version": "0.1.0-beta.6",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/plugin-pull"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Add npm metadata (`homepage` and `repository` with directory) to all 7 packages linking to the documentation site and GitHub monorepo
- Update all package READMEs to explicitly link to the chkit CLI as the entry point
- Simplify install instructions across all packages to just `bun add -d chkit`
- Expand the main CLI README with 9 feature highlights and a plugin reference table
- Add CLAUDE.md documenting project structure and conventions; clarify that `chkit` (the CLI) is the primary entry point and distribution package
- Add sponsorship attribution to ObsessionDB in the main CLI README

The chkit package is now the clear main entry point for the entire monorepo, with all supporting packages linked back to it.

## Test plan

- [x] All package.json files have homepage and repository fields
- [x] All READMEs link to the chkit CLI on npm
- [x] Install instructions are consistent across packages
- [x] Documentation links point to https://chkit.obsessiondb.com
- [x] CLAUDE.md provides clear project orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)