### PR TITLE
fix: create database in e2e fixture to prevent flaky tests

### DIFF
--- a/packages/cli/src/clickhouse-live.e2e.test.ts
+++ b/packages/cli/src/clickhouse-live.e2e.test.ts
@@ -91,6 +91,17 @@ async function createFixture(database: string): Promise<E2EFixture> {
     'utf8'
   )
 
+  const auth = Buffer.from(`${clickhouseUser}:${clickhousePassword}`).toString('base64')
+  await fetch(clickhouseUrl, {
+    method: 'POST',
+    signal: AbortSignal.timeout(10_000),
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'text/plain',
+    },
+    body: `CREATE DATABASE IF NOT EXISTS ${database}`,
+  })
+
   return { dir, configPath, migrationsDir, schemaPath }
 }
 


### PR DESCRIPTION
## Summary
Fixed flaky e2e tests by ensuring the ClickHouse database is created before migrations run. The `createFixture` function now executes `CREATE DATABASE IF NOT EXISTS` using the same HTTP fetch pattern as the existing `dropDatabase` helper.

## Changes
Added database creation to `createFixture` after config file setup, using Basic auth to send a CREATE DATABASE IF NOT EXISTS statement to ClickHouse. This ensures the database exists when subsequent `migrate --execute` commands run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)