### PR TITLE
Add @chkit/plugin-obsessiondb for ObsessionDB engine compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,13 @@
         "zod": "^4.3.6",
       },
     },
+    "packages/plugin-obsessiondb": {
+      "name": "@chkit/plugin-obsessiondb",
+      "version": "0.1.0-beta.7",
+      "dependencies": {
+        "@chkit/core": "workspace:*",
+      },
+    },
     "packages/plugin-pull": {
       "name": "@chkit/plugin-pull",
       "version": "0.1.0-beta.7",
@@ -177,6 +184,8 @@
     "@chkit/plugin-backfill": ["@chkit/plugin-backfill@workspace:packages/plugin-backfill"],
 
     "@chkit/plugin-codegen": ["@chkit/plugin-codegen@workspace:packages/plugin-codegen"],
+
+    "@chkit/plugin-obsessiondb": ["@chkit/plugin-obsessiondb@workspace:packages/plugin-obsessiondb"],
 
     "@chkit/plugin-pull": ["@chkit/plugin-pull@workspace:packages/plugin-pull"],
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,6 +53,7 @@ All commands support `--json` for machine-readable output and `--config <path>` 
 | [`@chkit/plugin-codegen`](https://www.npmjs.com/package/@chkit/plugin-codegen) | Generate TypeScript row types and Zod schemas |
 | [`@chkit/plugin-pull`](https://www.npmjs.com/package/@chkit/plugin-pull) | Pull schemas from a live ClickHouse instance |
 | [`@chkit/plugin-backfill`](https://www.npmjs.com/package/@chkit/plugin-backfill) | Time-windowed data backfill with checkpoints |
+| [`@chkit/plugin-obsessiondb`](https://www.npmjs.com/package/@chkit/plugin-obsessiondb) | Auto-rewrite Shared engines for ObsessionDB compatibility |
 
 ## Documentation
 

--- a/packages/plugin-obsessiondb/README.md
+++ b/packages/plugin-obsessiondb/README.md
@@ -1,0 +1,88 @@
+# @chkit/plugin-obsessiondb
+
+[ObsessionDB](https://obsessiondb.com) companion plugin for chkit. This plugin is designed for [ObsessionDB](https://obsessiondb.com) users who also need to target regular ClickHouse instances (e.g. local development, self-hosted staging).
+
+Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo. This plugin extends the [`chkit`](https://www.npmjs.com/package/chkit) CLI with automatic engine rewriting.
+
+## Features
+
+- **Automatic `Shared` engine stripping** -- Rewrites `SharedXXXTree` engines (e.g. `SharedReplacingMergeTree`) to their standard ClickHouse equivalents when targeting non-ObsessionDB instances
+- **Host auto-detection** -- Inspects `clickhouse.url` to determine whether the target is ObsessionDB or regular ClickHouse, no manual configuration needed
+- **CLI flag overrides** -- `--force-shared-engines` and `--no-shared-engines` flags to override auto-detection on any command
+- **Works with all schema commands** -- Hooks into `generate`, `migrate`, `status`, `drift`, and `check`
+- **Views and materialized views are untouched** -- Only table engine definitions are rewritten
+
+## Why
+
+ObsessionDB and ClickHouse Cloud use `Shared` engine variants (e.g. `SharedReplacingMergeTree`, `SharedMergeTree`). These engines don't exist in regular ClickHouse. If you define schemas with `Shared` engines but target a standard ClickHouse instance, migrations will fail.
+
+This plugin intercepts schema definitions before the diff/planning pipeline and strips the `Shared` prefix when needed, so you can use a single set of schema files across both ObsessionDB and regular ClickHouse.
+
+## Install
+
+```bash
+bun add -d @chkit/plugin-obsessiondb
+```
+
+## Usage
+
+Register the plugin in your config:
+
+```ts
+// clickhouse.config.ts
+import { defineConfig } from '@chkit/core'
+import { obsessiondb } from '@chkit/plugin-obsessiondb'
+
+export default defineConfig({
+  schema: './src/db/schema/**/*.ts',
+  outDir: './chkit',
+  plugins: [
+    obsessiondb(),
+  ],
+  clickhouse: {
+    url: process.env.CLICKHOUSE_URL ?? 'http://localhost:8123',
+  },
+})
+```
+
+The plugin works automatically with `generate`, `migrate`, `status`, `drift`, and `check` commands.
+
+## How it works
+
+1. **Auto-detection** (default): The plugin inspects your `clickhouse.url` config value. If the host is an ObsessionDB instance (`.obsessiondb.com` or `obsession.numia-dev.com`), `Shared` engines are kept as-is. Otherwise, the `Shared` prefix is stripped.
+
+2. **Force flags**: Override auto-detection with CLI flags:
+   - `--force-shared-engines` -- Keep `Shared` engine prefixes, even on regular ClickHouse
+   - `--no-shared-engines` -- Strip `Shared` engine prefixes, even on ObsessionDB
+
+### Examples
+
+```bash
+# Auto-detect based on clickhouse.url (default behavior)
+bunx chkit generate
+
+# Force stripping even when targeting ObsessionDB
+bunx chkit generate --no-shared-engines
+
+# Force keeping Shared engines even on regular ClickHouse
+bunx chkit migrate --force-shared-engines
+```
+
+### Engine rewriting
+
+| Schema engine | Regular ClickHouse | ObsessionDB |
+|---|---|---|
+| `SharedMergeTree` | `MergeTree` | `SharedMergeTree` |
+| `SharedReplacingMergeTree(ts)` | `ReplacingMergeTree(ts)` | `SharedReplacingMergeTree(ts)` |
+| `SharedAggregatingMergeTree` | `AggregatingMergeTree` | `SharedAggregatingMergeTree` |
+| `MergeTree` | `MergeTree` | `MergeTree` |
+
+Only table definitions are affected. Views and materialized views are passed through unchanged.
+
+## Documentation
+
+See the [chkit documentation](https://chkit.obsessiondb.com).
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/plugin-obsessiondb/package.json
+++ b/packages/plugin-obsessiondb/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@chkit/plugin-obsessiondb",
+  "version": "0.1.0-beta.7",
+  "homepage": "https://chkit.obsessiondb.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/obsessiondb/chkit.git",
+    "directory": "packages/plugin-obsessiondb"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "biome lint src",
+    "test": "bun test src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chkit/core": "workspace:*"
+  }
+}

--- a/packages/plugin-obsessiondb/src/index.test.ts
+++ b/packages/plugin-obsessiondb/src/index.test.ts
@@ -219,9 +219,9 @@ describe('obsessiondb plugin', () => {
 
     expect(result).toBeDefined()
     expect(result).toHaveLength(3)
-    expect((result![0] as { engine: string }).engine).toBe('ReplacingMergeTree(ts)')
-    expect((result![1] as { engine: string }).engine).toBe('MergeTree')
-    expect(result![2]).toEqual(makeView('events_view'))
+    expect((result?.[0] as { engine: string }).engine).toBe('ReplacingMergeTree(ts)')
+    expect((result?.[1] as { engine: string }).engine).toBe('MergeTree')
+    expect(result?.[2]).toEqual(makeView('events_view'))
   })
 
   test('onSchemaLoaded is a no-op for ObsessionDB hosts', () => {

--- a/packages/plugin-obsessiondb/src/index.test.ts
+++ b/packages/plugin-obsessiondb/src/index.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from 'bun:test'
+import type { ResolvedChxConfig, SchemaDefinition } from '@chkit/core'
+
+import {
+  isObsessionDBHost,
+  obsessiondb,
+  resolveStripBehavior,
+  rewriteSharedEngines,
+  stripSharedPrefix,
+} from './index'
+
+function makeConfig(url?: string): ResolvedChxConfig {
+  return {
+    schema: ['schema/**/*.ts'],
+    outDir: '.chkit',
+    migrationsDir: 'migrations',
+    metaDir: '.chkit/meta',
+    plugins: [],
+    check: { unusedTables: true, unusedColumns: true },
+    safety: { allowDestructive: false },
+    ...(url ? { clickhouse: { url, username: 'default', password: '', database: 'default', secure: false } } : {}),
+  }
+}
+
+function makeTable(name: string, engine: string): SchemaDefinition {
+  return {
+    kind: 'table',
+    database: 'default',
+    name,
+    columns: [{ name: 'id', type: 'UInt64' }],
+    engine,
+    primaryKey: ['id'],
+    orderBy: ['id'],
+  }
+}
+
+function makeView(name: string): SchemaDefinition {
+  return {
+    kind: 'view',
+    database: 'default',
+    name,
+    as: 'SELECT 1',
+  }
+}
+
+function makeMaterializedView(name: string): SchemaDefinition {
+  return {
+    kind: 'materialized_view',
+    database: 'default',
+    name,
+    to: { database: 'default', name: 'target' },
+    as: 'SELECT 1',
+  }
+}
+
+describe('isObsessionDBHost', () => {
+  test('matches obsessiondb.com subdomains', () => {
+    expect(isObsessionDBHost('https://my-cluster.obsessiondb.com:8443')).toBe(true)
+    expect(isObsessionDBHost('https://app.obsessiondb.com')).toBe(true)
+    expect(isObsessionDBHost('https://obsessiondb.com')).toBe(true)
+  })
+
+  test('matches numia-dev.com hosts', () => {
+    expect(isObsessionDBHost('https://obsession.numia-dev.com:8443')).toBe(true)
+    expect(isObsessionDBHost('https://ch.obsession.numia-dev.com')).toBe(true)
+  })
+
+  test('does not match regular ClickHouse hosts', () => {
+    expect(isObsessionDBHost('http://localhost:8123')).toBe(false)
+    expect(isObsessionDBHost('https://clickhouse.example.com:8443')).toBe(false)
+    expect(isObsessionDBHost('https://notobsessiondb.com')).toBe(false)
+  })
+
+  test('returns false for invalid URLs', () => {
+    expect(isObsessionDBHost('not-a-url')).toBe(false)
+    expect(isObsessionDBHost('')).toBe(false)
+  })
+})
+
+describe('stripSharedPrefix', () => {
+  test('strips Shared prefix from engine names', () => {
+    expect(stripSharedPrefix('SharedReplacingMergeTree(ingested_at)')).toBe('ReplacingMergeTree(ingested_at)')
+    expect(stripSharedPrefix('SharedMergeTree')).toBe('MergeTree')
+    expect(stripSharedPrefix('SharedAggregatingMergeTree')).toBe('AggregatingMergeTree')
+  })
+
+  test('leaves non-Shared engines unchanged', () => {
+    expect(stripSharedPrefix('MergeTree')).toBe('MergeTree')
+    expect(stripSharedPrefix('ReplacingMergeTree(ts)')).toBe('ReplacingMergeTree(ts)')
+    expect(stripSharedPrefix('Log')).toBe('Log')
+  })
+})
+
+describe('rewriteSharedEngines', () => {
+  test('rewrites Shared engines on tables', () => {
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'SharedReplacingMergeTree(ingested_at)'),
+      makeTable('users', 'SharedMergeTree'),
+    ]
+    const result = rewriteSharedEngines(definitions)
+
+    expect(result.count).toBe(2)
+    expect((result.definitions[0] as { engine: string }).engine).toBe('ReplacingMergeTree(ingested_at)')
+    expect((result.definitions[1] as { engine: string }).engine).toBe('MergeTree')
+  })
+
+  test('skips views and materialized views', () => {
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'SharedMergeTree'),
+      makeView('events_view'),
+      makeMaterializedView('events_mv'),
+    ]
+    const result = rewriteSharedEngines(definitions)
+
+    expect(result.count).toBe(1)
+    expect(result.definitions).toHaveLength(3)
+    expect(result.definitions[1]).toEqual(makeView('events_view'))
+    expect(result.definitions[2]).toEqual(makeMaterializedView('events_mv'))
+  })
+
+  test('skips tables without Shared prefix', () => {
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'MergeTree'),
+      makeTable('users', 'ReplacingMergeTree(ts)'),
+    ]
+    const result = rewriteSharedEngines(definitions)
+
+    expect(result.count).toBe(0)
+    expect(result.definitions).toEqual(definitions)
+  })
+
+  test('handles empty definitions', () => {
+    const result = rewriteSharedEngines([])
+
+    expect(result.count).toBe(0)
+    expect(result.definitions).toEqual([])
+  })
+
+  test('handles mix of Shared and non-Shared tables', () => {
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'SharedReplacingMergeTree(ts)'),
+      makeTable('users', 'MergeTree'),
+      makeTable('logs', 'SharedMergeTree'),
+    ]
+    const result = rewriteSharedEngines(definitions)
+
+    expect(result.count).toBe(2)
+    expect((result.definitions[0] as { engine: string }).engine).toBe('ReplacingMergeTree(ts)')
+    expect((result.definitions[1] as { engine: string }).engine).toBe('MergeTree')
+    expect((result.definitions[2] as { engine: string }).engine).toBe('MergeTree')
+  })
+})
+
+describe('resolveStripBehavior', () => {
+  test('--force-shared-engines prevents stripping', () => {
+    const config = makeConfig('http://localhost:8123')
+    expect(resolveStripBehavior(config, { 'force-shared-engines': true })).toBe(false)
+  })
+
+  test('--no-shared-engines forces stripping', () => {
+    const config = makeConfig('https://my-cluster.obsessiondb.com:8443')
+    expect(resolveStripBehavior(config, { 'no-shared-engines': true })).toBe(true)
+  })
+
+  test('--force-shared-engines takes precedence over --no-shared-engines', () => {
+    const config = makeConfig('http://localhost:8123')
+    expect(resolveStripBehavior(config, { 'force-shared-engines': true, 'no-shared-engines': true })).toBe(false)
+  })
+
+  test('auto-detects ObsessionDB host and keeps Shared engines', () => {
+    const config = makeConfig('https://my-cluster.obsessiondb.com:8443')
+    expect(resolveStripBehavior(config, {})).toBe(false)
+  })
+
+  test('auto-detects regular ClickHouse and strips Shared engines', () => {
+    const config = makeConfig('http://localhost:8123')
+    expect(resolveStripBehavior(config, {})).toBe(true)
+  })
+
+  test('strips when no clickhouse config is present', () => {
+    const config = makeConfig()
+    expect(resolveStripBehavior(config, {})).toBe(true)
+  })
+})
+
+describe('obsessiondb plugin', () => {
+  test('creates typed inline plugin registration', () => {
+    const registration = obsessiondb()
+
+    expect(registration.name).toBe('obsessiondb')
+    expect(registration.enabled).toBe(true)
+    expect(registration.plugin.manifest.name).toBe('obsessiondb')
+    expect(registration.plugin.manifest.apiVersion).toBe(1)
+  })
+
+  test('registers extendCommands for generate, migrate, status, drift, check', () => {
+    const registration = obsessiondb()
+    const ext = registration.plugin.extendCommands[0]
+
+    expect(ext?.command).toEqual(['generate', 'migrate', 'status', 'drift', 'check'])
+    expect(ext?.flags).toHaveLength(2)
+    expect(ext?.flags[0]?.name).toBe('--force-shared-engines')
+    expect(ext?.flags[1]?.name).toBe('--no-shared-engines')
+  })
+
+  test('onSchemaLoaded strips Shared engines for regular ClickHouse', () => {
+    const registration = obsessiondb()
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'SharedReplacingMergeTree(ts)'),
+      makeTable('users', 'MergeTree'),
+      makeView('events_view'),
+    ]
+
+    const result = registration.plugin.hooks.onSchemaLoaded({
+      config: makeConfig('http://localhost:8123'),
+      flags: {},
+      definitions,
+    })
+
+    expect(result).toBeDefined()
+    expect(result).toHaveLength(3)
+    expect((result![0] as { engine: string }).engine).toBe('ReplacingMergeTree(ts)')
+    expect((result![1] as { engine: string }).engine).toBe('MergeTree')
+    expect(result![2]).toEqual(makeView('events_view'))
+  })
+
+  test('onSchemaLoaded is a no-op for ObsessionDB hosts', () => {
+    const registration = obsessiondb()
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'SharedReplacingMergeTree(ts)'),
+    ]
+
+    const result = registration.plugin.hooks.onSchemaLoaded({
+      config: makeConfig('https://my-cluster.obsessiondb.com:8443'),
+      flags: {},
+      definitions,
+    })
+
+    expect(result).toBeUndefined()
+  })
+
+  test('onSchemaLoaded returns undefined when no Shared engines exist', () => {
+    const registration = obsessiondb()
+    const definitions: SchemaDefinition[] = [
+      makeTable('events', 'MergeTree'),
+    ]
+
+    const result = registration.plugin.hooks.onSchemaLoaded({
+      config: makeConfig('http://localhost:8123'),
+      flags: {},
+      definitions,
+    })
+
+    expect(result).toBeDefined()
+    expect(result).toHaveLength(1)
+  })
+})

--- a/packages/plugin-obsessiondb/src/index.ts
+++ b/packages/plugin-obsessiondb/src/index.ts
@@ -4,7 +4,7 @@ import type {
   SchemaDefinition,
 } from '@chkit/core'
 
-export interface ObsessionDBPluginOptions {}
+export type ObsessionDBPluginOptions = Record<string, never>
 
 interface ObsessionDBPlugin {
   manifest: { name: 'obsessiondb'; apiVersion: 1 }
@@ -21,7 +21,7 @@ interface ObsessionDBPlugin {
       config: ResolvedChxConfig
       flags: Record<string, string | string[] | boolean | undefined>
       definitions: SchemaDefinition[]
-    }): SchemaDefinition[] | void
+    }): SchemaDefinition[] | undefined
   }
 }
 

--- a/packages/plugin-obsessiondb/src/index.ts
+++ b/packages/plugin-obsessiondb/src/index.ts
@@ -1,0 +1,121 @@
+import type {
+  ChxInlinePluginRegistration,
+  ResolvedChxConfig,
+  SchemaDefinition,
+} from '@chkit/core'
+
+export interface ObsessionDBPluginOptions {}
+
+interface ObsessionDBPlugin {
+  manifest: { name: 'obsessiondb'; apiVersion: 1 }
+  extendCommands: Array<{
+    command: string[]
+    flags: Array<{
+      name: string
+      type: 'boolean'
+      description: string
+    }>
+  }>
+  hooks: {
+    onSchemaLoaded(context: {
+      config: ResolvedChxConfig
+      flags: Record<string, string | string[] | boolean | undefined>
+      definitions: SchemaDefinition[]
+    }): SchemaDefinition[] | void
+  }
+}
+
+type ObsessionDBRegistration = ChxInlinePluginRegistration<
+  ObsessionDBPlugin,
+  ObsessionDBPluginOptions
+>
+
+export function isObsessionDBHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return (
+      hostname === 'obsessiondb.com' ||
+      hostname.endsWith('.obsessiondb.com') ||
+      hostname === 'obsession.numia-dev.com' ||
+      hostname.endsWith('.obsession.numia-dev.com')
+    )
+  } catch {
+    return false
+  }
+}
+
+export function resolveStripBehavior(
+  config: ResolvedChxConfig,
+  flags: Record<string, string | string[] | boolean | undefined>,
+): boolean {
+  if (flags['force-shared-engines']) return false
+  if (flags['no-shared-engines']) return true
+  // Auto-detect: if targeting ObsessionDB, keep Shared engines
+  const url = config.clickhouse?.url
+  if (url && isObsessionDBHost(url)) return false
+  return true
+}
+
+export function stripSharedPrefix(engine: string): string {
+  return engine.replace(/^Shared/, '')
+}
+
+export function rewriteSharedEngines(definitions: SchemaDefinition[]): {
+  definitions: SchemaDefinition[]
+  count: number
+} {
+  let count = 0
+  const rewritten = definitions.map((def) => {
+    if (def.kind !== 'table') return def
+    if (!def.engine.startsWith('Shared')) return def
+    count++
+    return { ...def, engine: stripSharedPrefix(def.engine) }
+  })
+  return { definitions: rewritten, count }
+}
+
+function createObsessionDBPlugin(_options: ObsessionDBPluginOptions): ObsessionDBPlugin {
+  return {
+    manifest: { name: 'obsessiondb', apiVersion: 1 },
+    extendCommands: [
+      {
+        command: ['generate', 'migrate', 'status', 'drift', 'check'],
+        flags: [
+          {
+            name: '--force-shared-engines',
+            type: 'boolean',
+            description: 'Keep Shared engine prefixes (skip stripping)',
+          },
+          {
+            name: '--no-shared-engines',
+            type: 'boolean',
+            description: 'Strip Shared engine prefixes (even on ObsessionDB)',
+          },
+        ],
+      },
+    ],
+    hooks: {
+      onSchemaLoaded(context) {
+        const shouldStrip = resolveStripBehavior(context.config, context.flags)
+        if (!shouldStrip) return
+
+        const rewritten = rewriteSharedEngines(context.definitions)
+        if (rewritten.count > 0) {
+          console.log(
+            `obsessiondb: Rewrote ${rewritten.count} Shared engine(s) to standard ClickHouse equivalents.`,
+          )
+        }
+        return rewritten.definitions
+      },
+    },
+  }
+}
+
+export function obsessiondb(options: ObsessionDBPluginOptions = {}): ObsessionDBRegistration {
+  return {
+    plugin: createObsessionDBPlugin(options),
+    name: 'obsessiondb',
+    enabled: true,
+    options,
+  }
+}

--- a/packages/plugin-obsessiondb/tsconfig.json
+++ b/packages/plugin-obsessiondb/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new plugin that automatically rewrites `SharedXXXTree` engines to standard ClickHouse equivalents when targeting regular ClickHouse. This allows ObsessionDB users to maintain a single set of schema files for use across both ObsessionDB and regular ClickHouse.

- Plugin uses host auto-detection based on `clickhouse.url` to determine target type
- `--force-shared-engines` and `--no-shared-engines` CLI flags override auto-detection when needed
- Integrates with `generate`, `migrate`, `status`, `drift`, and `check` commands via the `onSchemaLoaded` hook
- Comprehensive unit tests (22 tests covering all functions and integration scenarios)
- Full TypeScript definitions and documentation

## Test plan

- [x] All 22 unit tests pass
- [x] Typecheck succeeds across entire monorepo
- [x] Build succeeds with new package

🤖 Generated with [Claude Code](https://claude.com/claude-code)