### PR TITLE
docs: require bun verify before creating PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ bun run typecheck    # type-check all packages
 bun run lint         # lint all packages
 ```
 
+## Pull Requests
+
+Before creating a PR, you MUST run `bun verify` and ensure it passes. Do not create a PR if verification fails — fix the issues first.
+
 ## Release
 
 Uses changesets. Run `bun run changeset` to create a changeset, then `bun run version-packages` to bump versions.


### PR DESCRIPTION
## Summary

Add a Pull Requests section to CLAUDE.md that enforces `bun verify` must pass before any PR is created. This ensures code quality standards are consistently applied across the project.

## Test plan

- Review the CLAUDE.md change
- Verify the new section is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)