### PR TITLE
Add chkit agent skill and documentation

### DIFF
--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -27,6 +27,16 @@ bun run chkit status
 bun run chkit check
 ```
 
+## AI Agent Skill
+
+Install the chkit agent skill so AI coding assistants (Claude Code, Cursor, GitHub Copilot, Codex) understand chkit commands, schema DSL, and workflows:
+
+```bash
+npx skills add obsessiondb/chkit
+```
+
+This installs the skill into your project's agent configuration directory (e.g. `.claude/skills/chkit/`).
+
 ## Next
 
 - Continue to [CLI Overview](/cli/overview/)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,6 +55,14 @@ All commands support `--json` for machine-readable output and `--config <path>` 
 | [`@chkit/plugin-backfill`](https://www.npmjs.com/package/@chkit/plugin-backfill) | Time-windowed data backfill with checkpoints |
 | [`@chkit/plugin-obsessiondb`](https://www.npmjs.com/package/@chkit/plugin-obsessiondb) | Auto-rewrite Shared engines for ObsessionDB compatibility |
 
+## AI Agent Skill
+
+Install the chkit agent skill so AI coding assistants understand chkit:
+
+```bash
+npx skills add obsessiondb/chkit
+```
+
 ## Documentation
 
 See the [chkit documentation](https://chkit.obsessiondb.com).

--- a/packages/cli/src/bin/help.ts
+++ b/packages/cli/src/bin/help.ts
@@ -10,6 +10,8 @@ export function formatGlobalHelp(registry: CommandRegistry, version: string): st
   lines.push('')
   lines.push('Commands:')
 
+  lines.push(`  ${'init'.padEnd(14)} Scaffold a new project with config and example schema`)
+
   const coreCommands = registry.commands.filter((c) => !c.isPlugin)
   const pluginCommands = registry.commands.filter((c) => c.isPlugin)
 

--- a/skills/chkit/SKILL.md
+++ b/skills/chkit/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: chkit
+description: ClickHouse schema management with chkit. Use when working with chkit CLI commands, ClickHouse table/view/materialized view definitions, migration generation, drift detection, or clickhouse.config.ts files. Trigger on chkit commands, @chkit/core imports, or schema definition tasks.
+allowed-tools: [Read, Edit, Grep, Glob, Bash]
+---
+
+# chkit — ClickHouse Schema & Migration Toolkit
+
+chkit lets you define ClickHouse schemas in TypeScript, generate migrations automatically, detect drift, and run CI checks from a single CLI.
+
+Docs: https://chkit.obsessiondb.com
+
+## Configuration
+
+All chkit projects have a `clickhouse.config.ts` at the project root:
+
+```ts
+import { defineConfig } from '@chkit/core'
+
+export default defineConfig({
+  schema: './src/db/schema/**/*.ts',    // Glob to schema files
+  outDir: './chkit',                     // Artifact root
+  migrationsDir: './chkit/migrations',   // SQL migration files
+  metaDir: './chkit/meta',               // snapshot.json, journal.json
+  plugins: [],                           // Plugin registrations
+  clickhouse: {
+    url: process.env.CLICKHOUSE_URL ?? 'http://localhost:8123',
+    username: process.env.CLICKHOUSE_USER ?? 'default',
+    password: process.env.CLICKHOUSE_PASSWORD ?? '',
+    database: process.env.CLICKHOUSE_DB ?? 'default',
+  },
+  check: {
+    failOnPending: true,
+    failOnChecksumMismatch: true,
+    failOnDrift: true,
+  },
+  safety: {
+    allowDestructive: false,
+  },
+})
+```
+
+## Schema DSL
+
+Schema files are TypeScript files that export definitions using functions from `@chkit/core`.
+
+### Tables
+
+```ts
+import { schema, table } from '@chkit/core'
+
+const events = table({
+  database: 'default',
+  name: 'events',
+  columns: [
+    { name: 'id', type: 'UInt64' },
+    { name: 'org_id', type: 'String' },
+    { name: 'source', type: 'LowCardinality(String)' },
+    { name: 'payload', type: 'String', nullable: true },
+    { name: 'received_at', type: 'DateTime64(3)', default: 'fn:now64(3)' },
+    { name: 'status', type: 'String', default: 'pending', comment: 'Processing status' },
+  ],
+  engine: 'MergeTree()',
+  primaryKey: ['id'],
+  orderBy: ['org_id', 'received_at', 'id'],
+  partitionBy: 'toYYYYMM(received_at)',
+  ttl: 'received_at + INTERVAL 90 DAY',
+  settings: { index_granularity: 8192 },
+  indexes: [
+    { name: 'idx_source', expression: 'source', type: 'set', granularity: 1 },
+  ],
+})
+
+export default schema(events)
+```
+
+Required table fields: `database`, `name`, `columns`, `engine`, `primaryKey`, `orderBy`.
+Optional: `partitionBy`, `uniqueKey`, `ttl`, `settings`, `indexes`, `projections`, `comment`, `renamedFrom`.
+
+### Column defaults
+
+- String values are single-quoted: `default: 'pending'` → `DEFAULT 'pending'`
+- Numbers are literal: `default: 0` → `DEFAULT 0`
+- Function calls use `fn:` prefix: `default: 'fn:now64(3)'` → `DEFAULT now64(3)`
+
+### Views
+
+```ts
+import { view } from '@chkit/core'
+
+const activeUsers = view({
+  database: 'app',
+  name: 'active_users',
+  as: 'SELECT id, email FROM app.users WHERE active = 1',
+})
+```
+
+### Materialized views
+
+```ts
+import { materializedView } from '@chkit/core'
+
+const eventCounts = materializedView({
+  database: 'analytics',
+  name: 'event_counts_mv',
+  to: { database: 'analytics', name: 'event_counts' },
+  as: 'SELECT org_id, count() AS total FROM analytics.events GROUP BY org_id',
+})
+```
+
+### Exporting
+
+Use `schema()` to group definitions, or export individually (any export with a valid `kind` is discovered):
+
+```ts
+export default schema(users, events, eventCounts)
+// or
+export const users = table({ ... })
+export const events = table({ ... })
+```
+
+## CLI Commands
+
+All commands support `--json` for machine-readable output and `--config <path>` for custom config files.
+
+### init — Scaffold project
+
+```sh
+chkit init
+```
+
+Creates `clickhouse.config.ts` and `src/db/schema/example.ts`.
+
+### generate — Create migrations
+
+```sh
+chkit generate --name add-users-table
+chkit generate --dryrun                        # Preview without writing
+chkit generate --table analytics.events        # Scope to specific table
+chkit generate --rename-table old.users=new.accounts
+chkit generate --rename-column db.table.old=new
+```
+
+Diffs schema definitions against the last snapshot. Each operation gets a risk level:
+- **safe**: `CREATE TABLE`, `ADD COLUMN`
+- **caution**: settings changes
+- **danger**: `DROP TABLE`, `DROP COLUMN`
+
+### migrate — Apply migrations
+
+```sh
+chkit migrate                  # Preview pending
+chkit migrate --apply          # Apply all pending
+chkit migrate --apply --allow-destructive   # Allow danger operations
+chkit migrate --apply --table analytics.events
+```
+
+Verifies checksums before applying. Destructive operations require explicit `--allow-destructive` in CI.
+
+### status — Migration state
+
+```sh
+chkit status
+# Output: Migrations: 5 total, 3 applied, 2 pending
+```
+
+Read-only, no ClickHouse connection needed.
+
+### drift — Compare live vs expected
+
+```sh
+chkit drift
+chkit drift --table analytics.events
+```
+
+Compares snapshot against live ClickHouse. Reports missing/extra objects and column-level differences.
+
+### check — CI gate
+
+```sh
+chkit check              # Run all policy checks
+chkit check --strict     # Force all policies on
+chkit check --json       # Machine-readable output
+```
+
+Evaluates: pending migrations, checksum mismatches, schema drift, plugin checks. Exit code 1 on failure.
+
+## Rename Workflow
+
+To rename a table or column without drop+recreate:
+
+**Table rename** — set `renamedFrom` on the table:
+```ts
+const accounts = table({
+  database: 'app',
+  name: 'accounts',           // new name
+  renamedFrom: { name: 'users' },  // old name
+  // ... columns, engine, etc.
+})
+```
+
+**Column rename** — set `renamedFrom` on the column:
+```ts
+columns: [
+  { name: 'user_email', type: 'String', renamedFrom: 'email' },
+]
+```
+
+CLI flags override schema metadata: `--rename-table old=new`, `--rename-column db.table.old=new`.
+
+## Plugins
+
+Register plugins in `clickhouse.config.ts`:
+
+```ts
+import { codegen } from '@chkit/plugin-codegen'
+
+export default defineConfig({
+  plugins: [
+    codegen({ outFile: './src/generated/chkit-types.ts', emitZod: true }),
+  ],
+})
+```
+
+### Available plugins
+
+| Plugin | Install | Command | Purpose |
+|--------|---------|---------|---------|
+| `@chkit/plugin-codegen` | `bun add -d @chkit/plugin-codegen` | `chkit codegen` | Generate TypeScript types + Zod schemas |
+| `@chkit/plugin-pull` | `bun add -d @chkit/plugin-pull` | `chkit pull` | Introspect live ClickHouse into schema files |
+| `@chkit/plugin-backfill` | `bun add -d @chkit/plugin-backfill` | `chkit backfill` | Time-windowed data backfill with checkpoints |
+
+## Common Workflows
+
+### New project
+
+```sh
+bun add -d chkit
+bunx chkit init
+# Edit src/db/schema/example.ts with your tables
+bunx chkit generate --name init
+bunx chkit migrate --apply
+```
+
+### Add a table
+
+1. Create a new schema file in `src/db/schema/`
+2. Define the table using `table()` and export via `schema()`
+3. Run `chkit generate --name add-my-table`
+4. Run `chkit migrate --apply`
+
+### CI pipeline
+
+```sh
+chkit check --strict --json
+# Fails if: pending migrations, checksum mismatches, schema drift, or plugin errors
+```
+
+## Structural vs Alterable Properties
+
+When a property changes, chkit determines whether ALTER or DROP+CREATE is needed:
+
+- **Structural** (requires drop+recreate): `engine`, `primaryKey`, `orderBy`, `partitionBy`, `uniqueKey`
+- **Alterable** (ALTER in place): columns, indexes, projections, settings, TTL, comment
+
+Views and materialized views always use drop+recreate.
+
+## References
+
+For detailed specifications, see:
+- `references/dsl-reference.md` — full DSL field reference, column types, validation rules
+- `references/cli-reference.md` — per-command flags, JSON output schemas, exit codes

--- a/skills/chkit/references/cli-reference.md
+++ b/skills/chkit/references/cli-reference.md
@@ -1,0 +1,145 @@
+# CLI Reference
+
+## Global Flags
+
+Available on every command that loads a config file:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--config <path>` | string | `clickhouse.config.ts` | Path to config file |
+| `--json` | boolean | `false` | Machine-readable JSON output |
+| `--table <selector>` | string | — | Scope to matching tables |
+| `--help` | boolean | — | Show help text |
+| `--version` | boolean | — | Print CLI version |
+
+### Table selector syntax
+
+- Exact: `database.table` or `table`
+- Prefix wildcard: `database.prefix*` or `prefix*`
+
+## chkit init
+
+Scaffolds `clickhouse.config.ts` and `src/db/schema/example.ts`. No flags.
+
+## chkit generate
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--name <name>` | string | Migration name (used in filename) |
+| `--migration-id <id>` | string | Deterministic file prefix override |
+| `--rename-table <mapping>` | string[] | `old_db.old_table=new_db.new_table` |
+| `--rename-column <mapping>` | string[] | `db.table.old_column=new_column` |
+| `--dryrun` | boolean | Print plan without writing files |
+| `--table <selector>` | string | Scope to matching tables |
+
+Exit codes: 0 = success, 1 = validation error.
+
+### Risk levels
+
+| Risk | Meaning | Examples |
+|------|---------|---------|
+| `safe` | No data loss | `CREATE TABLE`, `ADD COLUMN` |
+| `caution` | Review recommended | Settings changes |
+| `danger` | May cause data loss | `DROP TABLE`, `DROP COLUMN` |
+
+## chkit migrate
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--apply` | boolean | Apply pending migrations |
+| `--execute` | boolean | Alias for `--apply` |
+| `--allow-destructive` | boolean | Allow danger operations |
+| `--table <selector>` | string | Scope to matching tables |
+
+Exit codes: 0 = success, 1 = checksum mismatch, 3 = destructive operations blocked.
+
+Non-interactive detection: `CI=1`/`CI=true`, stdin/stdout not TTY.
+
+## chkit status
+
+No command-specific flags. Read-only, no ClickHouse connection.
+
+Reports: total, applied, pending migrations, checksum mismatches.
+
+## chkit drift
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--table <selector>` | string | Scope drift detection |
+
+Requires snapshot and clickhouse config. Always exits 0 (use `chkit check` to enforce).
+
+### Drift reason codes
+
+Object-level: `missing_object`, `extra_object`, `kind_mismatch`
+Table-level: `missing_column`, `extra_column`, `changed_column`, `setting_mismatch`, `index_mismatch`, `ttl_mismatch`, `engine_mismatch`, `primary_key_mismatch`, `order_by_mismatch`, `partition_by_mismatch`, `unique_key_mismatch`, `projection_mismatch`
+
+## chkit check
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--strict` | boolean | Force all policies on |
+
+Exit codes: 0 = all pass, 1 = one or more failed.
+
+### Policies
+
+| Policy | Config key | Default |
+|--------|-----------|---------|
+| Fail on pending | `check.failOnPending` | `true` |
+| Fail on checksum mismatch | `check.failOnChecksumMismatch` | `true` |
+| Fail on drift | `check.failOnDrift` | `true` |
+
+Failed check codes: `pending_migrations`, `checksum_mismatch`, `schema_drift`, `plugin:<name>`
+
+## chkit codegen (plugin)
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--check` | boolean | Validate output is current |
+| `--out-file <path>` | string | Override output path |
+| `--emit-zod` / `--no-emit-zod` | boolean | Toggle Zod schemas |
+| `--emit-ingest` / `--no-emit-ingest` | boolean | Toggle ingest functions |
+| `--ingest-out-file <path>` | string | Override ingest output path |
+| `--bigint-mode <mode>` | string | `string` or `bigint` |
+| `--include-views` | boolean | Include views in output |
+
+## chkit pull (plugin)
+
+Introspects live ClickHouse and generates TypeScript schema files.
+
+## chkit plugin
+
+Lists registered plugins and their commands. Usage: `chkit plugin [pluginName] [commandName]`.
+
+## JSON Output Schema
+
+All JSON responses include `command` and `schemaVersion: 1`.
+
+### generate (dryrun)
+```json
+{ "command": "generate", "schemaVersion": 1, "mode": "plan",
+  "operationCount": 2, "riskSummary": { "safe": 1, "caution": 1, "danger": 0 },
+  "operations": [{ "type": "create_table", "key": "default.users", "risk": "safe", "sql": "..." }] }
+```
+
+### migrate (plan)
+```json
+{ "command": "migrate", "schemaVersion": 1, "mode": "plan",
+  "pending": ["0004_add_column.sql"] }
+```
+
+### status
+```json
+{ "command": "status", "schemaVersion": 1,
+  "total": 5, "applied": 3, "pending": 2,
+  "pendingMigrations": ["0004_add_column.sql"],
+  "checksumMismatchCount": 0 }
+```
+
+### check
+```json
+{ "command": "check", "schemaVersion": 1, "ok": false,
+  "failedChecks": ["pending_migrations"],
+  "pendingCount": 2, "drifted": false }
+```

--- a/skills/chkit/references/dsl-reference.md
+++ b/skills/chkit/references/dsl-reference.md
@@ -1,0 +1,131 @@
+# Schema DSL Reference
+
+## table() — Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `database` | `string` | ClickHouse database name |
+| `name` | `string` | Table name |
+| `columns` | `ColumnDefinition[]` | Column definitions |
+| `engine` | `string` | Engine clause: `'MergeTree()'`, `'ReplacingMergeTree(ver)'`, `'SummingMergeTree()'`, `'AggregatingMergeTree()'`, `'CollapsingMergeTree(sign)'` |
+| `primaryKey` | `string[]` | Primary key columns |
+| `orderBy` | `string[]` | ORDER BY columns |
+
+## table() — Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `partitionBy` | `string` | Partition expression, e.g. `'toYYYYMM(created_at)'` |
+| `uniqueKey` | `string[]` | Unique key columns |
+| `ttl` | `string` | TTL expression, e.g. `'created_at + INTERVAL 90 DAY'` |
+| `settings` | `Record<string, string \| number \| boolean>` | Table-level settings |
+| `indexes` | `SkipIndexDefinition[]` | Skip indexes |
+| `projections` | `ProjectionDefinition[]` | Projections |
+| `comment` | `string` | Table comment |
+| `renamedFrom` | `{ database?: string; name: string }` | Previous identity for rename tracking |
+
+Key clause arrays support comma-separated strings: `['id, org_id']` normalizes to `['id', 'org_id']`.
+
+## Column Definition
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | yes | Column name |
+| `type` | `string` | yes | Any ClickHouse type string |
+| `nullable` | `boolean` | no | Wraps type in `Nullable(...)` |
+| `default` | `string \| number \| boolean` | no | Default value (see below) |
+| `comment` | `string` | no | Column comment |
+| `renamedFrom` | `string` | no | Previous column name for rename tracking |
+
+### Default value rules
+
+- String: single-quoted in SQL — `default: 'pending'` → `DEFAULT 'pending'`
+- Number/boolean: literal — `default: 0` → `DEFAULT 0`
+- Function call: `fn:` prefix — `default: 'fn:now64(3)'` → `DEFAULT now64(3)`
+
+### Primitive column types
+
+`String`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `UInt128`, `UInt256`, `Int8`, `Int16`, `Int32`, `Int64`, `Int128`, `Int256`, `Float32`, `Float64`, `Bool`, `Boolean`, `Date`, `DateTime`, `DateTime64`
+
+Parameterized types are supported: `DateTime64(3)`, `Decimal(18, 4)`, `Enum8('a' = 1, 'b' = 2)`, `FixedString(32)`, `LowCardinality(String)`, `Nullable(String)`, `Array(UInt64)`, `Map(String, UInt64)`, `Tuple(String, UInt64)`.
+
+## Skip Indexes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Index name |
+| `expression` | `string` | Indexed expression |
+| `type` | `'minmax' \| 'set' \| 'bloom_filter' \| 'tokenbf_v1' \| 'ngrambf_v1'` | Index type |
+| `granularity` | `number` | Index granularity |
+
+```ts
+indexes: [
+  { name: 'idx_source', expression: 'source', type: 'set', granularity: 1 },
+  { name: 'idx_ts', expression: 'received_at', type: 'minmax', granularity: 3 },
+]
+```
+
+## Projections
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Projection name |
+| `query` | `string` | Projection SELECT query |
+
+```ts
+projections: [
+  { name: 'p_recent', query: 'SELECT id ORDER BY received_at DESC LIMIT 10' },
+]
+```
+
+## view()
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `database` | `string` | yes | Database name |
+| `name` | `string` | yes | View name |
+| `as` | `string` | yes | SELECT query |
+| `comment` | `string` | no | View comment |
+
+## materializedView()
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `database` | `string` | yes | Database name |
+| `name` | `string` | yes | Materialized view name |
+| `to` | `{ database: string; name: string }` | yes | Target table |
+| `as` | `string` | yes | SELECT query |
+| `comment` | `string` | no | View comment |
+
+## Validation Rules
+
+chkit validates schema definitions and throws `ChxValidationError` if:
+
+- Duplicate object names (same `kind`, `database`, and `name`)
+- Duplicate column names within a table
+- Duplicate index names within a table
+- Duplicate projection names within a table
+- Primary key references missing column
+- Order by references missing column
+
+## Structural vs Alterable Properties
+
+**Structural** (drop + recreate): `engine`, `primaryKey`, `orderBy`, `partitionBy`, `uniqueKey`
+**Alterable** (ALTER in place): columns, indexes, projections, settings, TTL, comment
+
+Views and materialized views always use drop + recreate.
+
+## Type System (Codegen Plugin)
+
+| Category | ClickHouse Types | TypeScript Type |
+|----------|-----------------|-----------------|
+| String-like | `String`, `FixedString`, `Date*`, `DateTime*`, `UUID`, `IPv4/6`, `Enum*`, `Decimal*` | `string` |
+| Number | `Int8-32`, `UInt8-32`, `Float32/64`, `BFloat16` | `number` |
+| Large integers | `Int64-256`, `UInt64-256` | `string` (default) or `bigint` |
+| Boolean | `Bool`, `Boolean` | `boolean` |
+| Wrappers | `Nullable(T)` | `T \| null` |
+| Wrappers | `LowCardinality(T)` | same as `T` |
+| Composite | `Array(T)` | `T[]` |
+| Composite | `Map(K, V)` | `Record<K, V>` |
+| Composite | `Tuple(T1, T2)` | `[T1, T2]` |
+| JSON | `JSON` | `Record<string, unknown>` |


### PR DESCRIPTION
## Summary

Creates the chkit agent skill (SKILL.md and reference guides) to help AI coding assistants understand chkit commands, schema DSL, and workflows. Updates getting-started.md, CLI README, and help text to promote skill installation via `npx skills add obsessiondb/chkit`. Removes the unnecessary CLI `skill` command since skill distribution is handled by the skills registry.

## Changes

- **skills/chkit/**: New skill files with configuration metadata and detailed DSL/CLI references
- **docs/getting-started.md**: Added AI Agent Skill section with installation instructions
- **packages/cli/README.md**: Added AI Agent Skill section
- **packages/cli/src/bin/**: Removed `chkit skill` command and updated help text

All unit tests and docs build pass. Ready to merge.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>