### PR TITLE
Fix Cloudflare Pages deployment for docs

### DIFF
--- a/.changeset/fix-docs-deploy.md
+++ b/.changeset/fix-docs-deploy.md
@@ -1,0 +1,5 @@
+---
+"@chkit/docs": patch
+---
+
+Fix Cloudflare Pages deployment command. Changed from `wrangler deploy` (Workers command) to `wrangler pages deploy dist` (correct Pages command).

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,7 +8,7 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler pages deploy dist",
     "astro": "astro"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Fixed deploy script from `wrangler deploy` (Workers command) to `wrangler pages deploy dist` (correct Pages command)
- This fixes deployment failures that have been blocking all pushes to main since the docs migration

## Test plan
- [ ] Verify next push to main deploys docs successfully without wrangler command errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)