### PR TITLE
fix: pass Cloudflare secrets to deploy task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,11 @@
     },
     "deploy": {
       "dependsOn": ["build"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": [
+        "CLOUDFLARE_API_TOKEN",
+        "CLOUDFLARE_ACCOUNT_ID"
+      ]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- Fixed production deployment failure by adding `passThroughEnv` to the `deploy` task in turbo.json
- Turborepo was stripping `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` environment variables before passing them to the deploy script, causing wrangler to fail
- GitHub Actions was correctly setting these secrets, but they weren't reaching the deployment command

## Test plan
- [x] Verification passed (lint, typecheck, test, build)
- [ ] Next CI run on main should succeed (secrets will now be available to wrangler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)