### PR TITLE
Hide internal development skills from public skill discovery

### DIFF
--- a/.claude/skills/code-architecture/SKILL.md
+++ b/.claude/skills/code-architecture/SKILL.md
@@ -2,6 +2,8 @@
 name: code-architecture
 description: Code architecture patterns for this monorepo. Use when organizing code, refactoring modules, designing service structure, or extracting/moving code to new files. Enforces clean function ordering, service functions over classes, and explicit dependency injection.
 allowed-tools: [Read, Edit, Grep, Glob]
+metadata:
+  internal: true
 ---
 
 # Code Architecture Standards

--- a/.claude/skills/documentation-authoring/SKILL.md
+++ b/.claude/skills/documentation-authoring/SKILL.md
@@ -7,6 +7,8 @@ description: >
   writing guides, updating CLI references, or any work involving files in apps/docs/. Also trigger
   when the user asks about the docs site structure, how pages are organized, or how to add content
   to the chkit website.
+metadata:
+  internal: true
 ---
 
 ## Overview

--- a/.claude/skills/environment-variables/SKILL.md
+++ b/.claude/skills/environment-variables/SKILL.md
@@ -2,6 +2,8 @@
 name: environment-variables
 description: Environment variable management for this monorepo. Use when adding new env vars/secrets, debugging missing env errors, CI mismatches, or Turborepo env passthrough issues.
 allowed-tools: [Read, Edit, Grep, Glob, Bash]
+metadata:
+  internal: true
 ---
 
 # Environment Variables Management

--- a/.claude/skills/library-docs/SKILL.md
+++ b/.claude/skills/library-docs/SKILL.md
@@ -2,6 +2,8 @@
 name: library-docs
 description: Fetch real-time, official library docs instead of relying on stale memory. Use whenever implementing against external libraries/frameworks/packages.
 allowed-tools: mcp__context7__resolve-library-id, mcp__context7__get-library-docs
+metadata:
+  internal: true
 ---
 
 # Library Documentation Research

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -2,6 +2,8 @@
 name: pr-creation
 description: Use when creating a pull request. Ensures changesets are created for user-facing changes, verification passes, and PR metadata is correct. Invoke this skill BEFORE committing or pushing PR code.
 allowed-tools: [Read, Edit, Write, Bash, Glob, Grep, mcp__conductor__GetWorkspaceDiff]
+metadata:
+  internal: true
 ---
 
 # PR Creation Checklist

--- a/.claude/skills/testing-bun/SKILL.md
+++ b/.claude/skills/testing-bun/SKILL.md
@@ -2,6 +2,8 @@
 name: testing-bun
 description: CRITICAL - Invoke before writing or modifying tests in this repo. Use for `bun:test` test files, new test cases, and test refactors. Enforces no try/catch in positive tests, no early returns, and no hidden skips.
 allowed-tools: [Read, Edit, Grep, Glob, Bash]
+metadata:
+  internal: true
 ---
 
 # Testing Standards (Bun)

--- a/.claude/skills/typescript-standards/SKILL.md
+++ b/.claude/skills/typescript-standards/SKILL.md
@@ -2,6 +2,8 @@
 name: typescript-standards
 description: TypeScript coding standards for this monorepo. Use when writing/refactoring/reviewing TypeScript.
 allowed-tools: [Read, Edit, Grep, Glob]
+metadata:
+  internal: true
 ---
 
 # TypeScript Standards


### PR DESCRIPTION
## Summary
- Mark 7 internal development skills (code-architecture, documentation-authoring, environment-variables, library-docs, pr-creation, testing-bun, typescript-standards) with `metadata.internal: true`
- These skills are development tools for repository maintainers, not for end users installing chkit
- When users run `npx skills add obsessiondb/chkit`, they will only see the customer-facing `chkit` skill
- Internal skills are only visible when `INSTALL_INTERNAL_SKILLS=1` environment variable is explicitly set

## Test plan
- [x] Verification passed (typecheck, lint, test, build)
- [x] No changes to user-facing functionality
- [x] Configuration follows [Agent Skills specification](https://github.com/vercel-labs/skills/blob/main/README.md#optional-fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)