### PR TITLE
feat: make skill-hint plugin agent-aware

### DIFF
--- a/.changeset/skill-hint-agent-aware.md
+++ b/.changeset/skill-hint-agent-aware.md
@@ -1,0 +1,5 @@
+---
+"chkit": patch
+---
+
+Make skill-hint plugin agent-aware to support all agents (Cursor, Windsurf, Roo, etc). Previously, the plugin only showed install prompts for Claude Code even when used in other agents. Now it detects the agent environment and displays agent-specific messages.

--- a/packages/cli/src/bin/internal-plugins/skill-hint.ts
+++ b/packages/cli/src/bin/internal-plugins/skill-hint.ts
@@ -5,7 +5,35 @@ import process from 'node:process'
 
 import { definePlugin, type ChxPlugin } from '../../plugins.js'
 
-const AGENTIC_MARKERS = ['.claude', '.cursor', 'CLAUDE.md', '.cursorrules', '.github/copilot-instructions.md']
+export type AgentKind = 'claude' | 'cursor' | 'copilot' | 'windsurf' | 'roo' | 'augment' | 'continue' | 'trae' | 'unknown'
+
+interface AgentInfo { name: string; skillsDir: string }
+
+export const AGENT_REGISTRY: Record<Exclude<AgentKind, 'unknown'>, AgentInfo> = {
+  claude:   { name: 'Claude Code', skillsDir: '.claude/skills' },
+  cursor:   { name: 'Cursor',      skillsDir: '.agents/skills' },
+  copilot:  { name: 'Copilot',     skillsDir: '.agents/skills' },
+  windsurf: { name: 'Windsurf',    skillsDir: '.windsurf/skills' },
+  roo:      { name: 'Roo Code',    skillsDir: '.roo/skills' },
+  augment:  { name: 'Augment',     skillsDir: '.augment/skills' },
+  continue: { name: 'Continue',    skillsDir: '.continue/skills' },
+  trae:     { name: 'Trae',        skillsDir: '.trae/skills' },
+}
+
+const AGENT_MARKERS: { path: string; agent: AgentKind }[] = [
+  { path: '.claude', agent: 'claude' },
+  { path: 'CLAUDE.md', agent: 'claude' },
+  { path: '.cursor', agent: 'cursor' },
+  { path: '.cursorrules', agent: 'cursor' },
+  { path: '.github/copilot-instructions.md', agent: 'copilot' },
+  { path: '.windsurf', agent: 'windsurf' },
+  { path: '.roo', agent: 'roo' },
+  { path: '.augment', agent: 'augment' },
+  { path: '.continue', agent: 'continue' },
+  { path: '.trae', agent: 'trae' },
+]
+
+export interface AgentRootResult { root: string; agent: AgentKind }
 
 /**
  * Walk up from `cwd` to find the best directory for installing agent skills.
@@ -14,12 +42,12 @@ const AGENTIC_MARKERS = ['.claude', '.cursor', 'CLAUDE.md', '.cursorrules', '.gi
  * 2. Fall back to the git root (.git)
  * 3. Fall back to `cwd`
  */
-export function findAgentRoot(cwd: string): string {
+export function findAgentRoot(cwd: string): AgentRootResult {
   // Pass 1: look for agentic markers
   let dir = cwd
   while (true) {
-    for (const marker of AGENTIC_MARKERS) {
-      if (existsSync(join(dir, marker))) return dir
+    for (const marker of AGENT_MARKERS) {
+      if (existsSync(join(dir, marker.path))) return { root: dir, agent: marker.agent }
     }
     const parent = dirname(dir)
     if (parent === dir) break
@@ -29,13 +57,13 @@ export function findAgentRoot(cwd: string): string {
   // Pass 2: look for .git
   dir = cwd
   while (true) {
-    if (existsSync(join(dir, '.git'))) return dir
+    if (existsSync(join(dir, '.git'))) return { root: dir, agent: 'unknown' }
     const parent = dirname(dir)
     if (parent === dir) break
     dir = parent
   }
 
-  return cwd
+  return { root: cwd, agent: 'unknown' }
 }
 
 export const SKILL_INSTALL_COMMAND = 'npx skills add obsessiondb/chkit'
@@ -46,10 +74,11 @@ export interface SkillHintState {
 }
 
 export interface SkillHintDeps {
+  detectAgent(): AgentRootResult
   isSkillInstalled(): boolean
   readState(): SkillHintState
   writeState(state: SkillHintState): void
-  promptUser(): Promise<boolean>
+  promptUser(agent: AgentKind): Promise<boolean>
   installSkill(): Promise<boolean>
   now(): number
 }
@@ -63,11 +92,22 @@ function getStateFilePath(): string {
 }
 
 const defaultDeps: SkillHintDeps = {
+  detectAgent() {
+    return findAgentRoot(process.cwd())
+  },
+
   isSkillInstalled() {
-    const root = findAgentRoot(process.cwd())
-    const projectSkill = join(root, '.claude', 'skills', 'chkit', 'SKILL.md')
-    const globalSkill = join(homedir(), '.claude', 'skills', 'chkit', 'SKILL.md')
-    return existsSync(projectSkill) || existsSync(globalSkill)
+    const { root, agent } = findAgentRoot(process.cwd())
+    // Check agent-specific skill path
+    if (agent !== 'unknown') {
+      const { skillsDir } = AGENT_REGISTRY[agent]
+      if (existsSync(join(root, skillsDir, 'chkit', 'SKILL.md'))) return true
+    }
+    // Check universal .agents/skills path
+    if (existsSync(join(root, '.agents', 'skills', 'chkit', 'SKILL.md'))) return true
+    // Check global Claude path
+    if (existsSync(join(homedir(), '.claude', 'skills', 'chkit', 'SKILL.md'))) return true
+    return false
   },
 
   readState(): SkillHintState {
@@ -81,15 +121,18 @@ const defaultDeps: SkillHintDeps = {
   writeState(state: SkillHintState): void {
     const dir = getStateDir()
     mkdirSync(dir, { recursive: true })
-    writeFileSync(getStateFilePath(), JSON.stringify(state, null, 2) + '\n')
+    writeFileSync(getStateFilePath(), `${JSON.stringify(state, null, 2)}\n`)
   },
 
-  async promptUser(): Promise<boolean> {
+  async promptUser(agent: AgentKind): Promise<boolean> {
     const { createInterface } = await import('node:readline/promises')
     const rl = createInterface({ input: process.stdin, output: process.stderr })
     try {
+      const agentLabel = agent !== 'unknown' ? AGENT_REGISTRY[agent].name : undefined
       console.error('')
-      console.error('chkit has an AI agent skill for Claude Code.')
+      console.error(agentLabel
+        ? `chkit has an AI agent skill for ${agentLabel}.`
+        : 'chkit has an AI agent skill available.')
       console.error(`Install it with: ${SKILL_INSTALL_COMMAND}`)
       console.error('')
       const answer = await rl.question('Install now? [y/N] ')
@@ -103,7 +146,7 @@ const defaultDeps: SkillHintDeps = {
     const { execSync } = await import('node:child_process')
     try {
       console.error('')
-      execSync(SKILL_INSTALL_COMMAND, { cwd: findAgentRoot(process.cwd()), stdio: 'inherit' })
+      execSync(SKILL_INSTALL_COMMAND, { cwd: findAgentRoot(process.cwd()).root, stdio: 'inherit' })
       return true
     } catch {
       console.error(`Failed to install. Run manually: ${SKILL_INSTALL_COMMAND}`)
@@ -134,7 +177,8 @@ export function createSkillHintPlugin(overrides?: Partial<SkillHintDeps>): ChxPl
           if (elapsed < HINT_INTERVAL_MS) return
         }
 
-        const accepted = await deps.promptUser()
+        const { agent } = deps.detectAgent()
+        const accepted = await deps.promptUser(agent)
         if (accepted) {
           await deps.installSkill()
         } else {


### PR DESCRIPTION
## Summary
- Make skill-hint plugin agent-aware to detect and display prompts for all agents (Claude, Cursor, Windsurf, Roo, etc)
- Update `findAgentRoot()` to return both root path and detected agent
- Check agent-specific skill directories (e.g., `.roo/skills`, `.windsurf/skills`) in addition to universal paths
- Display agent-specific messages in installation prompts (e.g., "chkit has an AI agent skill for Windsurf.")

## Test plan
- [x] All 23 skill-hint tests pass (including 3 new agent detection tests and 3 new agent-aware prompting tests)
- [x] Linting passes
- [x] Typecheck passes
- [x] Changeset created for patch release

🤖 Generated with [Claude Code](https://claude.com/claude-code)