### PR TITLE
fix: use DROP TABLE SYNC for materialized view drops

### DIFF
--- a/.changeset/mv-drop-sync.md
+++ b/.changeset/mv-drop-sync.md
@@ -1,0 +1,5 @@
+---
+"@chkit/core": patch
+---
+
+Fix materialized view drop operations on ClickHouse Cloud by using `DROP TABLE ... SYNC` instead of `DROP VIEW IF EXISTS`. This ensures metadata removal is fully propagated before subsequent column drop operations execute, preventing "column is referenced by materialized view" errors.

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -55,7 +55,7 @@ function pushDropOperation(
     type: 'drop_materialized_view',
     key: definitionKey(def),
     risk,
-    sql: `DROP VIEW IF EXISTS ${def.database}.${def.name};`,
+    sql: `DROP TABLE IF EXISTS ${def.database}.${def.name} SYNC;`,
   })
 }
 


### PR DESCRIPTION
## Summary
- Fix materialized view drop operations on ClickHouse Cloud by using `DROP TABLE ... SYNC` instead of `DROP VIEW IF EXISTS`
- Ensures metadata removal is fully propagated before subsequent column drop operations execute
- Prevents "column is referenced by materialized view" errors when dropping columns with dependent MVs

## Test plan
- [x] All tests pass (`bun verify` successful)
- [x] Codegen tests verify migration SQL is rendered correctly
- [x] Core planner tests pass with new DROP TABLE syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)