### PR TITLE
Use ClickHouse executor wrapper in CLI commands

### DIFF
--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process'
 
-import type { ParsedFlags } from '../plugins.js'
-import { typedFlags } from '../plugins.js'
 import { createCommandRegistry } from './command-registry.js'
+import { runResolvedCommand } from './command-dispatch.js'
 import { generateCommand } from './commands/generate.js'
 import { migrateCommand } from './commands/migrate.js'
 import { statusCommand } from './commands/status.js'
@@ -11,13 +10,10 @@ import { driftCommand } from './commands/drift.js'
 import { checkCommand } from './commands/check.js'
 import { pluginCommand } from './commands/plugin.js'
 import { cmdInit } from './commands/init.js'
-import { loadConfig, resolveDirs } from './config.js'
+import { loadConfig } from './config.js'
 import { GLOBAL_FLAGS } from './global-flags.js'
 import { formatGlobalHelp, formatCommandHelp } from './help.js'
-import { parseFlags, UnknownFlagError, MissingFlagValueError } from '@chkit/core'
 import { loadPluginRuntime } from './plugin-runtime.js'
-import { resolveTableScope, tableKeysFromDefinitions } from './table-scope.js'
-import { loadSchemaDefinitions } from './schema-loader.js'
 import { getInternalPlugins } from './internal-plugins/index.js'
 import { CLI_VERSION } from './version.js'
 
@@ -30,37 +26,6 @@ function extractConfigPath(argv: string[]): string | undefined {
   const idx = argv.indexOf('--config')
   if (idx === -1) return undefined
   return argv[idx + 1]
-}
-
-/** Strip global flags (--config, --json, --table) from argv, returning their values and the rest. */
-function stripGlobalFlags(argv: string[]): {
-  jsonMode: boolean
-  tableSelector: string | undefined
-  rest: string[]
-} {
-  const rest: string[] = []
-  let jsonMode = false
-  let tableSelector: string | undefined
-
-  for (let i = 0; i < argv.length; i++) {
-    const token = argv[i] as string
-    if (token === '--json') {
-      jsonMode = true
-      continue
-    }
-    if (token === '--config' && i + 1 < argv.length) {
-      i++
-      continue
-    }
-    if (token === '--table' && i + 1 < argv.length) {
-      tableSelector = argv[i + 1]
-      i++
-      continue
-    }
-    rest.push(token)
-  }
-
-  return { jsonMode, tableSelector, rest }
 }
 
 function formatFatalError(error: unknown): string {
@@ -189,132 +154,17 @@ async function main(): Promise<void> {
     return
   }
 
-  if (resolved.isPlugin && !resolved.run) {
-    const argsAfterCommand = argv.slice(1)
-    let subcommandName: string | undefined
-
-    if (resolved.subcommands) {
-      // Match against known subcommand names to avoid confusing flag values
-      // (e.g., config paths) with subcommand candidates
-      const matchedSub = resolved.subcommands.find((s) => argsAfterCommand.includes(s.name))
-      if (matchedSub) {
-        subcommandName = matchedSub.name
-      } else if (resolved.subcommands.length === 1) {
-        subcommandName = resolved.subcommands[0]?.name
-      } else {
-        console.log(formatCommandHelp(resolved, registry.globalFlags))
-        return
-      }
-    }
-
-    const allPluginFlags = registry.resolveFlags(commandName, subcommandName)
-    let flags: ParsedFlags
-    try {
-      flags = parseFlags(argsAfterCommand, allPluginFlags)
-    } catch (error) {
-      if (error instanceof UnknownFlagError || error instanceof MissingFlagValueError) {
-        console.error(error.message)
-        process.exitCode = 1
-        return
-      }
-      throw error
-    }
-
-    const gf = typedFlags(flags, GLOBAL_FLAGS)
-    const jsonMode = gf['--json'] === true
-    const tableSelector = gf['--table']
-
-    let tableScope: ReturnType<typeof resolveTableScope>
-    try {
-      const definitions = await loadSchemaDefinitions(config.schema)
-      tableScope = resolveTableScope(tableSelector, tableKeysFromDefinitions(definitions))
-    } catch {
-      tableScope = resolveTableScope(tableSelector, [])
-    }
-
-    try {
-      await pluginRuntime.runOnConfigLoaded({
-        command: commandName,
-        config,
-        configPath,
-        tableScope,
-        flags,
-      })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      if (jsonMode) {
-        console.log(JSON.stringify({ ok: false, error: message }))
-      } else {
-        console.error(message)
-      }
-      process.exitCode = 2
-      return
-    }
-
-    const pluginName = resolved.pluginName ?? commandName
-    const pluginCommandName = subcommandName ?? commandName
-
-    const { printOutput } = await import('./json-output.js')
-    const exitCode = await pluginRuntime.runPluginCommand(pluginName, pluginCommandName, {
-      config,
-      configPath,
-      jsonMode,
-      tableScope,
-      args: [],
-      flags,
-      print(value) {
-        printOutput(value, jsonMode)
-      },
-    })
-
-    if (exitCode !== 0) process.exitCode = exitCode
-    return
-  }
-
-  // For the 'plugin' command, use lenient flag extraction since plugin-specific
-  // flags are handled by the plugin's own parser
-  if (commandName === 'plugin') {
-    const { jsonMode, tableSelector } = stripGlobalFlags(argv.slice(1))
-    const flags: ParsedFlags = {}
-    if (jsonMode) flags['--json'] = true
-    if (tableSelector) flags['--table'] = tableSelector
-
-    const dirs = resolveDirs(config)
-    if (!resolved.run) throw new Error(`Command '${commandName}' has no run handler`)
-    await resolved.run({
-      command: commandName,
-      flags,
-      config,
-      configPath,
-      dirs,
-      pluginRuntime,
-    })
-    return
-  }
-
-  const allFlags = registry.resolveFlags(commandName)
-  let flags: ParsedFlags
-  try {
-    flags = parseFlags(argv.slice(1), allFlags)
-  } catch (error) {
-    if (error instanceof UnknownFlagError || error instanceof MissingFlagValueError) {
-      console.error(error.message)
-      process.exitCode = 1
-      return
-    }
-    throw error
-  }
-
-  const dirs = resolveDirs(config)
-
-  if (!resolved.run) throw new Error(`Command '${commandName}' has no run handler`)
-  await resolved.run({
-    command: commandName,
-    flags,
+  await runResolvedCommand({
+    argv,
+    commandName,
+    resolved,
+    registry,
     config,
     configPath,
-    dirs,
     pluginRuntime,
+    onAmbiguousPluginSubcommand() {
+      console.log(formatCommandHelp(resolved, registry.globalFlags))
+    },
   })
 }
 

--- a/packages/cli/src/bin/clickhouse-resource.ts
+++ b/packages/cli/src/bin/clickhouse-resource.ts
@@ -1,0 +1,14 @@
+import { createClickHouseExecutor, type ClickHouseExecutor } from '@chkit/clickhouse'
+import type { ChxConfig } from '@chkit/core'
+
+export async function withClickHouseExecutor<T>(
+  clickhouseConfig: NonNullable<ChxConfig['clickhouse']>,
+  run: (db: ClickHouseExecutor) => Promise<T>
+): Promise<T> {
+  const db = createClickHouseExecutor(clickhouseConfig)
+  try {
+    return await run(db)
+  } finally {
+    await db.close()
+  }
+}

--- a/packages/cli/src/bin/command-dispatch.ts
+++ b/packages/cli/src/bin/command-dispatch.ts
@@ -1,0 +1,199 @@
+import { parseFlags, UnknownFlagError, MissingFlagValueError, type ParsedFlags } from '@chkit/core'
+
+import { typedFlags } from '../plugins.js'
+import type { CommandRegistry, RegisteredCommand } from './command-registry.js'
+import { resolveDirs } from './config.js'
+import { GLOBAL_FLAGS } from './global-flags.js'
+import { printOutput } from './json-output.js'
+import type { PluginRuntime } from './plugin-runtime.js'
+import { loadSchemaDefinitions } from './schema-loader.js'
+import { resolveTableScope, tableKeysFromDefinitions } from './table-scope.js'
+
+export function stripGlobalFlags(argv: string[]): {
+  jsonMode: boolean
+  tableSelector: string | undefined
+  rest: string[]
+} {
+  const rest: string[] = []
+  let jsonMode = false
+  let tableSelector: string | undefined
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i] as string
+    if (token === '--json') {
+      jsonMode = true
+      continue
+    }
+    if (token === '--config' && i + 1 < argv.length) {
+      i++
+      continue
+    }
+    if (token === '--table' && i + 1 < argv.length) {
+      tableSelector = argv[i + 1]
+      i++
+      continue
+    }
+    rest.push(token)
+  }
+
+  return { jsonMode, tableSelector, rest }
+}
+
+function parseFlagsOrReport(args: string[], defs: ReturnType<CommandRegistry['resolveFlags']>): ParsedFlags | null {
+  try {
+    return parseFlags(args, defs)
+  } catch (error) {
+    if (error instanceof UnknownFlagError || error instanceof MissingFlagValueError) {
+      console.error(error.message)
+      process.exitCode = 1
+      return null
+    }
+    throw error
+  }
+}
+
+async function resolvePluginTableScope(input: {
+  schemaGlobs: string | string[]
+  tableSelector: string | undefined
+}) {
+  try {
+    const definitions = await loadSchemaDefinitions(input.schemaGlobs)
+    return resolveTableScope(input.tableSelector, tableKeysFromDefinitions(definitions))
+  } catch {
+    return resolveTableScope(input.tableSelector, [])
+  }
+}
+
+async function runPluginCommand(input: {
+  argv: string[]
+  commandName: string
+  resolved: RegisteredCommand
+  registry: CommandRegistry
+  config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
+  configPath: string
+  pluginRuntime: PluginRuntime
+  onAmbiguousPluginSubcommand?: () => void
+}): Promise<void> {
+  const argsAfterCommand = input.argv.slice(1)
+  let subcommandName: string | undefined
+
+  if (input.resolved.subcommands) {
+    const matchedSub = input.resolved.subcommands.find((s) => argsAfterCommand.includes(s.name))
+    if (matchedSub) {
+      subcommandName = matchedSub.name
+    } else if (input.resolved.subcommands.length === 1) {
+      subcommandName = input.resolved.subcommands[0]?.name
+    } else {
+      input.onAmbiguousPluginSubcommand?.()
+      return
+    }
+  }
+
+  const allPluginFlags = input.registry.resolveFlags(input.commandName, subcommandName)
+  const flags = parseFlagsOrReport(argsAfterCommand, allPluginFlags)
+  if (!flags) return
+
+  const gf = typedFlags(flags, GLOBAL_FLAGS)
+  const jsonMode = gf['--json'] === true
+  const tableScope = await resolvePluginTableScope({
+    schemaGlobs: input.config.schema,
+    tableSelector: gf['--table'],
+  })
+
+  try {
+    await input.pluginRuntime.runOnConfigLoaded({
+      command: input.commandName,
+      config: input.config,
+      configPath: input.configPath,
+      tableScope,
+      flags,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (jsonMode) {
+      console.log(JSON.stringify({ ok: false, error: message }))
+    } else {
+      console.error(message)
+    }
+    process.exitCode = 2
+    return
+  }
+
+  const pluginName = input.resolved.pluginName ?? input.commandName
+  const pluginCommandName = subcommandName ?? input.commandName
+
+  const exitCode = await input.pluginRuntime.runPluginCommand(pluginName, pluginCommandName, {
+    config: input.config,
+    configPath: input.configPath,
+    jsonMode,
+    tableScope,
+    args: [],
+    flags,
+    print(value) {
+      printOutput(value, jsonMode)
+    },
+  })
+
+  if (exitCode !== 0) process.exitCode = exitCode
+}
+
+async function runCoreOrBuiltinCommand(input: {
+  argv: string[]
+  commandName: string
+  resolved: RegisteredCommand
+  registry: CommandRegistry
+  config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
+  configPath: string
+  pluginRuntime: PluginRuntime
+}): Promise<void> {
+  if (input.commandName === 'plugin') {
+    const { jsonMode, tableSelector } = stripGlobalFlags(input.argv.slice(1))
+    const flags: ParsedFlags = {}
+    if (jsonMode) flags['--json'] = true
+    if (tableSelector) flags['--table'] = tableSelector
+
+    const dirs = resolveDirs(input.config)
+    if (!input.resolved.run) throw new Error(`Command '${input.commandName}' has no run handler`)
+    await input.resolved.run({
+      command: input.commandName,
+      flags,
+      config: input.config,
+      configPath: input.configPath,
+      dirs,
+      pluginRuntime: input.pluginRuntime,
+    })
+    return
+  }
+
+  const allFlags = input.registry.resolveFlags(input.commandName)
+  const flags = parseFlagsOrReport(input.argv.slice(1), allFlags)
+  if (!flags) return
+
+  const dirs = resolveDirs(input.config)
+  if (!input.resolved.run) throw new Error(`Command '${input.commandName}' has no run handler`)
+  await input.resolved.run({
+    command: input.commandName,
+    flags,
+    config: input.config,
+    configPath: input.configPath,
+    dirs,
+    pluginRuntime: input.pluginRuntime,
+  })
+}
+
+export async function runResolvedCommand(input: {
+  argv: string[]
+  commandName: string
+  resolved: RegisteredCommand
+  registry: CommandRegistry
+  config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
+  configPath: string
+  pluginRuntime: PluginRuntime
+  onAmbiguousPluginSubcommand?: () => void
+}): Promise<void> {
+  if (input.resolved.isPlugin && !input.resolved.run) {
+    await runPluginCommand(input)
+    return
+  }
+  await runCoreOrBuiltinCommand(input)
+}

--- a/packages/cli/src/bin/commands/check.ts
+++ b/packages/cli/src/bin/commands/check.ts
@@ -2,8 +2,9 @@ import { mkdir } from 'node:fs/promises'
 
 import { summarizeDriftReasons } from '../../drift.js'
 import type { CommandDef, CommandRunContext } from '../../plugins.js'
+import { withClickHouseExecutor } from '../clickhouse-resource.js'
 import { emitJson } from '../json-output.js'
-import { createJournalStoreFromConfig } from '../journal-store.js'
+import { createJournalStore } from '../journal-store.js'
 import { findChecksumMismatches, listMigrations, readSnapshot } from '../migration-store.js'
 import { buildDriftPayload } from './drift.js'
 
@@ -27,120 +28,122 @@ async function cmdCheck(ctx: CommandRunContext): Promise<void> {
     throw new Error('clickhouse config is required for check (journal is stored in ClickHouse)')
   }
 
-  const { journalStore } = createJournalStoreFromConfig(config.clickhouse)
+  await withClickHouseExecutor(config.clickhouse, async (db) => {
+    const journalStore = createJournalStore(db)
 
-  const files = await listMigrations(migrationsDir)
-  const journal = await journalStore.readJournal()
-  const appliedNames = new Set(journal.applied.map((entry) => entry.name))
-  const pending = files.filter((f) => !appliedNames.has(f))
-  const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
-  const snapshot = await readSnapshot(metaDir)
-  const drift = snapshot && config.clickhouse ? await buildDriftPayload(config, metaDir, snapshot) : null
+    const files = await listMigrations(migrationsDir)
+    const journal = await journalStore.readJournal()
+    const appliedNames = new Set(journal.applied.map((entry) => entry.name))
+    const pending = files.filter((f) => !appliedNames.has(f))
+    const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
+    const snapshot = await readSnapshot(metaDir)
+    const drift = snapshot ? await buildDriftPayload(config, metaDir, snapshot) : null
 
-  const policy = {
-    failOnPending: strict ? true : config.check?.failOnPending ?? true,
-    failOnChecksumMismatch: strict ? true : config.check?.failOnChecksumMismatch ?? true,
-    failOnDrift: strict ? true : config.check?.failOnDrift ?? true,
-  }
-
-  await pluginRuntime.runOnConfigLoaded({
-    command: 'check',
-    config,
-    configPath,
-    flags,
-  })
-  const pluginResults = await pluginRuntime.runOnCheck({
-    command: 'check',
-    config,
-    configPath,
-    jsonMode,
-    flags,
-  })
-
-  const failedChecks: string[] = []
-  if (policy.failOnPending && pending.length > 0) failedChecks.push('pending_migrations')
-  if (policy.failOnChecksumMismatch && checksumMismatches.length > 0) failedChecks.push('checksum_mismatch')
-  if (policy.failOnDrift && drift?.drifted) failedChecks.push('schema_drift')
-  for (const result of pluginResults) {
-    const hasErrorFinding = result.findings.some((finding) => finding.severity === 'error')
-    if (result.evaluated && !result.ok && hasErrorFinding) {
-      failedChecks.push(`plugin:${result.plugin}`)
+    const policy = {
+      failOnPending: strict ? true : config.check?.failOnPending ?? true,
+      failOnChecksumMismatch: strict ? true : config.check?.failOnChecksumMismatch ?? true,
+      failOnDrift: strict ? true : config.check?.failOnDrift ?? true,
     }
-  }
-  const ok = failedChecks.length === 0
-  const driftReasonSummary = drift
-    ? summarizeDriftReasons({
+
+    await pluginRuntime.runOnConfigLoaded({
+      command: 'check',
+      config,
+      configPath,
+      flags,
+    })
+    const pluginResults = await pluginRuntime.runOnCheck({
+      command: 'check',
+      config,
+      configPath,
+      jsonMode,
+      flags,
+    })
+
+    const failedChecks: string[] = []
+    if (policy.failOnPending && pending.length > 0) failedChecks.push('pending_migrations')
+    if (policy.failOnChecksumMismatch && checksumMismatches.length > 0) failedChecks.push('checksum_mismatch')
+    if (policy.failOnDrift && drift?.drifted) failedChecks.push('schema_drift')
+    for (const result of pluginResults) {
+      const hasErrorFinding = result.findings.some((finding) => finding.severity === 'error')
+      if (result.evaluated && !result.ok && hasErrorFinding) {
+        failedChecks.push(`plugin:${result.plugin}`)
+      }
+    }
+    const ok = failedChecks.length === 0
+    const driftReasonSummary = drift
+      ? summarizeDriftReasons({
+          objectDrift: drift.objectDrift,
+          tableDrift: drift.tableDrift,
+        })
+      : { counts: {}, total: 0, object: 0, table: 0 }
+
+    const payload = {
+      strict,
+      policy,
+      ok,
+      failedChecks,
+      pendingCount: pending.length,
+      checksumMismatchCount: checksumMismatches.length,
+      drifted: drift?.drifted ?? false,
+      driftEvaluated: drift !== null,
+      driftReasonCounts: driftReasonSummary.counts,
+      driftReasonTotals: {
+        total: driftReasonSummary.total,
+        object: driftReasonSummary.object,
+        table: driftReasonSummary.table,
+      },
+      plugins: Object.fromEntries(
+        pluginResults.map((result) => [
+          result.plugin,
+          {
+            evaluated: result.evaluated,
+            ok: result.ok,
+            findingCodes: result.findings.map((finding) => finding.code),
+            ...(result.metadata ?? {}),
+          },
+        ])
+      ),
+    }
+
+    if (jsonMode) {
+      emitJson('check', payload)
+      if (!ok) process.exitCode = 1
+      return
+    }
+
+    console.log(`Check status: ${ok ? 'ok' : 'failed'}`)
+    console.log(
+      `Policy: pending=${policy.failOnPending ? 'on' : 'off'}, checksum=${policy.failOnChecksumMismatch ? 'on' : 'off'}, drift=${policy.failOnDrift ? 'on' : 'off'}`
+    )
+    console.log(`Pending migrations: ${pending.length}`)
+    console.log(`Checksum mismatches: ${checksumMismatches.length}`)
+    if (drift === null) {
+      console.log('Schema drift: not evaluated (missing snapshot or clickhouse config)')
+    } else {
+      console.log(`Schema drift: ${drift.drifted ? 'yes' : 'no'}`)
+      const summary = summarizeDriftReasons({
         objectDrift: drift.objectDrift,
         tableDrift: drift.tableDrift,
       })
-    : { counts: {}, total: 0, object: 0, table: 0 }
-
-  const payload = {
-    strict,
-    policy,
-    ok,
-    failedChecks,
-    pendingCount: pending.length,
-    checksumMismatchCount: checksumMismatches.length,
-    drifted: drift?.drifted ?? false,
-    driftEvaluated: drift !== null,
-    driftReasonCounts: driftReasonSummary.counts,
-    driftReasonTotals: {
-      total: driftReasonSummary.total,
-      object: driftReasonSummary.object,
-      table: driftReasonSummary.table,
-    },
-    plugins: Object.fromEntries(
-      pluginResults.map((result) => [
-        result.plugin,
-        {
-          evaluated: result.evaluated,
-          ok: result.ok,
-          findingCodes: result.findings.map((finding) => finding.code),
-          ...(result.metadata ?? {}),
-        },
-      ])
-    ),
-  }
-
-  if (jsonMode) {
-    emitJson('check', payload)
-    if (!ok) process.exitCode = 1
-    return
-  }
-
-  console.log(`Check status: ${ok ? 'ok' : 'failed'}`)
-  console.log(
-    `Policy: pending=${policy.failOnPending ? 'on' : 'off'}, checksum=${policy.failOnChecksumMismatch ? 'on' : 'off'}, drift=${policy.failOnDrift ? 'on' : 'off'}`
-  )
-  console.log(`Pending migrations: ${pending.length}`)
-  console.log(`Checksum mismatches: ${checksumMismatches.length}`)
-  if (drift === null) {
-    console.log('Schema drift: not evaluated (missing snapshot or clickhouse config)')
-  } else {
-    console.log(`Schema drift: ${drift.drifted ? 'yes' : 'no'}`)
-    const summary = summarizeDriftReasons({
-      objectDrift: drift.objectDrift,
-      tableDrift: drift.tableDrift,
-    })
-    console.log(
-      `Drift reasons: total=${summary.total}, object=${summary.object}, table=${summary.table}`
-    )
-  }
-  if (pluginResults.length > 0) {
-    console.log('Plugin checks:')
-    for (const result of pluginResults) {
-      const findingCodes = result.findings.map((finding) => finding.code)
       console.log(
-        `- ${result.plugin}: ${result.ok ? 'ok' : 'failed'}${findingCodes.length > 0 ? ` (${findingCodes.join(', ')})` : ''}`
+        `Drift reasons: total=${summary.total}, object=${summary.object}, table=${summary.table}`
       )
     }
-    await pluginRuntime.runOnCheckReport(pluginResults, (line) => {
-      console.log(line)
-    })
-  }
-  if (!ok) {
-    console.log(`Failed checks: ${failedChecks.join(', ')}`)
-    process.exitCode = 1
-  }
+    if (pluginResults.length > 0) {
+      console.log('Plugin checks:')
+      for (const result of pluginResults) {
+        const findingCodes = result.findings.map((finding) => finding.code)
+        console.log(
+          `- ${result.plugin}: ${result.ok ? 'ok' : 'failed'}${findingCodes.length > 0 ? ` (${findingCodes.join(', ')})` : ''}`
+        )
+      }
+      await pluginRuntime.runOnCheckReport(pluginResults, (line) => {
+        console.log(line)
+      })
+    }
+    if (!ok) {
+      console.log(`Failed checks: ${failedChecks.join(', ')}`)
+      process.exitCode = 1
+    }
+  })
 }

--- a/packages/cli/src/bin/commands/migrate.ts
+++ b/packages/cli/src/bin/commands/migrate.ts
@@ -4,9 +4,10 @@ import process from 'node:process'
 import { createInterface } from 'node:readline/promises'
 
 import { defineFlags, typedFlags, type CommandDef, type CommandRunContext } from '../../plugins.js'
+import { withClickHouseExecutor } from '../clickhouse-resource.js'
 import { GLOBAL_FLAGS } from '../global-flags.js'
 import { emitJson } from '../json-output.js'
-import { createJournalStoreFromConfig } from '../journal-store.js'
+import { createJournalStore } from '../journal-store.js'
 import {
   checksumSQL,
   findChecksumMismatches,
@@ -107,215 +108,217 @@ async function cmdMigrate(ctx: CommandRunContext): Promise<void> {
     throw new Error('clickhouse config is required for migrate (journal is stored in ClickHouse)')
   }
 
-  const { journalStore, db } = createJournalStoreFromConfig(config.clickhouse)
-  const snapshot = await readSnapshot(metaDir)
-  const tableScope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot?.definitions ?? []))
+  await withClickHouseExecutor(config.clickhouse, async (db) => {
+    const journalStore = createJournalStore(db)
+    const snapshot = await readSnapshot(metaDir)
+    const tableScope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot?.definitions ?? []))
 
-  await pluginRuntime.runOnConfigLoaded({
-    command: 'migrate',
-    config,
-    configPath,
-    tableScope,
-    flags,
-  })
+    await pluginRuntime.runOnConfigLoaded({
+      command: 'migrate',
+      config,
+      configPath,
+      tableScope,
+      flags,
+    })
 
-  await mkdir(migrationsDir, { recursive: true })
-  const files = await listMigrations(migrationsDir)
-  const journal = await journalStore.readJournal()
-  const appliedNames = new Set(journal.applied.map((entry) => entry.name))
-  const pendingAll = files.filter((f) => !appliedNames.has(f))
-  const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
+    await mkdir(migrationsDir, { recursive: true })
+    const files = await listMigrations(migrationsDir)
+    const journal = await journalStore.readJournal()
+    const appliedNames = new Set(journal.applied.map((entry) => entry.name))
+    const pendingAll = files.filter((f) => !appliedNames.has(f))
+    const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
 
-  if (checksumMismatches.length > 0) {
-    if (jsonMode) {
-      emitJson('migrate', {
-        mode: executeRequested ? 'execute' : 'plan',
-        scope: tableScope,
-        error: 'Checksum mismatch detected on applied migrations',
-        checksumMismatches,
-      })
-      process.exitCode = 1
-      return
+    if (checksumMismatches.length > 0) {
+      if (jsonMode) {
+        emitJson('migrate', {
+          mode: executeRequested ? 'execute' : 'plan',
+          scope: tableScope,
+          error: 'Checksum mismatch detected on applied migrations',
+          checksumMismatches,
+        })
+        process.exitCode = 1
+        return
+      }
+      throw new Error(
+        `Checksum mismatch detected on applied migrations: ${checksumMismatches
+          .map((item) => item.name)
+          .join(', ')}`
+      )
     }
-    throw new Error(
-      `Checksum mismatch detected on applied migrations: ${checksumMismatches
-        .map((item) => item.name)
-        .join(', ')}`
-    )
-  }
 
-  if (tableScope.enabled && tableScope.matchCount === 0) {
-    if (jsonMode) {
-      emitJson('migrate', {
-        mode: executeRequested ? 'execute' : 'plan',
-        scope: tableScope,
-        pending: [],
-        applied: [],
-        warning: `No tables matched selector "${tableScope.selector ?? ''}".`,
-      })
-    } else {
-      console.log(`No tables matched selector "${tableScope.selector ?? ''}". No migrations selected.`)
-    }
-    return
-  }
-
-  const pending = tableScope.enabled
-    ? await filterPendingByScope(migrationsDir, pendingAll, new Set(tableScope.matchedTables))
-    : pendingAll
-
-  if (pending.length === 0) {
-    if (jsonMode) {
-      emitJson('migrate', {
-        mode: executeRequested ? 'execute' : 'plan',
-        scope: tableScope,
-        pending: [],
-        applied: [],
-      })
-    } else {
-      console.log('No pending migrations.')
-    }
-    return
-  }
-
-  const planned = {
-    mode: executeRequested ? 'execute' : 'plan',
-    scope: tableScope,
-    pending,
-  }
-
-  if (jsonMode && !executeRequested) {
-    emitJson('migrate', planned)
-    return
-  }
-
-  if (!jsonMode) {
-    if (tableScope.enabled) {
-      console.log(`Table scope: ${tableScope.selector ?? ''} (${tableScope.matchCount} matched)`)
-      for (const table of tableScope.matchedTables) console.log(`- ${table}`)
-    }
-    console.log(`Pending migrations: ${pending.length}`)
-    for (const file of pending) console.log(`- ${file}`)
-  }
-
-  let shouldExecute = executeRequested
-  if (!shouldExecute) {
-    if (isBackgroundOrCI() || jsonMode) {
-      if (!jsonMode) {
-        console.log('\nPlan only. Re-run with --apply to apply and journal these migrations.')
+    if (tableScope.enabled && tableScope.matchCount === 0) {
+      if (jsonMode) {
+        emitJson('migrate', {
+          mode: executeRequested ? 'execute' : 'plan',
+          scope: tableScope,
+          pending: [],
+          applied: [],
+          warning: `No tables matched selector "${tableScope.selector ?? ''}".`,
+        })
+      } else {
+        console.log(`No tables matched selector "${tableScope.selector ?? ''}". No migrations selected.`)
       }
       return
     }
 
-    const rl = createInterface({ input: process.stdin, output: process.stdout })
-    try {
-      console.log('')
-      console.log('Type "yes" to continue. Any other input cancels.')
-      const response = await rl.question('Apply pending migrations now? [no/yes]: ')
-      shouldExecute = response.trim().toLowerCase() === 'yes'
-    } finally {
-      rl.close()
-    }
+    const pending = tableScope.enabled
+      ? await filterPendingByScope(migrationsDir, pendingAll, new Set(tableScope.matchedTables))
+      : pendingAll
 
-    if (!shouldExecute) {
-      console.log('Migration apply cancelled by user.')
+    if (pending.length === 0) {
+      if (jsonMode) {
+        emitJson('migrate', {
+          mode: executeRequested ? 'execute' : 'plan',
+          scope: tableScope,
+          pending: [],
+          applied: [],
+        })
+      } else {
+        console.log('No pending migrations.')
+      }
       return
     }
-  }
 
-  const destructiveMigrations: string[] = []
-  const destructiveOperations: DestructiveOperationMarker[] = []
-  for (const file of pending) {
-    const sql = await readFile(join(migrationsDir, file), 'utf8')
-    if (migrationContainsDangerOperation(sql)) {
-      destructiveMigrations.push(file)
-      destructiveOperations.push(...collectDestructiveOperationMarkers(file, sql))
+    const planned = {
+      mode: executeRequested ? 'execute' : 'plan',
+      scope: tableScope,
+      pending,
     }
-  }
 
-  let destructiveAllowed = allowDestructive || config.safety?.allowDestructive === true
-  if (destructiveMigrations.length > 0 && !destructiveAllowed) {
-    const error =
-      'Blocked destructive migration execution. Re-run with --allow-destructive or set safety.allowDestructive=true after review.'
+    if (jsonMode && !executeRequested) {
+      emitJson('migrate', planned)
+      return
+    }
+
+    if (!jsonMode) {
+      if (tableScope.enabled) {
+        console.log(`Table scope: ${tableScope.selector ?? ''} (${tableScope.matchCount} matched)`)
+        for (const table of tableScope.matchedTables) console.log(`- ${table}`)
+      }
+      console.log(`Pending migrations: ${pending.length}`)
+      for (const file of pending) console.log(`- ${file}`)
+    }
+
+    let shouldExecute = executeRequested
+    if (!shouldExecute) {
+      if (isBackgroundOrCI() || jsonMode) {
+        if (!jsonMode) {
+          console.log('\nPlan only. Re-run with --apply to apply and journal these migrations.')
+        }
+        return
+      }
+
+      const rl = createInterface({ input: process.stdin, output: process.stdout })
+      try {
+        console.log('')
+        console.log('Type "yes" to continue. Any other input cancels.')
+        const response = await rl.question('Apply pending migrations now? [no/yes]: ')
+        shouldExecute = response.trim().toLowerCase() === 'yes'
+      } finally {
+        rl.close()
+      }
+
+      if (!shouldExecute) {
+        console.log('Migration apply cancelled by user.')
+        return
+      }
+    }
+
+    const destructiveMigrations: string[] = []
+    const destructiveOperations: DestructiveOperationMarker[] = []
+    for (const file of pending) {
+      const sql = await readFile(join(migrationsDir, file), 'utf8')
+      if (migrationContainsDangerOperation(sql)) {
+        destructiveMigrations.push(file)
+        destructiveOperations.push(...collectDestructiveOperationMarkers(file, sql))
+      }
+    }
+
+    let destructiveAllowed = allowDestructive || config.safety?.allowDestructive === true
+    if (destructiveMigrations.length > 0 && !destructiveAllowed) {
+      const error =
+        'Blocked destructive migration execution. Re-run with --allow-destructive or set safety.allowDestructive=true after review.'
+      if (jsonMode) {
+        emitJson('migrate', {
+          mode: 'execute',
+          scope: tableScope,
+          error,
+          destructiveMigrations,
+          destructiveOperations,
+        })
+        process.exitCode = 3
+        return
+      }
+
+      if (isBackgroundOrCI()) {
+        printDestructiveOperationDetails(destructiveOperations)
+        throw new Error(
+          `${error}\nDestructive migrations: ${destructiveMigrations.join(', ')}\n` +
+            'Non-interactive run detected. Pass --allow-destructive to proceed.'
+        )
+      }
+
+      const confirmed = await confirmDestructiveExecution(destructiveOperations)
+      if (!confirmed) {
+        throw new Error(
+          `Destructive migration cancelled by user.\nDestructive migrations: ${destructiveMigrations.join(', ')}`
+        )
+      }
+      destructiveAllowed = true
+    }
+
+    if (destructiveMigrations.length > 0 && !destructiveAllowed) {
+      throw new Error('Blocked destructive migration execution.')
+    }
+
+    const appliedNow: MigrationJournalEntry[] = []
+
+    for (const file of pending) {
+      const fullPath = join(migrationsDir, file)
+      const sql = await readFile(fullPath, 'utf8')
+      const parsedStatements = extractExecutableStatements(sql)
+      const statements = await pluginRuntime.runOnBeforeApply({
+        command: 'migrate',
+        config,
+        tableScope,
+        flags,
+        migration: file,
+        sql,
+        statements: parsedStatements,
+      })
+      for (const statement of statements) {
+        await db.execute(statement)
+      }
+
+      const entry: MigrationJournalEntry = {
+        name: file,
+        appliedAt: new Date().toISOString().replace('Z', ''),
+        checksum: checksumSQL(sql),
+      }
+      appliedNow.push(entry)
+      await journalStore.appendEntry(entry)
+      await pluginRuntime.runOnAfterApply({
+        command: 'migrate',
+        config,
+        tableScope,
+        flags,
+        migration: file,
+        statements,
+        appliedAt: entry.appliedAt,
+      })
+
+      if (!jsonMode) console.log(`Applied: ${file}`)
+    }
+
     if (jsonMode) {
       emitJson('migrate', {
         mode: 'execute',
         scope: tableScope,
-        error,
-        destructiveMigrations,
-        destructiveOperations,
+        applied: appliedNow,
       })
-      process.exitCode = 3
       return
     }
 
-    if (isBackgroundOrCI()) {
-      printDestructiveOperationDetails(destructiveOperations)
-      throw new Error(
-        `${error}\nDestructive migrations: ${destructiveMigrations.join(', ')}\n` +
-          'Non-interactive run detected. Pass --allow-destructive to proceed.'
-      )
-    }
-
-    const confirmed = await confirmDestructiveExecution(destructiveOperations)
-    if (!confirmed) {
-      throw new Error(
-        `Destructive migration cancelled by user.\nDestructive migrations: ${destructiveMigrations.join(', ')}`
-      )
-    }
-    destructiveAllowed = true
-  }
-
-  if (destructiveMigrations.length > 0 && !destructiveAllowed) {
-    throw new Error('Blocked destructive migration execution.')
-  }
-
-  const appliedNow: MigrationJournalEntry[] = []
-
-  for (const file of pending) {
-    const fullPath = join(migrationsDir, file)
-    const sql = await readFile(fullPath, 'utf8')
-    const parsedStatements = extractExecutableStatements(sql)
-    const statements = await pluginRuntime.runOnBeforeApply({
-      command: 'migrate',
-      config,
-      tableScope,
-      flags,
-      migration: file,
-      sql,
-      statements: parsedStatements,
-    })
-    for (const statement of statements) {
-      await db.execute(statement)
-    }
-
-    const entry: MigrationJournalEntry = {
-      name: file,
-      appliedAt: new Date().toISOString().replace('Z', ''),
-      checksum: checksumSQL(sql),
-    }
-    appliedNow.push(entry)
-    await journalStore.appendEntry(entry)
-    await pluginRuntime.runOnAfterApply({
-      command: 'migrate',
-      config,
-      tableScope,
-      flags,
-      migration: file,
-      statements,
-      appliedAt: entry.appliedAt,
-    })
-
-    if (!jsonMode) console.log(`Applied: ${file}`)
-  }
-
-  if (jsonMode) {
-    emitJson('migrate', {
-      mode: 'execute',
-      scope: tableScope,
-      applied: appliedNow,
-    })
-    return
-  }
-
-  console.log(`\nMigrations recorded in ClickHouse _chkit_migrations table.`)
+    console.log(`\nMigrations recorded in ClickHouse _chkit_migrations table.`)
+  })
 }

--- a/packages/cli/src/bin/commands/status.ts
+++ b/packages/cli/src/bin/commands/status.ts
@@ -1,8 +1,9 @@
 import { mkdir } from 'node:fs/promises'
 
 import type { CommandDef, CommandRunContext } from '../../plugins.js'
+import { withClickHouseExecutor } from '../clickhouse-resource.js'
 import { emitJson } from '../json-output.js'
-import { createJournalStoreFromConfig } from '../journal-store.js'
+import { createJournalStore } from '../journal-store.js'
 import { findChecksumMismatches, listMigrations } from '../migration-store.js'
 
 export const statusCommand: CommandDef = {
@@ -21,41 +22,43 @@ async function cmdStatus(ctx: CommandRunContext): Promise<void> {
     throw new Error('clickhouse config is required for status (journal is stored in ClickHouse)')
   }
 
-  const { journalStore } = createJournalStoreFromConfig(config.clickhouse)
+  await withClickHouseExecutor(config.clickhouse, async (db) => {
+    const journalStore = createJournalStore(db)
 
-  await mkdir(migrationsDir, { recursive: true })
-  const files = await listMigrations(migrationsDir)
-  const journal = await journalStore.readJournal()
-  const appliedNames = new Set(journal.applied.map((entry) => entry.name))
-  const pending = files.filter((f) => !appliedNames.has(f))
-  const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
+    await mkdir(migrationsDir, { recursive: true })
+    const files = await listMigrations(migrationsDir)
+    const journal = await journalStore.readJournal()
+    const appliedNames = new Set(journal.applied.map((entry) => entry.name))
+    const pending = files.filter((f) => !appliedNames.has(f))
+    const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
 
-  const payload = {
-    migrationsDir,
-    total: files.length,
-    applied: journal.applied.length,
-    pending: pending.length,
-    pendingMigrations: pending,
-    checksumMismatchCount: checksumMismatches.length,
-    checksumMismatches,
-  }
+    const payload = {
+      migrationsDir,
+      total: files.length,
+      applied: journal.applied.length,
+      pending: pending.length,
+      pendingMigrations: pending,
+      checksumMismatchCount: checksumMismatches.length,
+      checksumMismatches,
+    }
 
-  if (jsonMode) {
-    emitJson('status', payload)
-    return
-  }
+    if (jsonMode) {
+      emitJson('status', payload)
+      return
+    }
 
-  console.log(`Migrations directory: ${migrationsDir}`)
-  console.log(`Total migrations:     ${files.length}`)
-  console.log(`Applied:              ${journal.applied.length}`)
-  console.log(`Pending:              ${pending.length}`)
+    console.log(`Migrations directory: ${migrationsDir}`)
+    console.log(`Total migrations:     ${files.length}`)
+    console.log(`Applied:              ${journal.applied.length}`)
+    console.log(`Pending:              ${pending.length}`)
 
-  if (pending.length > 0) {
-    console.log('\nPending migrations:')
-    for (const item of pending) console.log(`- ${item}`)
-  }
-  if (checksumMismatches.length > 0) {
-    console.log('\nChecksum mismatches on applied migrations:')
-    for (const item of checksumMismatches) console.log(`- ${item.name}`)
-  }
+    if (pending.length > 0) {
+      console.log('\nPending migrations:')
+      for (const item of pending) console.log(`- ${item}`)
+    }
+    if (checksumMismatches.length > 0) {
+      console.log('\nChecksum mismatches on applied migrations:')
+      for (const item of checksumMismatches) console.log(`- ${item.name}`)
+    }
+  })
 }

--- a/packages/cli/src/bin/safety-markers.test.ts
+++ b/packages/cli/src/bin/safety-markers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import { extractExecutableStatements } from './safety-markers.js'
+
+describe('extractExecutableStatements', () => {
+  test('splits simple statement batches', () => {
+    const sql = `
+      CREATE TABLE app.events (id UInt64);
+      ALTER TABLE app.events ADD COLUMN name String;
+    `
+
+    expect(extractExecutableStatements(sql)).toEqual([
+      'CREATE TABLE app.events (id UInt64);',
+      'ALTER TABLE app.events ADD COLUMN name String;',
+    ])
+  })
+
+  test('does not split on semicolons inside quoted strings', () => {
+    const sql = `
+      INSERT INTO app.logs (message) VALUES ('first;second');
+      INSERT INTO app.logs (message) VALUES ("third;fourth");
+      INSERT INTO app.logs (message) VALUES ('it''s;fine');
+    `
+
+    expect(extractExecutableStatements(sql)).toEqual([
+      "INSERT INTO app.logs (message) VALUES ('first;second');",
+      'INSERT INTO app.logs (message) VALUES ("third;fourth");',
+      "INSERT INTO app.logs (message) VALUES ('it''s;fine');",
+    ])
+  })
+
+  test('does not split on semicolons in backtick identifiers or block comments', () => {
+    const sql = `
+      /* migration metadata ; keep as comment */
+      ALTER TABLE app.events ADD COLUMN \`semi;name\` String;
+      /* another ; comment */ ALTER TABLE app.events DROP COLUMN IF EXISTS old_col;
+    `
+
+    expect(extractExecutableStatements(sql)).toEqual([
+      '/* migration metadata ; keep as comment */\n      ALTER TABLE app.events ADD COLUMN `semi;name` String;',
+      '/* another ; comment */ ALTER TABLE app.events DROP COLUMN IF EXISTS old_col;',
+    ])
+  })
+
+  test('ignores full-line comments while preserving executable statements', () => {
+    const sql = `
+      -- operation: alter_table_drop_column key=table:app.events:column:old_col risk=danger
+      -- sql: ALTER TABLE app.events DROP COLUMN old_col;
+      ALTER TABLE app.events DROP COLUMN IF EXISTS old_col;
+    `
+
+    expect(extractExecutableStatements(sql)).toEqual([
+      'ALTER TABLE app.events DROP COLUMN IF EXISTS old_col;',
+    ])
+  })
+})

--- a/packages/plugin-pull/src/render-schema.ts
+++ b/packages/plugin-pull/src/render-schema.ts
@@ -1,0 +1,140 @@
+import { canonicalizeDefinitions, type SchemaDefinition } from '@chkit/core'
+
+export function renderSchemaFile(definitions: SchemaDefinition[]): string {
+  const canonical = canonicalizeDefinitions(definitions)
+  const declarationNames = new Map<string, number>()
+  const hasTable = canonical.some((definition) => definition.kind === 'table')
+  const hasView = canonical.some((definition) => definition.kind === 'view')
+  const hasMaterializedView = canonical.some((definition) => definition.kind === 'materialized_view')
+  const imports = ['schema']
+  if (hasTable) imports.push('table')
+  if (hasView) imports.push('view')
+  if (hasMaterializedView) imports.push('materializedView')
+  const lines: string[] = [
+    `import { ${imports.join(', ')} } from '@chkit/core'`,
+    '',
+    '// Pulled from live ClickHouse metadata via chkit plugin pull schema',
+    '',
+  ]
+
+  const references: string[] = []
+
+  for (const definition of canonical) {
+    const variableName = resolveTableVariableName(definition.database, definition.name, declarationNames)
+    references.push(variableName)
+
+    if (definition.kind === 'table') {
+      lines.push(`const ${variableName} = table({`)
+      lines.push(`  database: ${renderString(definition.database)},`)
+      lines.push(`  name: ${renderString(definition.name)},`)
+      lines.push(`  engine: ${renderString(definition.engine)},`)
+      lines.push('  columns: [')
+
+      for (const column of definition.columns) {
+        const parts: string[] = [
+          `name: ${renderString(column.name)}`,
+          `type: ${renderString(column.type)}`,
+        ]
+        if (column.nullable) parts.push('nullable: true')
+        if (column.default !== undefined) parts.push(`default: ${renderLiteral(column.default)}`)
+        if (column.comment) parts.push(`comment: ${renderString(column.comment)}`)
+        lines.push(`    { ${parts.join(', ')} },`)
+      }
+
+      lines.push('  ],')
+      lines.push(`  primaryKey: ${renderStringArray(definition.primaryKey)},`)
+      lines.push(`  orderBy: ${renderStringArray(definition.orderBy)},`)
+      if (definition.uniqueKey && definition.uniqueKey.length > 0) {
+        lines.push(`  uniqueKey: ${renderStringArray(definition.uniqueKey)},`)
+      }
+      if (definition.partitionBy) {
+        lines.push(`  partitionBy: ${renderString(definition.partitionBy)},`)
+      }
+      if (definition.ttl) {
+        lines.push(`  ttl: ${renderString(definition.ttl)},`)
+      }
+      if (definition.settings && Object.keys(definition.settings).length > 0) {
+        lines.push('  settings: {')
+        for (const key of Object.keys(definition.settings).sort()) {
+          const value = definition.settings[key]
+          if (value === undefined) continue
+          lines.push(`    ${renderKey(key)}: ${renderLiteral(value)},`)
+        }
+        lines.push('  },')
+      }
+      if (definition.indexes && definition.indexes.length > 0) {
+        lines.push('  indexes: [')
+        for (const index of definition.indexes) {
+          lines.push(
+            `    { name: ${renderString(index.name)}, expression: ${renderString(index.expression)}, type: ${renderString(index.type)}, granularity: ${index.granularity} },`
+          )
+        }
+        lines.push('  ],')
+      }
+      if (definition.projections && definition.projections.length > 0) {
+        lines.push('  projections: [')
+        for (const projection of definition.projections) {
+          lines.push(
+            `    { name: ${renderString(projection.name)}, query: ${renderString(projection.query)} },`
+          )
+        }
+        lines.push('  ],')
+      }
+      lines.push('})')
+    } else if (definition.kind === 'view') {
+      lines.push(`const ${variableName} = view({`)
+      lines.push(`  database: ${renderString(definition.database)},`)
+      lines.push(`  name: ${renderString(definition.name)},`)
+      lines.push(`  as: ${renderString(definition.as)},`)
+      lines.push('})')
+    } else {
+      lines.push(`const ${variableName} = materializedView({`)
+      lines.push(`  database: ${renderString(definition.database)},`)
+      lines.push(`  name: ${renderString(definition.name)},`)
+      lines.push(`  to: { database: ${renderString(definition.to.database)}, name: ${renderString(definition.to.name)} },`)
+      lines.push(`  as: ${renderString(definition.as)},`)
+      lines.push('})')
+    }
+    lines.push('')
+  }
+
+  lines.push(`export default schema(${references.join(', ')})`)
+  return `${lines.join('\n')}\n`
+}
+
+function resolveTableVariableName(
+  database: string,
+  name: string,
+  counts: Map<string, number>
+): string {
+  const base = sanitizeIdentifier(`${database}_${name}`)
+  const current = counts.get(base) ?? 0
+  const next = current + 1
+  counts.set(base, next)
+  return next === 1 ? base : `${base}_${next}`
+}
+
+function sanitizeIdentifier(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9_]/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '')
+  if (sanitized.length === 0) return 'table_ref'
+  if (/^[0-9]/.test(sanitized)) return `table_${sanitized}`
+  return sanitized
+}
+
+function renderString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function renderStringArray(values: string[]): string {
+  return `[${values.map((value) => renderString(value)).join(', ')}]`
+}
+
+function renderLiteral(value: string | number | boolean): string {
+  if (typeof value === 'string') return renderString(value)
+  return String(value)
+}
+
+function renderKey(value: string): string {
+  if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(value)) return value
+  return renderString(value)
+}

--- a/packages/plugin-pull/src/view-parser.ts
+++ b/packages/plugin-pull/src/view-parser.ts
@@ -1,0 +1,65 @@
+import { inferSchemaKindFromEngine, type IntrospectedTable } from '@chkit/clickhouse'
+import type { MaterializedViewDefinition, ViewDefinition } from '@chkit/core'
+
+export interface SystemTableRow {
+  database: string
+  name: string
+  engine: string
+  create_table_query?: string
+}
+
+export type IntrospectedObject =
+  | ({ kind: 'table' } & IntrospectedTable)
+  | ({ kind: 'view' } & Pick<ViewDefinition, 'database' | 'name' | 'as'>)
+  | ({ kind: 'materialized_view' } & Pick<MaterializedViewDefinition, 'database' | 'name' | 'to' | 'as'>)
+  | IntrospectedTable
+
+export function mapSystemTableRowToDefinition(
+  row: SystemTableRow
+): Exclude<IntrospectedObject, IntrospectedTable> | null {
+  const kind = inferSchemaKindFromEngine(row.engine)
+  if (kind === 'view') {
+    const as = parseAsClause(row.create_table_query)
+    if (!as) return null
+    return { kind: 'view', database: row.database, name: row.name, as }
+  }
+  if (kind === 'materialized_view') {
+    const as = parseAsClause(row.create_table_query)
+    const to = parseToClause(row.create_table_query, row.database)
+    if (!as || !to) return null
+    return { kind: 'materialized_view', database: row.database, name: row.name, to, as }
+  }
+  return null
+}
+
+export function parseAsClause(query: string | undefined): string | null {
+  if (!query) return null
+  const match = /\bAS\b([\s\S]*)$/i.exec(query)
+  if (!match?.[1]) return null
+  const asClause = match[1].trim().replace(/;$/, '').trim()
+  return asClause.length > 0 ? asClause : null
+}
+
+export function parseToClause(
+  query: string | undefined,
+  fallbackDatabase: string
+): { database: string; name: string } | null {
+  if (!query) return null
+  const identifier = /(?:^|\s)TO\s+((?:`[^`]+`|"[^"]+"|[A-Za-z0-9_]+)(?:\.(?:`[^`]+`|"[^"]+"|[A-Za-z0-9_]+))?)/i.exec(
+    query
+  )?.[1]
+  if (!identifier) return null
+  const parts = identifier.split('.').map((part) => part.replace(/^[`"]|[`"]$/g, '').trim())
+  if (parts.length === 1) {
+    const name = parts[0] ?? ''
+    if (name.length === 0) return null
+    return { database: fallbackDatabase, name }
+  }
+  if (parts.length === 2) {
+    const database = parts[0] ?? fallbackDatabase
+    const name = parts[1] ?? ''
+    if (database.length === 0 || name.length === 0) return null
+    return { database, name }
+  }
+  return null
+}


### PR DESCRIPTION
Summary
- wrap migrate/check/drift/status flows in the shared `withClickHouseExecutor` helper and simplify journal store creation
- ensure drift computation and migrate execution reuse shared database lifecycle handling while keeping output/json paths intact
- add destructive migration guard and proper scope handling inside the migrated execute block
Testing
- Not run (not requested)