### PR TITLE
fix: prevent undefined from overwriting backfill defaults

### DIFF
--- a/.changeset/backfill-options-merge-fix.md
+++ b/.changeset/backfill-options-merge-fix.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Fix option merging to prevent undefined values from overwriting base defaults, which caused `RangeError: Invalid Date` when using partial backfill config objects. Add validation to catch undefined/NaN numeric fields earlier with clearer error messages.

--- a/packages/cli/src/clickhouse-live.e2e.test.ts
+++ b/packages/cli/src/clickhouse-live.e2e.test.ts
@@ -45,14 +45,24 @@ function runCli(cwd: string, args: string[]): { exitCode: number; stdout: string
   }
 }
 
+function isValidJson(str: string): boolean {
+  try {
+    JSON.parse(str)
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function runCliWithRetry(
   cwd: string,
   args: string[],
   { maxAttempts = 5, delayMs = 2000 }: { maxAttempts?: number; delayMs?: number } = {},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const expectJson = args.includes('--json')
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const result = runCli(cwd, args)
-    if (result.exitCode === 0) return result
+    if (result.exitCode === 0 && (!expectJson || isValidJson(result.stdout))) return result
     if (attempt === maxAttempts) return result
     await new Promise((r) => setTimeout(r, delayMs))
   }

--- a/packages/plugin-backfill/src/options.test.ts
+++ b/packages/plugin-backfill/src/options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { normalizeBackfillOptions } from './options.js'
+import { mergeOptions, normalizeBackfillOptions } from './options.js'
 
 describe('@chkit/plugin-backfill options', () => {
   test('normalizes documented defaults', () => {
@@ -25,5 +25,34 @@ describe('@chkit/plugin-backfill options', () => {
     })
 
     expect(options.defaults.timeColumn).toBe('created_at')
+  })
+
+  test('mergeOptions preserves base defaults when runtime only sets timeColumn', () => {
+    const base = normalizeBackfillOptions()
+    const merged = mergeOptions(base, { defaults: { timeColumn: 'session_date' } })
+
+    expect(merged.defaults.chunkHours).toBe(6)
+    expect(merged.defaults.maxParallelChunks).toBe(1)
+    expect(merged.defaults.maxRetriesPerChunk).toBe(3)
+    expect(merged.defaults.requireIdempotencyToken).toBe(true)
+    expect(merged.defaults.timeColumn).toBe('session_date')
+  })
+
+  test('mergeOptions preserves base policy when runtime only sets one policy field', () => {
+    const base = normalizeBackfillOptions()
+    const merged = mergeOptions(base, { policy: { blockOverlappingRuns: false } })
+
+    expect(merged.policy.requireDryRunBeforeRun).toBe(true)
+    expect(merged.policy.requireExplicitWindow).toBe(true)
+    expect(merged.policy.blockOverlappingRuns).toBe(false)
+    expect(merged.policy.failCheckOnRequiredPendingBackfill).toBe(true)
+  })
+
+  test('mergeOptions preserves base limits when runtime only sets one limit field', () => {
+    const base = normalizeBackfillOptions()
+    const merged = mergeOptions(base, { limits: { maxWindowHours: 48 } })
+
+    expect(merged.limits.maxWindowHours).toBe(48)
+    expect(merged.limits.minChunkMinutes).toBe(15)
   })
 })


### PR DESCRIPTION
## Summary

Fixed a critical bug where partial backfill plugin configurations would crash with `RangeError: Invalid Date`. When users provided only a subset of config options (e.g., just `defaults.timeColumn`), the option merging logic would create objects with explicit `undefined` values that overwrote base defaults via spread operator, causing `NaN` to propagate through the backfill planning logic.

## Changes

- **stripUndefined helper**: Removes explicit `undefined` keys before spreading to prevent overwriting base defaults
- **Defense-in-depth validation**: Added checks in `validateBaseOptions` to catch undefined/NaN numeric fields early with clear error messages
- **Test coverage**: Added three new test cases covering partial config merging for defaults, policy, and limits

## Test plan

- [x] All existing tests pass (`bun verify`)
- [x] New test cases verify partial configs correctly merge with base defaults
- [x] Manual verification: backfill with partial config no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)