### PR TITLE
fix(plugin-backfill): fix Array column handling in MV replay

### DIFF
--- a/.changeset/backfill-array-fix.md
+++ b/.changeset/backfill-array-fix.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Fix: Backfill no longer fails with "Array(String) cannot be inside Nullable column" error when replaying materialized views that compute array columns. The plugin now injects time-range filters directly into the MV query instead of wrapping it in a CTE, avoiding ClickHouse's illegal type inference.


### PR DESCRIPTION
## Summary

**Backfill Array column fix:** Fixes backfill plugin failure when replaying materialized views that compute `Array(String)` or other non-nullable-compatible columns. The plugin previously wrapped the MV query in a CTE, causing ClickHouse to infer `Nullable(Array(String))` — an illegal type combination. The fix injects the time-range filter directly into the MV query instead of using a CTE.

**Pull e2e flake fix:** Fixes a flaky `plugin-pull` e2e test that was failing on CI (and on main) because ClickHouse Cloud's eventually consistent DDL meant not all 5 fixture objects were visible when the pull command ran. Adds a visibility poll loop before running introspection.

## Changes

- **packages/plugin-backfill/src/planner.ts**: Added `injectTimeFilter()` function; updated `buildChunkSqlTemplate()` to use direct filter injection instead of CTE wrapping for MV replay.
- **packages/plugin-backfill/src/planner.test.ts**: Updated existing MV replay test; added 7 unit tests for `injectTimeFilter` edge cases.
- **packages/plugin-pull/src/pull.e2e.test.ts**: Added `querySql()` helper and a retry loop that waits for all 5 DDL objects to be visible in `system.tables` before running the pull command.
- **.changeset/backfill-array-fix.md**: Changeset for the backfill bug fix.

## Test plan

- [x] All 45 backfill plugin tests pass
- [x] All 12 plugin-pull unit tests pass
- [x] Full verification suite passes locally (build, test, typecheck, lint)
- [x] Plugin-pull e2e test now polls for DDL visibility (up to 30s) before asserting

🤖 Generated with [Claude Code](https://claude.com/claude-code)