### PR TITLE
fix(plugin-backfill): explicit column list in MV replay INSERT

### DIFF
--- a/.changeset/mv-column-list.md
+++ b/.changeset/mv-column-list.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Fix backfill MV replay SQL generation to include explicit column list in INSERT clause, avoiding positional column mismatches when the materialized view uses SELECT * and adds computed columns.


### PR DESCRIPTION
## Summary
Fixed backfill MV replay SQL generation to include an explicit column list in the INSERT clause. This prevents positional column mismatches when the materialized view uses `SELECT *` and adds computed columns.

## The Problem
When `INSERT INTO target SELECT ...` is used with a SELECT that expands `SELECT *` and appends computed columns, ClickHouse matches columns by position. If the SELECT output order doesn't match the target table's column order, ClickHouse attempts to insert incompatible types, causing errors like "Array(String) cannot be inside Nullable column".

## The Solution
Generate `INSERT INTO target (col1, col2, ...)` with an explicit column list from the target table's schema definition. This forces ClickHouse to match columns by name instead of position, matching the behavior of live materialized view inserts.

## Testing
- All 46 backfill plugin tests pass, including a new test verifying the explicit column list is generated correctly
- Added comprehensive test case covering the exact scenario described in the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)