### PR TITLE
fix(plugin-backfill): rewrite SELECT columns in MV replay to match target order

### DIFF
--- a/.changeset/fix-mv-backfill-select-column-order.md
+++ b/.changeset/fix-mv-backfill-select-column-order.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Fix materialized view backfill INSERT by rewriting SELECT column order to match target table. ClickHouse's positional column mapping requires SELECT output columns to be in the same order as the INSERT target columns, not matched by name.


### PR DESCRIPTION
## Summary

ClickHouse's `INSERT INTO target (cols) SELECT ...` maps columns positionally (not by name). When a materialized view query's SELECT output columns are in a different order than the target table's columns, data was being inserted into wrong columns, causing type mismatches and failures. Now `rewriteSelectColumns()` parses the SELECT projection, builds an alias→expression map, and emits columns in target table order.

Added comprehensive unit tests for the new function covering star expansion, WITH clause preservation, and edge cases.

## Test plan

- [x] All existing backfill plugin tests pass (50 tests)
- [x] Full monorepo verification passes (all lint, type, test)
- [x] New `rewriteSelectColumns` unit tests added and passing
- [x] Updated existing MV replay test to verify SELECT rewriting instead of INSERT column list

🤖 Generated with [Claude Code](https://claude.com/claude-code)