### PR TITLE
feat: backfill UX improvements

### DIFF
--- a/.changeset/backfill-ux-improvements.md
+++ b/.changeset/backfill-ux-improvements.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Add backfill UX improvements: Track rows-written per chunk and warn when 0 rows complete, add `--force` flag to regenerate plans, handle graceful shutdown with signal handling, return exit code 0 for completed re-runs with friendly message, and always show lastError in non-JSON output.

--- a/apps/docs/src/content/docs/plugins/backfill.md
+++ b/apps/docs/src/content/docs/plugins/backfill.md
@@ -170,6 +170,7 @@ Build a deterministic backfill plan and persist immutable plan state.
 | `--chunk-hours <n>` | No | Override chunk size (defaults to `defaults.chunkHours`) |
 | `--time-column <column>` | No | Time column for WHERE clause (auto-detected if omitted) |
 | `--force-large-window` | No | Allow windows exceeding `limits.maxWindowHours` |
+| `--force` | No | Delete existing plan and regenerate from scratch |
 
 ### `chkit plugin backfill run`
 

--- a/packages/plugin-backfill/src/args.ts
+++ b/packages/plugin-backfill/src/args.ts
@@ -17,6 +17,7 @@ export const PLAN_FLAGS = defineFlags([
   { name: '--chunk-hours', type: 'string', description: 'Hours per chunk', placeholder: '<hours>' },
   { name: '--time-column', type: 'string', description: 'Time column for WHERE clause', placeholder: '<column>' },
   { name: '--force-large-window', type: 'boolean', description: 'Allow large time windows without confirmation' },
+  { name: '--force', type: 'boolean', description: 'Delete existing plan and regenerate from scratch' },
 ] as const)
 
 export const RUN_FLAGS = defineFlags([
@@ -79,6 +80,7 @@ export function parsePlanArgs(flags: ParsedFlags): ParsedPlanArgs {
   const rawChunkHours = f['--chunk-hours']
   const timeColumn = f['--time-column']
   const forceLargeWindow = f['--force-large-window'] === true
+  const force = f['--force'] === true
 
   let chunkHours: number | undefined
   if (rawChunkHours !== undefined) {
@@ -100,6 +102,7 @@ export function parsePlanArgs(flags: ParsedFlags): ParsedPlanArgs {
     chunkHours,
     timeColumn: timeColumn?.trim() || undefined,
     forceLargeWindow,
+    force,
   }
 }
 

--- a/packages/plugin-backfill/src/payload.ts
+++ b/packages/plugin-backfill/src/payload.ts
@@ -41,9 +41,11 @@ export function runPayload(output: ExecuteBackfillRunOutput): {
   status: BackfillPlanStatus
   chunkCounts: BackfillStatusSummary['totals']
   attempts: number
+  rowsWritten: number
   runPath: string
   eventPath: string
   lastError?: string
+  noop?: boolean
 } {
   return {
     ok: output.status.status === 'completed',
@@ -52,9 +54,11 @@ export function runPayload(output: ExecuteBackfillRunOutput): {
     status: output.status.status,
     chunkCounts: output.status.totals,
     attempts: output.status.attempts,
+    rowsWritten: output.status.rowsWritten,
     runPath: output.runPath,
     eventPath: output.eventPath,
     lastError: output.status.lastError,
+    noop: output.noop,
   }
 }
 
@@ -65,6 +69,7 @@ export function statusPayload(summary: BackfillStatusSummary): {
   status: BackfillPlanStatus
   chunkCounts: BackfillStatusSummary['totals']
   attempts: number
+  rowsWritten: number
   runPath: string
   eventPath: string
   updatedAt: string
@@ -77,6 +82,7 @@ export function statusPayload(summary: BackfillStatusSummary): {
     status: summary.status,
     chunkCounts: summary.totals,
     attempts: summary.attempts,
+    rowsWritten: summary.rowsWritten,
     runPath: summary.runPath,
     eventPath: summary.eventPath,
     updatedAt: summary.updatedAt,

--- a/packages/plugin-backfill/src/planner.ts
+++ b/packages/plugin-backfill/src/planner.ts
@@ -1,4 +1,5 @@
 import { dirname } from 'node:path'
+import { unlink } from 'node:fs/promises'
 
 import { loadSchemaDefinitions } from '@chkit/core'
 import type { ResolvedChxConfig } from '@chkit/core'
@@ -329,6 +330,7 @@ export async function buildBackfillPlan(input: {
   options: NormalizedBackfillPluginOptions
   chunkHours?: number
   forceLargeWindow?: boolean
+  force?: boolean
 }): Promise<BuildBackfillPlanOutput> {
   const chunkHours = input.chunkHours ?? input.options.defaults.chunkHours
   if (chunkHours * 60 < input.options.limits.minChunkMinutes) {
@@ -402,6 +404,14 @@ export async function buildBackfillPlan(input: {
     },
     policy: input.options.policy,
     limits: input.options.limits,
+  }
+
+  if (input.force) {
+    for (const filePath of [paths.planPath, paths.runPath, paths.eventPath]) {
+      await unlink(filePath).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== 'ENOENT') throw err
+      })
+    }
   }
 
   const existing = await readExistingPlan(paths.planPath)

--- a/packages/plugin-backfill/src/state.ts
+++ b/packages/plugin-backfill/src/state.ts
@@ -202,8 +202,10 @@ export function summarizeRunStatus(
   }
 
   let attempts = 0
+  let rowsWritten = 0
   for (const chunk of run.chunks) {
     attempts += chunk.attempts
+    rowsWritten += chunk.rowsWritten ?? 0
     if (chunk.status === 'pending') summary.pending += 1
     if (chunk.status === 'running') summary.running += 1
     if (chunk.status === 'done') summary.done += 1
@@ -217,6 +219,7 @@ export function summarizeRunStatus(
     status: run.status,
     totals: summary,
     attempts,
+    rowsWritten,
     updatedAt: run.updatedAt,
     runPath,
     eventPath,

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -86,6 +86,7 @@ export interface BackfillRunChunkState {
   startedAt?: string
   completedAt?: string
   lastError?: string
+  rowsWritten?: number
 }
 
 export interface BackfillRunState {
@@ -117,6 +118,7 @@ export interface BackfillStatusSummary {
     skipped: number
   }
   attempts: number
+  rowsWritten: number
   updatedAt: string
   runPath: string
   eventPath: string
@@ -197,6 +199,7 @@ export interface ExecuteBackfillRunOutput {
   status: BackfillStatusSummary
   runPath: string
   eventPath: string
+  noop?: boolean
 }
 
 export interface BackfillPluginCommandContext {
@@ -257,6 +260,7 @@ export interface ParsedPlanArgs {
   chunkHours?: number
   timeColumn?: string
   forceLargeWindow: boolean
+  force: boolean
 }
 
 export interface ParsedRunArgs {


### PR DESCRIPTION
## Summary
- Track rows written per chunk and warn when completed with 0 rows written
- Add `--force` flag to regenerate plans by deleting existing state
- Handle process interruption gracefully: register SIGINT/SIGTERM, cleanup chunks and transition run to paused
- Return exit 0 with friendly message for re-running completed plans (was: cryptic exit 2 error)
- Always show lastError in non-JSON output for run, resume, and status commands
- Include rowsWritten in JSON output for both run and status commands

## Test plan
- [x] All 50 backfill plugin unit tests pass
- [x] All 96 CLI integration tests pass (includes backfill e2e)
- [x] `bun verify` passes (typecheck, lint, test, build)
- [x] Backward compatible: executor implementations returning `Promise<void>` still work
- [x] Signal handling integrated without affecting normal completion path

🤖 Generated with [Claude Code](https://claude.com/claude-code)