### PR TITLE
fix(plugin-backfill): add retry backoff and continue processing after chunk failure

### DIFF
--- a/.changeset/backfill-retry-backoff.md
+++ b/.changeset/backfill-retry-backoff.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Fix backfill runtime issues: add exponential backoff between retries (configurable via `defaults.retryDelayMs`, default 1000ms), continue processing remaining chunks after one fails permanently (instead of stopping), and make `resume` automatically retry failed chunks without requiring `--replay-failed`.

--- a/packages/cli/src/plugin.test.ts
+++ b/packages/cli/src/plugin.test.ts
@@ -369,7 +369,7 @@ describe('plugin runtime', () => {
         chunkCounts: { done: number; failed: number }
       }
       expect(failedPayload.status).toBe('failed')
-      expect(failedPayload.chunkCounts.done).toBe(1)
+      expect(failedPayload.chunkCounts.done).toBe(2)
       expect(failedPayload.chunkCounts.failed).toBe(1)
 
       const resumed = runCli([

--- a/packages/plugin-backfill/src/options.ts
+++ b/packages/plugin-backfill/src/options.ts
@@ -6,6 +6,7 @@ const DEFAULT_OPTIONS: NormalizedBackfillPluginOptions = {
     chunkHours: 6,
     maxParallelChunks: 1,
     maxRetriesPerChunk: 3,
+    retryDelayMs: 1000,
     requireIdempotencyToken: true,
   },
   policy: {
@@ -32,6 +33,14 @@ function parsePositiveNumber(value: unknown, key: string): number | undefined {
   if (value === undefined) return undefined
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     throw new BackfillConfigError(`Invalid plugin option "${key}". Expected a positive number.`)
+  }
+  return value
+}
+
+function parseNonNegativeNumber(value: unknown, key: string): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new BackfillConfigError(`Invalid plugin option "${key}". Expected a non-negative number.`)
   }
   return value
 }
@@ -72,6 +81,7 @@ function normalizeRuntimeOptions(options: Record<string, unknown>): BackfillPlug
         options.defaults.maxRetriesPerChunk,
         'defaults.maxRetriesPerChunk'
       ),
+      retryDelayMs: parseNonNegativeNumber(options.defaults.retryDelayMs, 'defaults.retryDelayMs'),
       requireIdempotencyToken: parseBoolean(
         options.defaults.requireIdempotencyToken,
         'defaults.requireIdempotencyToken'

--- a/packages/plugin-backfill/src/state.ts
+++ b/packages/plugin-backfill/src/state.ts
@@ -44,6 +44,9 @@ export function computeCompatibilityToken(input: {
   plan: BackfillPlanState
   options: NormalizedBackfillPluginOptions
 }): string {
+  // Exclude retryDelayMs — it's a runtime behavior setting that doesn't
+  // affect data integrity and shouldn't break compatibility on upgrade.
+  const { retryDelayMs: _, ...compatDefaults } = input.options.defaults
   return hashId(
     stableSerialize({
       planId: input.plan.planId,
@@ -51,7 +54,7 @@ export function computeCompatibilityToken(input: {
       from: input.plan.from,
       to: input.plan.to,
       planOptions: input.plan.options,
-      runtimeDefaults: input.options.defaults,
+      runtimeDefaults: compatDefaults,
       runtimePolicy: input.options.policy,
       runtimeLimits: input.options.limits,
     })

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -4,6 +4,7 @@ export interface BackfillPluginDefaults {
   chunkHours?: number
   maxParallelChunks?: number
   maxRetriesPerChunk?: number
+  retryDelayMs?: number
   requireIdempotencyToken?: boolean
   timeColumn?: string
 }
@@ -31,6 +32,7 @@ export interface NormalizedBackfillDefaults {
   chunkHours: number
   maxParallelChunks: number
   maxRetriesPerChunk: number
+  retryDelayMs: number
   requireIdempotencyToken: boolean
   timeColumn?: string
 }


### PR DESCRIPTION
## Summary
- Add exponential backoff between retries (configurable via `defaults.retryDelayMs`, default 1000ms) to recover from transient ClickHouse Cloud merge conflicts
- Continue processing remaining chunks after one fails permanently instead of stopping the entire backfill run
- Make `resume` automatically retry failed chunks without requiring `--replay-failed` flag
- Refactor executeChunk to eliminate duplicated simulation/real execution branches
- Update backfill plugin documentation with new option and simplified recovery workflow

## Test plan
- [x] All 52 existing tests pass (11 runtime tests, 52 total backfill plugin tests)
- [x] TypeCheck passes with no errors
- [x] Verification successful (turbo typecheck lint test build)
- [x] New tests added for continue-past-failure behavior and resume-without-replay-failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)