### PR TITLE
feat(plugin-backfill): bind backfill plans to ClickHouse environment

### DIFF
--- a/.changeset/backfill-env-binding.md
+++ b/.changeset/backfill-env-binding.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Bind backfill plans to ClickHouse environment. Plans now include an environment fingerprint (URL origin + database) when created with a ClickHouse config, preventing accidental cross-environment execution. Running or resuming a plan against a mismatched environment is blocked by default; use `--force-environment` to override. Plans created offline (without ClickHouse config) work against any environment for backward compatibility.

--- a/packages/plugin-backfill/src/args.ts
+++ b/packages/plugin-backfill/src/args.ts
@@ -26,6 +26,7 @@ export const RUN_FLAGS = defineFlags([
   { name: '--replay-failed', type: 'boolean', description: 'Re-execute failed chunks' },
   { name: '--force-overlap', type: 'boolean', description: 'Allow overlapping runs' },
   { name: '--force-compatibility', type: 'boolean', description: 'Skip compatibility checks' },
+  { name: '--force-environment', type: 'boolean', description: 'Skip environment mismatch checks' },
   { name: '--simulate-fail-chunk', type: 'string', description: 'Simulate failure on chunk', placeholder: '<chunk-id>' },
   { name: '--simulate-fail-count', type: 'string', description: 'Number of simulated failures', placeholder: '<count>' },
 ] as const)
@@ -36,6 +37,7 @@ export const RESUME_FLAGS = defineFlags([
   { name: '--replay-failed', type: 'boolean', description: 'Re-execute failed chunks' },
   { name: '--force-overlap', type: 'boolean', description: 'Allow overlapping runs' },
   { name: '--force-compatibility', type: 'boolean', description: 'Skip compatibility checks' },
+  { name: '--force-environment', type: 'boolean', description: 'Skip environment mismatch checks' },
 ] as const)
 
 export const PLAN_ID_FLAGS = defineFlags([
@@ -113,6 +115,7 @@ export function parseRunArgs(flags: ParsedFlags): ParsedRunArgs {
   const replayFailed = f['--replay-failed'] === true
   const forceOverlap = f['--force-overlap'] === true
   const forceCompatibility = f['--force-compatibility'] === true
+  const forceEnvironment = f['--force-environment'] === true
   const simulateFailChunk = f['--simulate-fail-chunk']
 
   let simulateFailCount = 1
@@ -133,6 +136,7 @@ export function parseRunArgs(flags: ParsedFlags): ParsedRunArgs {
     replayFailed,
     forceOverlap,
     forceCompatibility,
+    forceEnvironment,
     simulateFailChunk,
     simulateFailCount,
   }
@@ -146,6 +150,7 @@ export function parseResumeArgs(flags: ParsedFlags): ParsedResumeArgs {
     replayFailed: parsed.replayFailed,
     forceOverlap: parsed.forceOverlap,
     forceCompatibility: parsed.forceCompatibility,
+    forceEnvironment: parsed.forceEnvironment,
   }
 }
 

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -185,6 +185,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
               chunkHours: parsed.chunkHours,
               forceLargeWindow: parsed.forceLargeWindow,
               force: parsed.force,
+              clickhouse: context.config.clickhouse,
             })
 
             const payload = planPayload(output)
@@ -225,12 +226,14 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                   replayFailed: parsed.replayFailed,
                   forceOverlap: parsed.forceOverlap,
                   forceCompatibility: parsed.forceCompatibility,
+                  forceEnvironment: parsed.forceEnvironment,
                   simulation: {
                     failChunkId: parsed.simulateFailChunk,
                     failCount: parsed.simulateFailCount,
                   },
                 },
                 execute: db ? (sql) => db.execute(sql) : undefined,
+                clickhouse: context.config.clickhouse,
               })
 
               const payload = {
@@ -291,8 +294,10 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                   replayFailed: parsed.replayFailed,
                   forceOverlap: parsed.forceOverlap,
                   forceCompatibility: parsed.forceCompatibility,
+                  forceEnvironment: parsed.forceEnvironment,
                 },
                 execute: db ? (sql) => db.execute(sql) : undefined,
+                clickhouse: context.config.clickhouse,
               })
 
               const payload = {

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -42,6 +42,12 @@ export interface NormalizedBackfillPluginOptions {
   limits: Required<BackfillPluginLimits>
 }
 
+export interface BackfillEnvironment {
+  fingerprint: string
+  url: string
+  database: string
+}
+
 export type BackfillPlanStatus = 'planned' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled'
 
 export interface BackfillChunk {
@@ -61,6 +67,7 @@ export interface BackfillPlanState {
   createdAt: string
   status: BackfillPlanStatus
   strategy?: 'table' | 'mv_replay'
+  environment?: BackfillEnvironment
   from: string
   to: string
   chunks: BackfillChunk[]
@@ -180,6 +187,7 @@ export interface BackfillExecutionOptions {
   replayFailed?: boolean
   forceOverlap?: boolean
   forceCompatibility?: boolean
+  forceEnvironment?: boolean
   simulation?: {
     failChunkId?: string
     failCount?: number
@@ -269,6 +277,7 @@ export interface ParsedRunArgs {
   replayFailed: boolean
   forceOverlap: boolean
   forceCompatibility: boolean
+  forceEnvironment: boolean
   simulateFailChunk?: string
   simulateFailCount: number
 }
@@ -279,6 +288,7 @@ export interface ParsedResumeArgs {
   replayFailed: boolean
   forceOverlap: boolean
   forceCompatibility: boolean
+  forceEnvironment: boolean
 }
 
 export interface ParsedStatusArgs {


### PR DESCRIPTION
## Summary

Add environment binding to backfill plans to prevent accidental cross-environment execution. Plans now include a 16-char fingerprint (hash of ClickHouse URL origin + database) when created with a `clickhouse` config. Different environments produce different plan IDs and separate plan files. Running or resuming against a mismatched environment is blocked by default with `--force-environment` escape hatch. Plans created offline (without config) work against any environment for backward compatibility.

## Changes

- **Type system**: Add `BackfillEnvironment` interface (fingerprint, url, database) to `BackfillPlanState`
- **State functions**: Add `computeEnvironmentFingerprint()` (hashes URL origin + database), `ensureEnvironmentMatch()` (validates at runtime), modify `planIdentity()` to include optional fingerprint
- **Planner**: Accept optional `clickhouse` param, compute fingerprint, include in plan ID and persisted plan state
- **Runtime**: Accept `clickhouse` param in `executeBackfillRun()` and `resumeBackfillRun()`, call `ensureEnvironmentMatch()` after reading plan
- **CLI flags**: Add `--force-environment` boolean flag to `run` and `resume` commands
- **Integration**: Wire ClickHouse config through plugin.ts commands
- **Documentation**: Add environment binding section explaining fingerprint, matching, override behavior; document `--force-environment` flag
- **Tests**: 9 new tests covering fingerprint computation, plan inclusion, different environments → different IDs, execution rejection/override, backward compat

## Test plan

- [x] All existing tests pass (62 tests in plugin-backfill)
- [x] All new tests pass (4 fingerprint tests + 4 binding tests + 1 resume test)
- [x] Full `bun verify` passes (typecheck, lint, test, build)
- [x] Backward compat: plans without environment work against any environment
- [x] Forward compat: plans with environment can run with `--force-environment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)