### PR TITLE
fix: handle UNKNOWN_DATABASE when target database doesn't exist yet

### DIFF
--- a/.changeset/handle-unknown-database.md
+++ b/.changeset/handle-unknown-database.md
@@ -1,0 +1,6 @@
+---
+"chkit": patch
+"@chkit/clickhouse": patch
+---
+
+Gracefully handle ClickHouse error 81 (UNKNOWN_DATABASE) when the configured database does not exist yet. Commands `status`, `drift`, `check`, and `migrate` no longer crash with a raw stack trace; instead they show a warning and continue with normal output.

--- a/packages/cli/src/bin/commands/check.ts
+++ b/packages/cli/src/bin/commands/check.ts
@@ -32,11 +32,13 @@ async function cmdCheck(ctx: CommandRunContext): Promise<void> {
     throw new Error('clickhouse config is required for check (journal is stored in ClickHouse)')
   }
 
+  const database = config.clickhouse.database
   await withClickHouseExecutor(config.clickhouse, async (db) => {
     const journalStore = createJournalStore(db)
 
     const files = await listMigrations(migrationsDir)
     const journal = await journalStore.readJournal()
+    const databaseMissing = journalStore.databaseMissing
     const appliedNames = new Set(journal.applied.map((entry) => entry.name))
     const pending = files.filter((f) => !appliedNames.has(f))
     const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
@@ -133,12 +135,18 @@ async function cmdCheck(ctx: CommandRunContext): Promise<void> {
         ])
       ),
       scope: tableScope,
+      ...(databaseMissing ? { databaseMissing: true, database } : {}),
     }
 
     if (jsonMode) {
       emitJson('check', payload)
       if (!ok) process.exitCode = 1
       return
+    }
+
+    if (databaseMissing) {
+      console.log(`\u26A0 Database "${database}" does not exist on the target server.`)
+      console.log('  It will be created when you run: chkit migrate --apply\n')
     }
 
     console.log(`Check status: ${ok ? 'ok' : 'failed'}`)

--- a/packages/cli/src/bin/commands/drift.ts
+++ b/packages/cli/src/bin/commands/drift.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 
+import { isUnknownDatabaseError, type SchemaObjectRef } from '@chkit/clickhouse'
 import type { ChxConfig, Snapshot, TableDefinition } from '@chkit/core'
 
 import { typedFlags, type CommandDef, type CommandRunContext } from '../../plugins.js'
@@ -21,6 +22,8 @@ export interface DriftPayload {
   expectedCount: number
   actualCount: number
   drifted: boolean
+  databaseMissing?: boolean
+  database?: string
   missing: string[]
   extra: string[]
   kindMismatches: Array<{ expected: string; actual: string; object: string }>
@@ -45,7 +48,35 @@ export async function buildDriftPayload(
     scope?.enabled && scope.matchCount > 0 ? new Set(scope.matchedTables) : undefined
   if (!config.clickhouse) throw new Error('clickhouse config is required for drift checks')
   return withClickHouseExecutor(config.clickhouse, async (db) => {
-    const actualObjects = await db.listSchemaObjects()
+    let actualObjects: SchemaObjectRef[]
+    try {
+      actualObjects = await db.listSchemaObjects()
+    } catch (error) {
+      if (isUnknownDatabaseError(error)) {
+        const allExpected = snapshot.definitions
+          .filter((def) => {
+            if (!selectedTables) return true
+            if (def.kind !== 'table') return true
+            return selectedTables.has(`${def.database}.${def.name}`)
+          })
+          .map((def) => `${def.database}.${def.name}`)
+        return {
+          scope,
+          snapshotFile: join(metaDir, 'snapshot.json'),
+          expectedCount: allExpected.length,
+          actualCount: 0,
+          drifted: allExpected.length > 0,
+          databaseMissing: true,
+          database: config.clickhouse?.database,
+          missing: allExpected,
+          extra: [],
+          kindMismatches: [],
+          objectDrift: [],
+          tableDrift: [],
+        }
+      }
+      throw error
+    }
     const expectedObjects = snapshot.definitions
       .filter((def) => {
         if (!selectedTables) return true
@@ -143,6 +174,11 @@ async function cmdDrift(ctx: CommandRunContext): Promise<void> {
   if (jsonMode) {
     emitJson('drift', payload)
     return
+  }
+
+  if (payload.databaseMissing) {
+    console.log(`\u26A0 Database "${payload.database ?? ''}" does not exist on the target server.`)
+    console.log('  It will be created when you run: chkit migrate --apply\n')
   }
 
   console.log(`Expected objects: ${payload.expectedCount}`)

--- a/packages/cli/src/bin/commands/status.ts
+++ b/packages/cli/src/bin/commands/status.ts
@@ -22,6 +22,7 @@ async function cmdStatus(ctx: CommandRunContext): Promise<void> {
     throw new Error('clickhouse config is required for status (journal is stored in ClickHouse)')
   }
 
+  const database = config.clickhouse.database
   await withClickHouseExecutor(config.clickhouse, async (db) => {
     const journalStore = createJournalStore(db)
 
@@ -32,6 +33,7 @@ async function cmdStatus(ctx: CommandRunContext): Promise<void> {
     const pending = files.filter((f) => !appliedNames.has(f))
     const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
 
+    const databaseMissing = journalStore.databaseMissing
     const payload = {
       migrationsDir,
       total: files.length,
@@ -40,11 +42,17 @@ async function cmdStatus(ctx: CommandRunContext): Promise<void> {
       pendingMigrations: pending,
       checksumMismatchCount: checksumMismatches.length,
       checksumMismatches,
+      ...(databaseMissing ? { databaseMissing: true, database } : {}),
     }
 
     if (jsonMode) {
       emitJson('status', payload)
       return
+    }
+
+    if (databaseMissing) {
+      console.log(`\u26A0 Database "${database}" does not exist on the target server.`)
+      console.log('  It will be created when you run: chkit migrate --apply\n')
     }
 
     console.log(`Migrations directory: ${migrationsDir}`)

--- a/packages/cli/src/bin/journal-store.ts
+++ b/packages/cli/src/bin/journal-store.ts
@@ -1,4 +1,4 @@
-import { createClickHouseExecutor, type ClickHouseExecutor } from '@chkit/clickhouse'
+import { createClickHouseExecutor, isUnknownDatabaseError, type ClickHouseExecutor } from '@chkit/clickhouse'
 import type { ChxConfig } from '@chkit/core'
 
 import type { MigrationJournal, MigrationJournalEntry } from './migration-store.js'
@@ -7,6 +7,7 @@ import { CLI_VERSION } from './version.js'
 export interface JournalStore {
   readJournal(): Promise<MigrationJournal>
   appendEntry(entry: MigrationJournalEntry): Promise<void>
+  readonly databaseMissing: boolean
 }
 
 const DEFAULT_JOURNAL_TABLE = '_chkit_migrations'
@@ -46,6 +47,7 @@ export function createJournalStore(db: ClickHouseExecutor): JournalStore {
 ORDER BY (name)
 SETTINGS index_granularity = 1`
   let bootstrapped = false
+  let _databaseMissing = false
 
   async function ensureTable(): Promise<void> {
     if (bootstrapped) return
@@ -58,10 +60,24 @@ SETTINGS index_granularity = 1`
       await db.query(`SELECT name FROM ${journalTable} LIMIT 0`)
       bootstrapped = true
       return
-    } catch {
+    } catch (error) {
+      if (isUnknownDatabaseError(error)) {
+        _databaseMissing = true
+        bootstrapped = true
+        return
+      }
       // Table does not exist yet – create it below.
     }
-    await db.execute(createTableSql)
+    try {
+      await db.execute(createTableSql)
+    } catch (error) {
+      if (isUnknownDatabaseError(error)) {
+        _databaseMissing = true
+        bootstrapped = true
+        return
+      }
+      throw error
+    }
     // On ClickHouse Cloud, DDL propagation across nodes may lag behind the
     // CREATE TABLE acknowledgment. Wait until the table is queryable.
     for (let attempt = 0; attempt < 10; attempt++) {
@@ -76,8 +92,14 @@ SETTINGS index_granularity = 1`
   }
 
   return {
+    get databaseMissing() {
+      return _databaseMissing
+    },
     async readJournal(): Promise<MigrationJournal> {
       await ensureTable()
+      if (_databaseMissing) {
+        return { version: 1, applied: [] }
+      }
       try {
         await db.execute(`SYSTEM SYNC REPLICA ${journalTable}`)
       } catch {
@@ -97,6 +119,11 @@ SETTINGS index_granularity = 1`
     },
 
     async appendEntry(entry: MigrationJournalEntry): Promise<void> {
+      if (_databaseMissing) {
+        // A migration may have created the database — reset and retry.
+        _databaseMissing = false
+        bootstrapped = false
+      }
       await ensureTable()
       const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
       const insertSql = `INSERT INTO ${journalTable} (name, applied_at, checksum, chkit_version) VALUES ('${esc(entry.name)}', '${esc(entry.appliedAt)}', '${esc(entry.checksum)}', '${esc(CLI_VERSION)}')`

--- a/packages/cli/src/clickhouse-live.e2e.test.ts
+++ b/packages/cli/src/clickhouse-live.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   quoteIdent,
   runCli,
   runCliWithRetry,
+  waitForCliJson,
   waitForTable,
   waitForView,
 } from './e2e-testkit.js'
@@ -207,13 +208,16 @@ describe('@chkit/cli doppler env e2e', () => {
         }
         expect(secondExecute.exitCode).toBe(0)
 
-        const statusResult = runCli(fixture.dir, ['status', '--config', fixture.configPath, '--json'], cliEnv)
-        expect(statusResult.exitCode).toBe(0)
-        const statusPayload = JSON.parse(statusResult.stdout) as {
+        const { payload: statusPayload } = await waitForCliJson<{
           total: number
           applied: number
           pending: number
-        }
+        }>(
+          fixture.dir,
+          ['status', '--config', fixture.configPath, '--json'],
+          (p) => p.applied === 2,
+          { extraEnv: cliEnv }
+        )
         expect(statusPayload.total).toBe(2)
         expect(statusPayload.applied).toBe(2)
         expect(statusPayload.pending).toBe(0)

--- a/packages/cli/src/e2e-testkit.ts
+++ b/packages/cli/src/e2e-testkit.ts
@@ -84,6 +84,41 @@ export async function runCliWithRetry(
 }
 
 // ---------------------------------------------------------------------------
+// Polling helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Polls a CLI command until a predicate on the parsed JSON output passes.
+ * Useful for waiting on ClickHouse Cloud replication lag after writes.
+ */
+export async function waitForCliJson<T>(
+  cwd: string,
+  args: string[],
+  predicate: (payload: T) => boolean,
+  {
+    maxAttempts = 10,
+    delayMs = 1000,
+    extraEnv = {},
+  }: { maxAttempts?: number; delayMs?: number; extraEnv?: Record<string, string> } = {}
+): Promise<{ result: CliResult; payload: T }> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = runCli(cwd, args, extraEnv)
+    if (result.exitCode === 0 && isValidJson(result.stdout)) {
+      const payload = JSON.parse(result.stdout) as T
+      if (predicate(payload)) return { result, payload }
+    }
+    if (attempt === maxAttempts) {
+      throw new Error(
+        `waitForCliJson: predicate not satisfied after ${maxAttempts} attempts.\n` +
+          formatTestDiagnostic('last attempt', result)
+      )
+    }
+    await new Promise((r) => setTimeout(r, delayMs))
+  }
+  throw new Error('waitForCliJson: unreachable')
+}
+
+// ---------------------------------------------------------------------------
 // Diagnostics
 // ---------------------------------------------------------------------------
 

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -159,6 +159,12 @@ function wrapConnectionError(error: unknown, url: string): never {
   throw error
 }
 
+export function isUnknownDatabaseError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (!('code' in error)) return false
+  return String(error.code) === '81'
+}
+
 export {
   waitForDDLPropagation,
   waitForTable,
@@ -185,6 +191,22 @@ export function createClickHouseExecutor(config: NonNullable<ChxConfig['clickhou
       try {
         await client.command({ query: sql, http_headers: { 'X-DDL': '1' } })
       } catch (error) {
+        if (isUnknownDatabaseError(error)) {
+          // The configured database doesn't exist yet. Retry without the
+          // session database so that CREATE DATABASE can succeed.
+          const fallback = createClient({
+            url: config.url,
+            username: config.username,
+            password: config.password,
+            clickhouse_settings: { wait_end_of_query: 1, async_insert: 0 },
+          })
+          try {
+            await fallback.command({ query: sql, http_headers: { 'X-DDL': '1' } })
+          } finally {
+            await fallback.close()
+          }
+          return
+        }
         wrapConnectionError(error, config.url)
       }
     },


### PR DESCRIPTION
## Summary
- Catch ClickHouse error code 81 (`UNKNOWN_DATABASE`) in `status`, `drift`, `check`, and `migrate` commands instead of crashing with a raw stack trace
- Show a clear warning (`⚠ Database "X" does not exist on the target server`) and continue with normal output
- Retry `execute()` without the session database parameter so `CREATE DATABASE IF NOT EXISTS` succeeds during `migrate --apply`
- Reset journal store cached state after migration creates the database, so the migrations table can be bootstrapped

## Test plan
- [x] `bun verify` passes (typecheck, lint, test, build)
- [ ] Run `chkit status` / `chkit drift` / `chkit check` against a non-existent database — should warn and exit 0
- [ ] Run `chkit migrate --apply` with first migration containing `CREATE DATABASE IF NOT EXISTS` — should succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)