### PR TITLE
refactor(clickhouse): rename execute to command

### DIFF
--- a/packages/cli/src/bin/commands/migrate.ts
+++ b/packages/cli/src/bin/commands/migrate.ts
@@ -290,7 +290,7 @@ async function cmdMigrate(ctx: CommandRunContext): Promise<void> {
       })
       for (let i = 0; i < statements.length; i++) {
         const statement = statements[i] as string
-        await db.execute(statement)
+        await db.command(statement)
         const operation = operationSummaries[i]
         if (operation) {
           await waitForDDLPropagation(db, operation.type, operation.key)

--- a/packages/cli/src/bin/journal-store.ts
+++ b/packages/cli/src/bin/journal-store.ts
@@ -69,7 +69,7 @@ SETTINGS index_granularity = 1`
       // Table does not exist yet – create it below.
     }
     try {
-      await db.execute(createTableSql)
+      await db.command(createTableSql)
     } catch (error) {
       if (isUnknownDatabaseError(error)) {
         _databaseMissing = true
@@ -101,7 +101,7 @@ SETTINGS index_granularity = 1`
         return { version: 1, applied: [] }
       }
       try {
-        await db.execute(`SYSTEM SYNC REPLICA ${journalTable}`)
+        await db.command(`SYSTEM SYNC REPLICA ${journalTable}`)
       } catch {
         // Non-replicated or single-node setups don't support SYSTEM SYNC REPLICA.
       }
@@ -130,7 +130,7 @@ SETTINGS index_granularity = 1`
       const maxAttempts = 5
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         try {
-          await db.execute(insertSql)
+          await db.command(insertSql)
           break
         } catch (error) {
           if (!isRetryableInsertRace(error) || attempt === maxAttempts) {
@@ -140,7 +140,7 @@ SETTINGS index_granularity = 1`
         }
       }
       try {
-        await db.execute(`SYSTEM SYNC REPLICA ${journalTable}`)
+        await db.command(`SYSTEM SYNC REPLICA ${journalTable}`)
       } catch {
         // Non-replicated or single-node setups don't support SYSTEM SYNC REPLICA.
       }

--- a/packages/cli/src/clickhouse-live.e2e.test.ts
+++ b/packages/cli/src/clickhouse-live.e2e.test.ts
@@ -132,9 +132,9 @@ describe('@chkit/cli doppler env e2e', () => {
         expect(generatedSql.length).toBeGreaterThan(0)
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersView)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersView)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },
@@ -223,9 +223,9 @@ describe('@chkit/cli doppler env e2e', () => {
         expect(statusPayload.pending).toBe(0)
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersView)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersView)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },
@@ -326,10 +326,10 @@ export default schema(events, eventCounts, eventCountsMv)
         await waitForView(executor, database, eventCountsMv)
       } finally {
         await rm(dir, { recursive: true, force: true })
-        await executor.execute(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(eventCountsMv)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(eventCountsTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(eventsTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(eventCountsMv)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(eventCountsTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(eventsTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },
@@ -427,9 +427,9 @@ export default schema(events, eventCounts, eventCountsMv)
         expect(checkPayload.drifted).toBe(false)
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersView)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersView)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },

--- a/packages/cli/src/drift.e2e.test.ts
+++ b/packages/cli/src/drift.e2e.test.ts
@@ -88,14 +88,14 @@ describe('@chkit/cli drift depth env e2e', () => {
         // Wait for the table to be visible before altering it
         await waitForTable(executor, database, usersTable)
 
-        await executor.execute(
+        await executor.command(
           `ALTER TABLE ${quoteIdent(database)}.${quoteIdent(usersTable)} ADD COLUMN rogue String`
         )
 
         // Wait for the column to propagate (ClickHouse Cloud DDL is eventually consistent)
         await waitForColumn(executor, database, usersTable, 'rogue')
 
-        await executor.execute(
+        await executor.command(
           `CREATE VIEW ${quoteIdent(database)}.${quoteIdent(manualView)} AS SELECT 1 AS one`
         )
 
@@ -129,9 +129,9 @@ describe('@chkit/cli drift depth env e2e', () => {
         expect(checkPayload.driftReasonTotals.table > 0).toBe(true)
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(manualView)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP VIEW IF EXISTS ${quoteIdent(database)}.${quoteIdent(manualView)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },
@@ -195,8 +195,8 @@ describe('@chkit/cli drift depth env e2e', () => {
         expect((checkPayload.driftReasonCounts.projection_mismatch ?? 0) > 0).toBe(true)
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },
@@ -232,7 +232,7 @@ describe('@chkit/cli drift depth env e2e', () => {
 
         await waitForTable(executor, database, usersTable)
 
-        await executor.execute(
+        await executor.command(
           `ALTER TABLE ${quoteIdent(database)}.${quoteIdent(usersTable)} ADD COLUMN rogue String`
         )
 
@@ -258,8 +258,8 @@ describe('@chkit/cli drift depth env e2e', () => {
         expect(checkPayload.failedChecks).not.toContain('schema_drift')
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },
@@ -295,7 +295,7 @@ describe('@chkit/cli drift depth env e2e', () => {
 
         await waitForTable(executor, database, usersTable)
 
-        await executor.execute(
+        await executor.command(
           `ALTER TABLE ${quoteIdent(database)}.${quoteIdent(usersTable)} ADD COLUMN rogue String`
         )
 
@@ -327,8 +327,8 @@ describe('@chkit/cli drift depth env e2e', () => {
         expect(checkPayload.failedChecks).toContain('schema_drift')
       } finally {
         await rm(fixture.dir, { recursive: true, force: true })
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
-        await executor.execute(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(usersTable)}`)
+        await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
         await executor.close()
       }
     },

--- a/packages/clickhouse/src/index.test.ts
+++ b/packages/clickhouse/src/index.test.ts
@@ -14,13 +14,13 @@ import {
 } from './index'
 
 describe('@chkit/clickhouse smoke', () => {
-  test('creates executor with execute/query methods', () => {
+  test('creates executor with command/query methods', () => {
     const executor = createClickHouseExecutor({
       url: 'http://localhost:8123',
       database: 'default',
     })
 
-    expect(typeof executor.execute).toBe('function')
+    expect(typeof executor.command).toBe('function')
     expect(typeof executor.query).toBe('function')
     expect(typeof executor.listSchemaObjects).toBe('function')
   })

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from './create-table-parser.js'
 
 export interface ClickHouseExecutor {
-  execute(sql: string): Promise<void>
+  command(sql: string): Promise<void>
   query<T>(sql: string): Promise<T[]>
   insert<T extends Record<string, unknown>>(params: { table: string; values: T[] }): Promise<void>
   listSchemaObjects(): Promise<SchemaObjectRef[]>
@@ -186,7 +186,7 @@ export function createClickHouseExecutor(config: NonNullable<ChxConfig['clickhou
   })
 
   return {
-    async execute(sql: string): Promise<void> {
+    async command(sql: string): Promise<void> {
       try {
         await client.command({ query: sql, http_headers: { 'X-DDL': '1' } })
       } catch (error) {

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -234,7 +234,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                     failCount: parsed.simulateFailCount,
                   },
                 },
-                execute: db ? async (sql) => { await db.execute(sql); return undefined } : undefined,
+                execute: db ? async (sql) => { await db.command(sql); return undefined } : undefined,
                 clickhouse: context.config.clickhouse,
               })
 
@@ -298,7 +298,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                   forceCompatibility: parsed.forceCompatibility,
                   forceEnvironment: parsed.forceEnvironment,
                 },
-                execute: db ? async (sql) => { await db.execute(sql); return undefined } : undefined,
+                execute: db ? async (sql) => { await db.command(sql); return undefined } : undefined,
                 clickhouse: context.config.clickhouse,
               })
 

--- a/packages/plugin-codegen/src/generators/migration-artifacts.ts
+++ b/packages/plugin-codegen/src/generators/migration-artifacts.ts
@@ -52,7 +52,7 @@ export async function generateMigrationArtifacts(
     '}',
     '',
     'export interface MigrationExecutor {',
-    '  execute(sql: string): Promise<void>',
+    '  command(sql: string): Promise<void>',
     '  query<T>(sql: string): Promise<T[]>',
     '}',
     '',
@@ -82,7 +82,7 @@ export async function runMigrations(
   const journalTable = options?.journalTable ?? '_chkit_migrations'
 
   // Ensure journal table exists
-  await executor.execute(\`
+  await executor.command(\`
     CREATE TABLE IF NOT EXISTS \${journalTable} (
       name String,
       applied_at DateTime64(3, 'UTC') DEFAULT now64(3),
@@ -107,11 +107,11 @@ export async function runMigrations(
 
     const statements = extractExecutableStatements(migration.sql)
     for (const statement of statements) {
-      await executor.execute(statement)
+      await executor.command(statement)
     }
 
     // Record in journal
-    await executor.execute(
+    await executor.command(
       \`INSERT INTO \${journalTable} (name, applied_at, checksum) VALUES ('\${migration.name}', now64(3), '')\`
     )
     result.applied.push(migration.name)

--- a/packages/plugin-pull/src/pull.e2e.test.ts
+++ b/packages/plugin-pull/src/pull.e2e.test.ts
@@ -53,19 +53,19 @@ describe('@chkit/plugin-pull live env e2e', () => {
       database: 'default',
     })
 
-    await executor.execute(`CREATE DATABASE IF NOT EXISTS ${quoteIdent(targetDatabase)}`)
-    await executor.execute(`CREATE DATABASE IF NOT EXISTS ${quoteIdent(noiseDatabase)}`)
+    await executor.command(`CREATE DATABASE IF NOT EXISTS ${quoteIdent(targetDatabase)}`)
+    await executor.command(`CREATE DATABASE IF NOT EXISTS ${quoteIdent(noiseDatabase)}`)
   })
 
   afterAll(async () => {
     try {
-      await executor.execute(`DROP DATABASE IF EXISTS ${quoteIdent(targetDatabase)}`)
+      await executor.command(`DROP DATABASE IF EXISTS ${quoteIdent(targetDatabase)}`)
     } catch {
       // Best-effort cleanup for shared e2e environment.
     }
 
     try {
-      await executor.execute(`DROP DATABASE IF EXISTS ${quoteIdent(noiseDatabase)}`)
+      await executor.command(`DROP DATABASE IF EXISTS ${quoteIdent(noiseDatabase)}`)
     } catch {
       // Best-effort cleanup for shared e2e environment.
     }
@@ -101,30 +101,30 @@ describe('@chkit/plugin-pull live env e2e', () => {
       }
 
       try {
-        await executor.execute(
+        await executor.command(
           `CREATE TABLE ${quoteIdent(targetDatabase)}.${quoteIdent(eventsTable)} (id UInt64, source String, received_at DateTime64(3) DEFAULT now64(3)) ENGINE = MergeTree() PARTITION BY toYYYYMM(received_at) PRIMARY KEY (id) ORDER BY (id) SETTINGS index_granularity = 8192`
         )
 
         // Wait for table to be visible before creating dependent objects
         await waitForTable(executor, targetDatabase, eventsTable)
 
-        await executor.execute(
+        await executor.command(
           `CREATE TABLE ${quoteIdent(targetDatabase)}.${quoteIdent(accountsTable)} (id UInt64, email Nullable(String), updated_at DateTime DEFAULT now()) ENGINE = MergeTree() PRIMARY KEY (id) ORDER BY (id)`
         )
-        await executor.execute(
+        await executor.command(
           `CREATE VIEW ${quoteIdent(targetDatabase)}.${quoteIdent(eventsView)} AS SELECT id, source FROM ${quoteIdent(targetDatabase)}.${quoteIdent(eventsTable)}`
         )
-        await executor.execute(
+        await executor.command(
           `CREATE TABLE ${quoteIdent(targetDatabase)}.${quoteIdent(eventsRollupTable)} (id UInt64, c UInt64) ENGINE = MergeTree() ORDER BY (id)`
         )
 
         // Wait for rollup table before creating MV that depends on it
         await waitForTable(executor, targetDatabase, eventsRollupTable)
 
-        await executor.execute(
+        await executor.command(
           `CREATE MATERIALIZED VIEW ${quoteIdent(targetDatabase)}.${quoteIdent(eventsMaterializedView)} TO ${quoteIdent(targetDatabase)}.${quoteIdent(eventsRollupTable)} AS SELECT id, count() AS c FROM ${quoteIdent(targetDatabase)}.${quoteIdent(eventsTable)} GROUP BY id`
         )
-        await executor.execute(
+        await executor.command(
           `CREATE TABLE ${quoteIdent(noiseDatabase)}.${quoteIdent(noiseTable)} (id UInt64) ENGINE = MergeTree() ORDER BY (id)`
         )
 


### PR DESCRIPTION
## Summary
- Renames the `execute` method to `command` on the `ClickHouseExecutor` interface and its implementation in `@chkit/clickhouse`
- Updates all call sites across CLI commands, journal store, plugins, codegen templates, and E2E tests
- Purely mechanical rename with no logic changes

## Test plan
- [x] `bun verify` passes (typecheck, lint, test, build — 33/33 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)