### PR TITLE
fix(core): make @chkit/core workerd-compatible

### DIFF
--- a/.changeset/core-workerd-compat.md
+++ b/.changeset/core-workerd-compat.md
@@ -1,0 +1,8 @@
+---
+"@chkit/core": patch
+"@chkit/plugin-codegen": patch
+"@chkit/plugin-backfill": patch
+"chkit": patch
+---
+
+Move `loadSchemaDefinitions` out of the `@chkit/core` barrel export into a dedicated `@chkit/core/schema-loader` subpath. This removes the transitive `fast-glob` -> `node:os` dependency from the main entry point, making `@chkit/core` safe to import in non-Node runtimes like Cloudflare Workers (workerd). The `./utils` subpath is removed since `extractExecutableStatements` is now available directly from `@chkit/core`.

--- a/packages/cli/src/bin/schema-loader.ts
+++ b/packages/cli/src/bin/schema-loader.ts
@@ -1,6 +1,7 @@
 import process from 'node:process'
 
-import { loadSchemaDefinitions as loadSchemaDefinitionsFromCore, type SchemaDefinition } from '@chkit/core'
+import { loadSchemaDefinitions as loadSchemaDefinitionsFromCore } from '@chkit/core/schema-loader'
+import type { SchemaDefinition } from '@chkit/core'
 
 export async function loadSchemaDefinitions(schemaGlobs: string | string[]): Promise<SchemaDefinition[]> {
   return loadSchemaDefinitionsFromCore(schemaGlobs, { cwd: process.cwd() })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,10 +29,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./utils": {
-      "source": "./src/utils.ts",
-      "types": "./dist/utils.d.ts",
-      "default": "./dist/utils.js"
+    "./schema-loader": {
+      "source": "./src/schema-loader.ts",
+      "types": "./dist/schema-loader.d.ts",
+      "default": "./dist/schema-loader.js"
     }
   },
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,6 @@ export {
 } from './canonical.js'
 export { planDiff } from './planner.js'
 export { createSnapshot } from './snapshot.js'
-export { loadSchemaDefinitions, type SchemaLoaderOptions } from './schema-loader.js'
 export { splitTopLevelComma } from './key-clause.js'
 export { normalizeEngine, normalizeSQLFragment } from './sql-normalizer.js'
 export { toCreateSQL } from './sql.js'

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,1 +1,0 @@
-export { splitSqlStatements, extractExecutableStatements } from './sql-splitter.js'

--- a/packages/plugin-backfill/src/detect.ts
+++ b/packages/plugin-backfill/src/detect.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path'
 
-import { loadSchemaDefinitions } from '@chkit/core'
+import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 import type { MaterializedViewDefinition, SchemaDefinition, TableDefinition } from '@chkit/core'
 
 import './table-config.js'

--- a/packages/plugin-backfill/src/planner.ts
+++ b/packages/plugin-backfill/src/planner.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'node:path'
 import { unlink } from 'node:fs/promises'
 
-import { loadSchemaDefinitions } from '@chkit/core'
+import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 import type { ResolvedChxConfig } from '@chkit/core'
 
 import { findMvForTarget } from './detect.js'

--- a/packages/plugin-codegen/src/__tests__/generate-migrations.test.ts
+++ b/packages/plugin-codegen/src/__tests__/generate-migrations.test.ts
@@ -38,7 +38,7 @@ describe('generateMigrationArtifacts', () => {
       expect(result.content).toContain("name: '20260325114021_init',")
       expect(result.content).toContain('CREATE TABLE IF NOT EXISTS app.users')
       expect(result.content).toContain('export const migrations: MigrationEntry[]')
-      expect(result.content).toContain("import { extractExecutableStatements } from '@chkit/core/utils'")
+      expect(result.content).toContain("import { extractExecutableStatements } from '@chkit/core'")
       expect(result.content).toContain('export async function runMigrations(')
       expect(result.content).toContain('_chkit_migrations')
       expect(result.content).toContain('executor: MigrationExecutor')

--- a/packages/plugin-codegen/src/generators/migration-artifacts.ts
+++ b/packages/plugin-codegen/src/generators/migration-artifacts.ts
@@ -44,7 +44,7 @@ export async function generateMigrationArtifacts(
   const content = [
     ...header,
     '',
-    "import { extractExecutableStatements } from '@chkit/core/utils'",
+    "import { extractExecutableStatements } from '@chkit/core'",
     '',
     'export interface MigrationEntry {',
     '  name: string',

--- a/packages/plugin-codegen/src/plugin.ts
+++ b/packages/plugin-codegen/src/plugin.ts
@@ -1,7 +1,8 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
-import { loadSchemaDefinitions, wrapPluginRun } from '@chkit/core'
+import { wrapPluginRun } from '@chkit/core'
+import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 
 import type {
   CodegenPlugin,


### PR DESCRIPTION
## Summary
- Moved `loadSchemaDefinitions` from the `@chkit/core` barrel export into a dedicated `@chkit/core/schema-loader` subpath export, breaking the transitive `fast-glob` → `node:os` dependency that made `@chkit/core` unusable in Cloudflare Workers (workerd)
- Removed the `@chkit/core/utils` subpath (was a workaround for the same issue) since `extractExecutableStatements` is now available directly from `@chkit/core`
- Updated generated migration code to import from `@chkit/core` instead of `@chkit/core/utils`
- Updated internal consumers (CLI, plugin-codegen, plugin-backfill) to import `loadSchemaDefinitions` from the new subpath

## Test plan
- [x] `bun verify` passes (typecheck, lint, test, build)
- [x] Migration codegen test updated and passing
- [ ] Verify workerd-based tests pass in obdb-platform after upgrading

🤖 Generated with [Claude Code](https://claude.com/claude-code)