### PR TITLE
refactor(plugin-backfill): restructure into composable subsystems

### DIFF
--- a/packages/cli/src/plugin.test.ts
+++ b/packages/cli/src/plugin.test.ts
@@ -3,6 +3,8 @@ import { existsSync } from 'node:fs'
 import { readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { createClickHouseExecutor } from '@chkit/clickhouse'
+
 import {
   BACKFILL_PLUGIN_ENTRY,
   CLI_ENTRY,
@@ -12,6 +14,45 @@ import {
   createFixture,
   runCli,
 } from './testkit.test'
+
+function getClickHouseEnv(): {
+  url: string
+  username: string
+  password: string
+  database: string
+} {
+  const host = process.env.CLICKHOUSE_HOST?.trim()
+  const url = process.env.CLICKHOUSE_URL?.trim() || (host ? `https://${host}` : '')
+  const username = process.env.CLICKHOUSE_USER?.trim() || 'default'
+  const password = process.env.CLICKHOUSE_PASSWORD?.trim() || ''
+  const database = process.env.CLICKHOUSE_DB?.trim() || 'default'
+  if (!url) throw new Error('Missing CLICKHOUSE_URL or CLICKHOUSE_HOST')
+  if (!password) throw new Error('Missing CLICKHOUSE_PASSWORD')
+  return { url, username, password, database }
+}
+
+function clickhouseConfigBlock(env: { url: string; username: string; password: string; database: string }): string {
+  return `clickhouse: {\n    url: '${env.url}',\n    username: '${env.username}',\n    password: '${env.password}',\n    database: '${env.database}',\n  },`
+}
+
+async function waitForParts(
+  db: ReturnType<typeof createClickHouseExecutor>,
+  database: string,
+  table: string,
+  expectedPartitions: number,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const rows = await db.query<{ cnt: string }>(
+      `SELECT count(DISTINCT partition) AS cnt FROM system.parts WHERE database = '${database}' AND table = '${table}' AND active`
+    )
+    const count = Number(rows[0]?.cnt ?? 0)
+    if (count >= expectedPartitions) return
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  throw new Error(`Timed out waiting for ${expectedPartitions} partitions in ${database}.${table}`)
+}
 
 describe('plugin runtime', () => {
   test('generate --dryrun --json applies onPlanCreated hook output', async () => {
@@ -153,253 +194,259 @@ describe('plugin runtime', () => {
     }
   })
 
-  test('chkit plugin backfill plan writes deterministic state artifact', async () => {
-    const fixture = await createFixture()
-    const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+  test('chkit plugin backfill plan writes state artifact', async () => {
+    const chEnv = getClickHouseEnv()
+    const chConfig = clickhouseConfigBlock(chEnv)
+    const tableName = `chkit_e2e_bf_plan_${Date.now()}_${Math.floor(Math.random() * 100000)}`
+    const db = createClickHouseExecutor(chEnv)
     try {
-      await writeFile(
-        pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
-        'utf8'
-      )
+      await db.command(`CREATE TABLE ${chEnv.database}.${tableName} (id UInt64, event_time DateTime) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(event_time) ORDER BY (event_time, id)`)
+      await db.command(`INSERT INTO ${chEnv.database}.${tableName} VALUES (1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00')`)
+      await waitForParts(db, chEnv.database, tableName, 2)
 
-      await writeFile(
-        fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
-        'utf8'
-      )
+      const fixture = await createFixture()
+      const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+      try {
+        await writeFile(
+          pluginPath,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          'utf8'
+        )
 
-      const first = runCli([
-        'plugin',
-        'backfill',
-        'plan',
-        '--target',
-        'app.users',
-        '--from',
-        '2026-01-01T00:00:00.000Z',
-        '--to',
-        '2026-01-01T12:00:00.000Z',
-        '--time-column',
-        'event_time',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(first.exitCode).toBe(0)
-      const firstPayload = JSON.parse(first.stdout) as {
-        ok: boolean
-        planId: string
-        chunkCount: number
-        chunkHours: number
-        existed: boolean
-        planPath: string
+        await writeFile(
+          fixture.configPath,
+          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          'utf8'
+        )
+
+        const result = runCli([
+          'plugin',
+          'backfill',
+          'plan',
+          '--target',
+          `${chEnv.database}.${tableName}`,
+          '--from',
+          '2026-01-01T00:00:00.000Z',
+          '--to',
+          '2026-01-03T00:00:00.000Z',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(result.exitCode).toBe(0)
+        const payload = JSON.parse(result.stdout) as {
+          ok: boolean
+          planId: string
+          chunkCount: number
+          planPath: string
+        }
+        expect(payload.ok).toBe(true)
+        expect(payload.planId).toMatch(/^[a-f0-9]{16}$/)
+        expect(payload.chunkCount).toBe(2)
+        expect(existsSync(payload.planPath)).toBe(true)
+      } finally {
+        await rm(fixture.dir, { recursive: true, force: true })
       }
-      expect(firstPayload.ok).toBe(true)
-      expect(firstPayload.chunkCount).toBe(2)
-      expect(firstPayload.chunkHours).toBe(6)
-      expect(firstPayload.existed).toBe(false)
-      expect(existsSync(firstPayload.planPath)).toBe(true)
-
-      const second = runCli([
-        'plugin',
-        'backfill',
-        'plan',
-        '--target',
-        'app.users',
-        '--from',
-        '2026-01-01T00:00:00.000Z',
-        '--to',
-        '2026-01-01T12:00:00.000Z',
-        '--time-column',
-        'event_time',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(second.exitCode).toBe(0)
-      const secondPayload = JSON.parse(second.stdout) as {
-        planId: string
-        existed: boolean
-      }
-      expect(secondPayload.planId).toBe(firstPayload.planId)
-      expect(secondPayload.existed).toBe(true)
     } finally {
-      await rm(fixture.dir, { recursive: true, force: true })
+      await db.command(`DROP TABLE IF EXISTS ${chEnv.database}.${tableName}`)
+      await db.close()
     }
   })
 
   test('chkit plugin backfill run and status complete planned chunks', async () => {
-    const fixture = await createFixture()
-    const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+    const chEnv = getClickHouseEnv()
+    const chConfig = clickhouseConfigBlock(chEnv)
+    const tableName = `chkit_e2e_bf_run_${Date.now()}_${Math.floor(Math.random() * 100000)}`
+    const db = createClickHouseExecutor(chEnv)
     try {
-      await writeFile(
-        pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { chunkHours: 2 } })\n`,
-        'utf8'
-      )
+      await db.command(`CREATE TABLE ${chEnv.database}.${tableName} (id UInt64, event_time DateTime) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(event_time) ORDER BY (event_time, id)`)
+      await db.command(`INSERT INTO ${chEnv.database}.${tableName} VALUES (1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), (3, '2026-01-03 12:00:00')`)
+      await waitForParts(db, chEnv.database, tableName, 3)
 
-      await writeFile(
-        fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
-        'utf8'
-      )
+      const fixture = await createFixture()
+      const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+      try {
+        await writeFile(
+          pluginPath,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          'utf8'
+        )
 
-      const planned = runCli([
-        'plugin',
-        'backfill',
-        'plan',
-        '--target',
-        'app.users',
-        '--from',
-        '2026-01-01T00:00:00.000Z',
-        '--to',
-        '2026-01-01T06:00:00.000Z',
-        '--time-column',
-        'event_time',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(planned.exitCode).toBe(0)
-      const planPayload = JSON.parse(planned.stdout) as { planId: string }
+        await writeFile(
+          fixture.configPath,
+          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          'utf8'
+        )
 
-      const ran = runCli([
-        'plugin',
-        'backfill',
-        'run',
-        '--plan-id',
-        planPayload.planId,
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(ran.exitCode).toBe(0)
-      const runPayload = JSON.parse(ran.stdout) as {
-        status: string
-        chunkCounts: { done: number; total: number; failed: number }
+        const planned = runCli([
+          'plugin',
+          'backfill',
+          'plan',
+          '--target',
+          `${chEnv.database}.${tableName}`,
+          '--from',
+          '2026-01-01T00:00:00.000Z',
+          '--to',
+          '2026-01-04T00:00:00.000Z',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(planned.exitCode).toBe(0)
+        const planPayload = JSON.parse(planned.stdout) as { planId: string }
+
+        const ran = runCli([
+          'plugin',
+          'backfill',
+          'run',
+          '--plan-id',
+          planPayload.planId,
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(ran.exitCode).toBe(0)
+        const runPayload = JSON.parse(ran.stdout) as {
+          status: string
+          chunkCounts: { done: number; total: number; failed: number }
+        }
+        expect(runPayload.status).toBe('completed')
+        expect(runPayload.chunkCounts.done).toBe(3)
+        expect(runPayload.chunkCounts.total).toBe(3)
+        expect(runPayload.chunkCounts.failed).toBe(0)
+
+        const status = runCli([
+          'plugin',
+          'backfill',
+          'status',
+          '--plan-id',
+          planPayload.planId,
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(status.exitCode).toBe(0)
+        const statusPayload = JSON.parse(status.stdout) as {
+          status: string
+          chunkCounts: { done: number; failed: number }
+        }
+        expect(statusPayload.status).toBe('completed')
+        expect(statusPayload.chunkCounts.done).toBe(3)
+        expect(statusPayload.chunkCounts.failed).toBe(0)
+      } finally {
+        await rm(fixture.dir, { recursive: true, force: true })
       }
-      expect(runPayload.status).toBe('completed')
-      expect(runPayload.chunkCounts.done).toBe(3)
-      expect(runPayload.chunkCounts.total).toBe(3)
-      expect(runPayload.chunkCounts.failed).toBe(0)
-
-      const status = runCli([
-        'plugin',
-        'backfill',
-        'status',
-        '--plan-id',
-        planPayload.planId,
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(status.exitCode).toBe(0)
-      const statusPayload = JSON.parse(status.stdout) as {
-        status: string
-        chunkCounts: { done: number; failed: number }
-      }
-      expect(statusPayload.status).toBe('completed')
-      expect(statusPayload.chunkCounts.done).toBe(3)
-      expect(statusPayload.chunkCounts.failed).toBe(0)
     } finally {
-      await rm(fixture.dir, { recursive: true, force: true })
+      await db.command(`DROP TABLE IF EXISTS ${chEnv.database}.${tableName}`)
+      await db.close()
     }
   })
 
   test('chkit plugin backfill fail then resume without replaying done chunks', async () => {
-    const fixture = await createFixture()
-    const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+    const chEnv = getClickHouseEnv()
+    const chConfig = clickhouseConfigBlock(chEnv)
+    const tableName = `chkit_e2e_bf_resume_${Date.now()}_${Math.floor(Math.random() * 100000)}`
+    const db = createClickHouseExecutor(chEnv)
     try {
-      await writeFile(
-        pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { chunkHours: 2, maxRetriesPerChunk: 1 } })\n`,
-        'utf8'
-      )
+      await db.command(`CREATE TABLE ${chEnv.database}.${tableName} (id UInt64, event_time DateTime) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(event_time) ORDER BY (event_time, id)`)
+      await db.command(`INSERT INTO ${chEnv.database}.${tableName} VALUES (1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), (3, '2026-01-03 12:00:00')`)
+      await waitForParts(db, chEnv.database, tableName, 3)
 
-      await writeFile(
-        fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
-        'utf8'
-      )
+      const fixture = await createFixture()
+      const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+      try {
+        await writeFile(
+          pluginPath,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { maxRetriesPerChunk: 1 } })\n`,
+          'utf8'
+        )
 
-      const planned = runCli([
-        'plugin',
-        'backfill',
-        'plan',
-        '--target',
-        'app.users',
-        '--from',
-        '2026-01-01T00:00:00.000Z',
-        '--to',
-        '2026-01-01T06:00:00.000Z',
-        '--time-column',
-        'event_time',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(planned.exitCode).toBe(0)
-      const planPayload = JSON.parse(planned.stdout) as {
-        planId: string
-        planPath: string
-      }
-      const planState = JSON.parse(await readFile(planPayload.planPath, 'utf8')) as {
-        chunks: Array<{ id: string }>
-      }
-      const failChunkId = planState.chunks[1]?.id
-      expect(failChunkId).toBeTruthy()
+        await writeFile(
+          fixture.configPath,
+          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          'utf8'
+        )
 
-      const failedRun = runCli([
-        'plugin',
-        'backfill',
-        'run',
-        '--plan-id',
-        planPayload.planId,
-        '--simulate-fail-chunk',
-        failChunkId as string,
-        '--simulate-fail-count',
-        '1',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(failedRun.exitCode).toBe(1)
-      const failedPayload = JSON.parse(failedRun.stdout) as {
-        status: string
-        chunkCounts: { done: number; failed: number }
-      }
-      expect(failedPayload.status).toBe('failed')
-      expect(failedPayload.chunkCounts.done).toBe(2)
-      expect(failedPayload.chunkCounts.failed).toBe(1)
+        const planned = runCli([
+          'plugin',
+          'backfill',
+          'plan',
+          '--target',
+          `${chEnv.database}.${tableName}`,
+          '--from',
+          '2026-01-01T00:00:00.000Z',
+          '--to',
+          '2026-01-04T00:00:00.000Z',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(planned.exitCode).toBe(0)
+        const planPayload = JSON.parse(planned.stdout) as {
+          planId: string
+          planPath: string
+        }
+        const planState = JSON.parse(await readFile(planPayload.planPath, 'utf8')) as {
+          chunks: Array<{ id: string }>
+        }
+        const failChunkId = planState.chunks[1]?.id
+        expect(failChunkId).toBeTruthy()
 
-      const resumed = runCli([
-        'plugin',
-        'backfill',
-        'resume',
-        '--plan-id',
-        planPayload.planId,
-        '--replay-failed',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(resumed.exitCode).toBe(0)
-      const resumedPayload = JSON.parse(resumed.stdout) as {
-        status: string
-        chunkCounts: { done: number }
-        runPath: string
-      }
-      expect(resumedPayload.status).toBe('completed')
-      expect(resumedPayload.chunkCounts.done).toBe(3)
+        const failedRun = runCli([
+          'plugin',
+          'backfill',
+          'run',
+          '--plan-id',
+          planPayload.planId,
+          '--simulate-fail-chunk',
+          failChunkId as string,
+          '--simulate-fail-count',
+          '1',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(failedRun.exitCode).toBe(1)
+        const failedPayload = JSON.parse(failedRun.stdout) as {
+          status: string
+          chunkCounts: { done: number; failed: number }
+        }
+        expect(failedPayload.status).toBe('failed')
+        expect(failedPayload.chunkCounts.done).toBe(2)
+        expect(failedPayload.chunkCounts.failed).toBe(1)
 
-      const runState = JSON.parse(await readFile(resumedPayload.runPath, 'utf8')) as {
-        chunks: Array<{ id: string; attempts: number }>
+        const resumed = runCli([
+          'plugin',
+          'backfill',
+          'resume',
+          '--plan-id',
+          planPayload.planId,
+          '--replay-failed',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(resumed.exitCode).toBe(0)
+        const resumedPayload = JSON.parse(resumed.stdout) as {
+          status: string
+          chunkCounts: { done: number }
+          runPath: string
+        }
+        expect(resumedPayload.status).toBe('completed')
+        expect(resumedPayload.chunkCounts.done).toBe(3)
+
+        const runState = JSON.parse(await readFile(resumedPayload.runPath, 'utf8')) as {
+          chunks: Array<{ id: string; attempts: number }>
+        }
+        const firstChunkId = planState.chunks[0]?.id
+        const firstChunk = runState.chunks.find((chunk) => chunk.id === firstChunkId)
+        expect(firstChunk?.attempts).toBe(1)
+      } finally {
+        await rm(fixture.dir, { recursive: true, force: true })
       }
-      const firstChunkId = planState.chunks[0]?.id
-      const firstChunk = runState.chunks.find((chunk) => chunk.id === firstChunkId)
-      expect(firstChunk?.attempts).toBe(1)
     } finally {
-      await rm(fixture.dir, { recursive: true, force: true })
+      await db.command(`DROP TABLE IF EXISTS ${chEnv.database}.${tableName}`)
+      await db.close()
     }
   })
 
@@ -452,181 +499,204 @@ describe('plugin runtime', () => {
   })
 
   test('chkit plugin backfill resume enforces compatibility check unless force override is provided', async () => {
-    const fixture = await createFixture()
-    const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+    const chEnv = getClickHouseEnv()
+    const chConfig = clickhouseConfigBlock(chEnv)
+    const tableName = `chkit_e2e_bf_compat_${Date.now()}_${Math.floor(Math.random() * 100000)}`
+    const db = createClickHouseExecutor(chEnv)
     try {
-      await writeFile(
-        pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { chunkHours: 2, maxRetriesPerChunk: 1 } })\n`,
-        'utf8'
-      )
-      await writeFile(
-        fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts', options: { defaults: { chunkHours: 2, maxRetriesPerChunk: 1 } } }],\n}\n`,
-        'utf8'
-      )
+      await db.command(`CREATE TABLE ${chEnv.database}.${tableName} (id UInt64, event_time DateTime) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(event_time) ORDER BY (event_time, id)`)
+      await db.command(`INSERT INTO ${chEnv.database}.${tableName} VALUES (1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), (3, '2026-01-03 12:00:00')`)
+      await waitForParts(db, chEnv.database, tableName, 3)
 
-      const planned = runCli([
-        'plugin',
-        'backfill',
-        'plan',
-        '--target',
-        'app.users',
-        '--from',
-        '2026-01-01T00:00:00.000Z',
-        '--to',
-        '2026-01-01T06:00:00.000Z',
-        '--time-column',
-        'event_time',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      const planPayload = JSON.parse(planned.stdout) as { planId: string; planPath: string }
-      const planState = JSON.parse(await readFile(planPayload.planPath, 'utf8')) as {
-        chunks: Array<{ id: string }>
+      const fixture = await createFixture()
+      const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+      try {
+        await writeFile(
+          pluginPath,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { maxRetriesPerChunk: 1 } })\n`,
+          'utf8'
+        )
+        await writeFile(
+          fixture.configPath,
+          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts', options: { defaults: { maxRetriesPerChunk: 1 } } }],\n}\n`,
+          'utf8'
+        )
+
+        const planned = runCli([
+          'plugin',
+          'backfill',
+          'plan',
+          '--target',
+          `${chEnv.database}.${tableName}`,
+          '--from',
+          '2026-01-01T00:00:00.000Z',
+          '--to',
+          '2026-01-04T00:00:00.000Z',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(planned.exitCode).toBe(0)
+        const planPayload = JSON.parse(planned.stdout) as { planId: string; planPath: string }
+        const planState = JSON.parse(await readFile(planPayload.planPath, 'utf8')) as {
+          chunks: Array<{ id: string }>
+        }
+
+        const failed = runCli([
+          'plugin',
+          'backfill',
+          'run',
+          '--plan-id',
+          planPayload.planId,
+          '--simulate-fail-chunk',
+          planState.chunks[1]?.id as string,
+          '--simulate-fail-count',
+          '1',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(failed.exitCode).toBe(1)
+
+        await writeFile(
+          fixture.configPath,
+          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts', options: { defaults: { maxRetriesPerChunk: 5 } } }],\n}\n`,
+          'utf8'
+        )
+
+        const blockedResume = runCli([
+          'plugin',
+          'backfill',
+          'resume',
+          '--plan-id',
+          planPayload.planId,
+          '--replay-failed',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(blockedResume.exitCode).toBe(2)
+        expect(blockedResume.stdout).toContain('compatibility check failed')
+
+        const forcedResume = runCli([
+          'plugin',
+          'backfill',
+          'resume',
+          '--plan-id',
+          planPayload.planId,
+          '--replay-failed',
+          '--force-compatibility',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(forcedResume.exitCode).toBe(0)
+        const forcedPayload = JSON.parse(forcedResume.stdout) as { status: string }
+        expect(forcedPayload.status).toBe('completed')
+      } finally {
+        await rm(fixture.dir, { recursive: true, force: true })
       }
-
-      const failed = runCli([
-        'plugin',
-        'backfill',
-        'run',
-        '--plan-id',
-        planPayload.planId,
-        '--simulate-fail-chunk',
-        planState.chunks[1]?.id as string,
-        '--simulate-fail-count',
-        '1',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(failed.exitCode).toBe(1)
-
-      await writeFile(
-        fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts', options: { defaults: { chunkHours: 2, maxRetriesPerChunk: 5 } } }],\n}\n`,
-        'utf8'
-      )
-
-      const blockedResume = runCli([
-        'plugin',
-        'backfill',
-        'resume',
-        '--plan-id',
-        planPayload.planId,
-        '--replay-failed',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(blockedResume.exitCode).toBe(2)
-      expect(blockedResume.stdout).toContain('compatibility check failed')
-
-      const forcedResume = runCli([
-        'plugin',
-        'backfill',
-        'resume',
-        '--plan-id',
-        planPayload.planId,
-        '--replay-failed',
-        '--force-compatibility',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(forcedResume.exitCode).toBe(0)
-      const forcedPayload = JSON.parse(forcedResume.stdout) as { status: string }
-      expect(forcedPayload.status).toBe('completed')
     } finally {
-      await rm(fixture.dir, { recursive: true, force: true })
+      await db.command(`DROP TABLE IF EXISTS ${chEnv.database}.${tableName}`)
+      await db.close()
     }
   })
 
   test('chkit plugin backfill cancel and doctor provide operator remediation flow', async () => {
-    const fixture = await createFixture()
-    const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+    const chEnv = getClickHouseEnv()
+    const chConfig = clickhouseConfigBlock(chEnv)
+    const tableName = `chkit_e2e_bf_doctor_${Date.now()}_${Math.floor(Math.random() * 100000)}`
+    const db = createClickHouseExecutor(chEnv)
     try {
-      await writeFile(
-        pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { chunkHours: 2, maxRetriesPerChunk: 1 } })\n`,
-        'utf8'
-      )
-      await writeFile(
-        fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
-        'utf8'
-      )
+      await db.command(`CREATE TABLE ${chEnv.database}.${tableName} (id UInt64, event_time DateTime) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(event_time) ORDER BY (event_time, id)`)
+      await db.command(`INSERT INTO ${chEnv.database}.${tableName} VALUES (1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), (3, '2026-01-03 12:00:00')`)
+      await waitForParts(db, chEnv.database, tableName, 3)
 
-      const planned = runCli([
-        'plugin',
-        'backfill',
-        'plan',
-        '--target',
-        'app.users',
-        '--from',
-        '2026-01-01T00:00:00.000Z',
-        '--to',
-        '2026-01-01T06:00:00.000Z',
-        '--time-column',
-        'event_time',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      const planPayload = JSON.parse(planned.stdout) as { planId: string; planPath: string }
-      const planState = JSON.parse(await readFile(planPayload.planPath, 'utf8')) as {
-        chunks: Array<{ id: string }>
+      const fixture = await createFixture()
+      const pluginPath = join(fixture.dir, 'backfill-plugin.ts')
+      try {
+        await writeFile(
+          pluginPath,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ defaults: { maxRetriesPerChunk: 1 } })\n`,
+          'utf8'
+        )
+        await writeFile(
+          fixture.configPath,
+          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          'utf8'
+        )
+
+        const planned = runCli([
+          'plugin',
+          'backfill',
+          'plan',
+          '--target',
+          `${chEnv.database}.${tableName}`,
+          '--from',
+          '2026-01-01T00:00:00.000Z',
+          '--to',
+          '2026-01-04T00:00:00.000Z',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        const planPayload = JSON.parse(planned.stdout) as { planId: string; planPath: string }
+        const planState = JSON.parse(await readFile(planPayload.planPath, 'utf8')) as {
+          chunks: Array<{ id: string }>
+        }
+
+        runCli([
+          'plugin',
+          'backfill',
+          'run',
+          '--plan-id',
+          planPayload.planId,
+          '--simulate-fail-chunk',
+          planState.chunks[1]?.id as string,
+          '--simulate-fail-count',
+          '1',
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+
+        const cancelled = runCli([
+          'plugin',
+          'backfill',
+          'cancel',
+          '--plan-id',
+          planPayload.planId,
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(cancelled.exitCode).toBe(0)
+        const cancelPayload = JSON.parse(cancelled.stdout) as { status: string }
+        expect(cancelPayload.status).toBe('cancelled')
+
+        const doctor = runCli([
+          'plugin',
+          'backfill',
+          'doctor',
+          '--plan-id',
+          planPayload.planId,
+          '--config',
+          fixture.configPath,
+          '--json',
+        ])
+        expect(doctor.exitCode).toBe(1)
+        const doctorPayload = JSON.parse(doctor.stdout) as {
+          issueCodes: string[]
+          recommendations: string[]
+        }
+        expect(doctorPayload.issueCodes).toContain('backfill_required_pending')
+        expect(doctorPayload.recommendations.join(' ')).toContain('backfill resume')
+      } finally {
+        await rm(fixture.dir, { recursive: true, force: true })
       }
-
-      runCli([
-        'plugin',
-        'backfill',
-        'run',
-        '--plan-id',
-        planPayload.planId,
-        '--simulate-fail-chunk',
-        planState.chunks[1]?.id as string,
-        '--simulate-fail-count',
-        '1',
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-
-      const cancelled = runCli([
-        'plugin',
-        'backfill',
-        'cancel',
-        '--plan-id',
-        planPayload.planId,
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(cancelled.exitCode).toBe(0)
-      const cancelPayload = JSON.parse(cancelled.stdout) as { status: string }
-      expect(cancelPayload.status).toBe('cancelled')
-
-      const doctor = runCli([
-        'plugin',
-        'backfill',
-        'doctor',
-        '--plan-id',
-        planPayload.planId,
-        '--config',
-        fixture.configPath,
-        '--json',
-      ])
-      expect(doctor.exitCode).toBe(1)
-      const doctorPayload = JSON.parse(doctor.stdout) as {
-        issueCodes: string[]
-        recommendations: string[]
-      }
-      expect(doctorPayload.issueCodes).toContain('backfill_required_pending')
-      expect(doctorPayload.recommendations.join(' ')).toContain('backfill resume')
     } finally {
-      await rm(fixture.dir, { recursive: true, force: true })
+      await db.command(`DROP TABLE IF EXISTS ${chEnv.database}.${tableName}`)
+      await db.close()
     }
   })
 

--- a/packages/cli/src/plugin.test.ts
+++ b/packages/cli/src/plugin.test.ts
@@ -45,7 +45,7 @@ async function waitForParts(
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
     // Sync replica state for the target table first, then check system.parts
-    await db.query(`SELECT 1 FROM ${database}.${table} LIMIT 0 SETTINGS select_sequential_consistency = 1`)
+    await db.query(`SELECT 1 FROM ${database}.${table} LIMIT 1 SETTINGS select_sequential_consistency = 1`)
     const rows = await db.query<{ cnt: string }>(
       `SELECT count(DISTINCT partition) AS cnt FROM system.parts WHERE database = '${database}' AND table = '${table}' AND active SETTINGS select_sequential_consistency = 1`
     )

--- a/packages/cli/src/plugin.test.ts
+++ b/packages/cli/src/plugin.test.ts
@@ -44,8 +44,10 @@ async function waitForParts(
 ): Promise<void> {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
+    // Sync replica state for the target table first, then check system.parts
+    await db.query(`SELECT 1 FROM ${database}.${table} LIMIT 0 SETTINGS select_sequential_consistency = 1`)
     const rows = await db.query<{ cnt: string }>(
-      `SELECT count(DISTINCT partition) AS cnt FROM system.parts WHERE database = '${database}' AND table = '${table}' AND active`
+      `SELECT count(DISTINCT partition) AS cnt FROM system.parts WHERE database = '${database}' AND table = '${table}' AND active SETTINGS select_sequential_consistency = 1`
     )
     const count = Number(rows[0]?.cnt ?? 0)
     if (count >= expectedPartitions) return

--- a/packages/plugin-backfill/src/args.test.ts
+++ b/packages/plugin-backfill/src/args.test.ts
@@ -75,11 +75,4 @@ describe('parsePlanArgs', () => {
     expect(() => parsePlanArgs({})).toThrow('Missing required --target')
   })
 
-  test('parses --force flag', () => {
-    const result = parsePlanArgs({
-      '--target': 'default.events',
-      '--force': true,
-    })
-    expect(result.force).toBe(true)
-  })
 })

--- a/packages/plugin-backfill/src/args.test.ts
+++ b/packages/plugin-backfill/src/args.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseByteSize, parsePlanArgs } from './args.js'
+
+describe('parseByteSize', () => {
+  test('parses gigabytes', () => {
+    expect(parseByteSize('10G')).toBe(10 * 1024 ** 3)
+  })
+
+  test('parses megabytes', () => {
+    expect(parseByteSize('500M')).toBe(500 * 1024 ** 2)
+  })
+
+  test('parses terabytes', () => {
+    expect(parseByteSize('1T')).toBe(1024 ** 4)
+  })
+
+  test('parses kilobytes', () => {
+    expect(parseByteSize('256K')).toBe(256 * 1024)
+  })
+
+  test('parses plain number as bytes', () => {
+    expect(parseByteSize('1048576')).toBe(1048576)
+  })
+
+  test('parses decimal values', () => {
+    expect(parseByteSize('1.5G')).toBe(1.5 * 1024 ** 3)
+  })
+
+  test('is case-insensitive', () => {
+    expect(parseByteSize('10g')).toBe(10 * 1024 ** 3)
+    expect(parseByteSize('500m')).toBe(500 * 1024 ** 2)
+  })
+
+  test('trims whitespace', () => {
+    expect(parseByteSize('  10G  ')).toBe(10 * 1024 ** 3)
+  })
+
+  test('throws on invalid input', () => {
+    expect(() => parseByteSize('abc')).toThrow('Invalid byte size')
+    expect(() => parseByteSize('')).toThrow('Invalid byte size')
+    expect(() => parseByteSize('10X')).toThrow('Invalid byte size')
+  })
+})
+
+describe('parsePlanArgs', () => {
+  test('parses without --from and --to', () => {
+    const result = parsePlanArgs({
+      '--target': 'default.events',
+    })
+    expect(result.target).toBe('default.events')
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+  })
+
+  test('parses --max-chunk-bytes', () => {
+    const result = parsePlanArgs({
+      '--target': 'default.events',
+      '--max-chunk-bytes': '20G',
+    })
+    expect(result.maxChunkBytes).toBe(20 * 1024 ** 3)
+  })
+
+  test('parses with --from and --to', () => {
+    const result = parsePlanArgs({
+      '--target': 'default.events',
+      '--from': '2025-01-01',
+      '--to': '2025-02-01',
+    })
+    expect(result.from).toBeDefined()
+    expect(result.to).toBeDefined()
+  })
+
+  test('throws on missing --target', () => {
+    expect(() => parsePlanArgs({})).toThrow('Missing required --target')
+  })
+
+  test('parses --force flag', () => {
+    const result = parsePlanArgs({
+      '--target': 'default.events',
+      '--force': true,
+    })
+    expect(result.force).toBe(true)
+  })
+})

--- a/packages/plugin-backfill/src/args.ts
+++ b/packages/plugin-backfill/src/args.ts
@@ -12,11 +12,9 @@ import type {
 
 export const PLAN_FLAGS = defineFlags([
   { name: '--target', type: 'string', description: 'Target table (database.table)', placeholder: '<database.table>' },
-  { name: '--from', type: 'string', description: 'Start timestamp', placeholder: '<timestamp>' },
-  { name: '--to', type: 'string', description: 'End timestamp', placeholder: '<timestamp>' },
-  { name: '--chunk-hours', type: 'string', description: 'Hours per chunk', placeholder: '<hours>' },
-  { name: '--time-column', type: 'string', description: 'Time column for WHERE clause', placeholder: '<column>' },
-  { name: '--force-large-window', type: 'boolean', description: 'Allow large time windows without confirmation' },
+  { name: '--from', type: 'string', description: 'Filter partitions starting from timestamp', placeholder: '<timestamp>' },
+  { name: '--to', type: 'string', description: 'Filter partitions up to timestamp', placeholder: '<timestamp>' },
+  { name: '--max-chunk-bytes', type: 'string', description: 'Max bytes per chunk (e.g. 10G, 500M)', placeholder: '<bytes>' },
   { name: '--force', type: 'boolean', description: 'Delete existing plan and regenerate from scratch' },
 ] as const)
 
@@ -66,6 +64,29 @@ function normalizeTarget(raw: string): string {
   return value
 }
 
+const BYTE_SUFFIXES: Record<string, number> = {
+  T: 1024 ** 4,
+  G: 1024 ** 3,
+  M: 1024 ** 2,
+  K: 1024,
+}
+
+export function parseByteSize(raw: string): number {
+  const trimmed = raw.trim().toUpperCase()
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([TGMK])?$/)
+  if (!match) {
+    throw new BackfillConfigError(`Invalid byte size: ${raw}. Expected a number with optional suffix (K, M, G, T).`)
+  }
+  const value = Number(match[1])
+  const suffix = match[2]
+  const multiplier = suffix ? BYTE_SUFFIXES[suffix] ?? 1 : 1
+  const result = value * multiplier
+  if (!Number.isFinite(result) || result <= 0) {
+    throw new BackfillConfigError(`Invalid byte size: ${raw}. Must be a positive number.`)
+  }
+  return result
+}
+
 function normalizePlanId(raw: string): string {
   const value = raw.trim()
   if (!/^[a-f0-9]{16}$/.test(value)) {
@@ -79,31 +100,21 @@ export function parsePlanArgs(flags: ParsedFlags): ParsedPlanArgs {
   const target = f['--target']
   const from = f['--from']
   const to = f['--to']
-  const rawChunkHours = f['--chunk-hours']
-  const timeColumn = f['--time-column']
-  const forceLargeWindow = f['--force-large-window'] === true
+  const rawMaxChunkBytes = f['--max-chunk-bytes']
   const force = f['--force'] === true
 
-  let chunkHours: number | undefined
-  if (rawChunkHours !== undefined) {
-    const parsed = Number(rawChunkHours)
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      throw new BackfillConfigError('Invalid value for --chunk-hours. Expected a positive number.')
-    }
-    chunkHours = parsed
+  let maxChunkBytes: number | undefined
+  if (rawMaxChunkBytes !== undefined) {
+    maxChunkBytes = parseByteSize(rawMaxChunkBytes)
   }
 
   if (!target) throw new BackfillConfigError('Missing required --target <database.table>')
-  if (!from) throw new BackfillConfigError('Missing required --from <timestamp>')
-  if (!to) throw new BackfillConfigError('Missing required --to <timestamp>')
 
   return {
     target: normalizeTarget(target),
-    from: normalizeTimestamp(from, '--from'),
-    to: normalizeTimestamp(to, '--to'),
-    chunkHours,
-    timeColumn: timeColumn?.trim() || undefined,
-    forceLargeWindow,
+    from: from ? normalizeTimestamp(from, '--from') : undefined,
+    to: to ? normalizeTimestamp(to, '--to') : undefined,
+    maxChunkBytes,
     force,
   }
 }

--- a/packages/plugin-backfill/src/args.ts
+++ b/packages/plugin-backfill/src/args.ts
@@ -15,7 +15,6 @@ export const PLAN_FLAGS = defineFlags([
   { name: '--from', type: 'string', description: 'Filter partitions starting from timestamp', placeholder: '<timestamp>' },
   { name: '--to', type: 'string', description: 'Filter partitions up to timestamp', placeholder: '<timestamp>' },
   { name: '--max-chunk-bytes', type: 'string', description: 'Max bytes per chunk (e.g. 10G, 500M)', placeholder: '<bytes>' },
-  { name: '--force', type: 'boolean', description: 'Delete existing plan and regenerate from scratch' },
 ] as const)
 
 export const RUN_FLAGS = defineFlags([
@@ -101,7 +100,6 @@ export function parsePlanArgs(flags: ParsedFlags): ParsedPlanArgs {
   const from = f['--from']
   const to = f['--to']
   const rawMaxChunkBytes = f['--max-chunk-bytes']
-  const force = f['--force'] === true
 
   let maxChunkBytes: number | undefined
   if (rawMaxChunkBytes !== undefined) {
@@ -115,7 +113,6 @@ export function parsePlanArgs(flags: ParsedFlags): ParsedPlanArgs {
     from: from ? normalizeTimestamp(from, '--from') : undefined,
     to: to ? normalizeTimestamp(to, '--to') : undefined,
     maxChunkBytes,
-    force,
   }
 }
 

--- a/packages/plugin-backfill/src/check.ts
+++ b/packages/plugin-backfill/src/check.ts
@@ -1,0 +1,99 @@
+import { join } from 'node:path'
+
+import type { ResolvedChxConfig } from '@chkit/core'
+
+import {
+  computeBackfillStateDir,
+  listPlanIds,
+  readRun,
+} from './state.js'
+import type {
+  BackfillPluginCheckResult,
+  NormalizedBackfillPluginOptions,
+} from './types.js'
+
+export async function evaluateBackfillCheck(input: {
+  configPath: string
+  config: Pick<ResolvedChxConfig, 'metaDir'>
+  options: NormalizedBackfillPluginOptions
+}): Promise<BackfillPluginCheckResult> {
+  const stateDir = computeBackfillStateDir(input.config, input.configPath, input.options)
+  const plansDir = join(stateDir, 'plans')
+  const runsDir = join(stateDir, 'runs')
+
+  const planIds = await listPlanIds(plansDir)
+  if (planIds.length === 0) {
+    return {
+      plugin: 'backfill',
+      evaluated: true,
+      ok: true,
+      findings: [],
+      metadata: {
+        requiredCount: 0,
+        activeRuns: 0,
+        failedRuns: 0,
+      },
+    }
+  }
+
+  let requiredCount = 0
+  let activeRuns = 0
+  let failedRuns = 0
+
+  for (const planId of planIds) {
+    const runPath = join(runsDir, `${planId}.json`)
+    const run = await readRun(runPath)
+    if (!run) {
+      requiredCount += 1
+      continue
+    }
+
+    if (run.status === 'running') activeRuns += 1
+    if (run.status === 'failed') failedRuns += 1
+    if (run.status !== 'completed') requiredCount += 1
+  }
+
+  const findings: BackfillPluginCheckResult['findings'] = []
+  if (requiredCount > 0) {
+    findings.push({
+      code: 'backfill_required_pending',
+      message: `Required backfills pending completion: ${requiredCount}`,
+      severity: input.options.policy.failCheckOnRequiredPendingBackfill ? 'error' : 'warn',
+      metadata: {
+        requiredCount,
+      },
+    })
+  }
+
+  if (failedRuns > 0) {
+    findings.push({
+      code: 'backfill_chunk_failed_retry_exhausted',
+      message: `Backfill runs failed after retry budget: ${failedRuns}`,
+      severity: 'error',
+      metadata: {
+        failedRuns,
+      },
+    })
+  }
+
+  if (!input.options.policy.failCheckOnRequiredPendingBackfill) {
+    findings.push({
+      code: 'backfill_policy_relaxed',
+      message: 'Backfill check policy is relaxed: failCheckOnRequiredPendingBackfill=false.',
+      severity: 'warn',
+    })
+  }
+
+  const ok = findings.every((finding) => finding.severity !== 'error')
+  return {
+    plugin: 'backfill',
+    evaluated: true,
+    ok,
+    findings,
+    metadata: {
+      requiredCount,
+      activeRuns,
+      failedRuns,
+    },
+  }
+}

--- a/packages/plugin-backfill/src/chunking/analyze.ts
+++ b/packages/plugin-backfill/src/chunking/analyze.ts
@@ -1,0 +1,127 @@
+import { hashId } from '../state.js'
+
+import { buildChunkBoundaries } from './build.js'
+import { introspectTable, querySortKeyRanges } from './introspect.js'
+import type { ChunkBoundary, PartitionInfo, PlannedChunk, SortKeyInfo } from './types.js'
+
+export interface AnalyzeAndChunkInput {
+  database: string
+  table: string
+  from?: string
+  to?: string
+  maxChunkBytes: number
+  requireIdempotencyToken: boolean
+  planId: string
+  query: <T>(sql: string) => Promise<T[]>
+}
+
+export interface AnalyzeAndChunkResult {
+  partitions: PartitionInfo[]
+  sortKey?: SortKeyInfo
+  chunks: PlannedChunk[]
+}
+
+export async function analyzeAndChunk(input: AnalyzeAndChunkInput): Promise<AnalyzeAndChunkResult> {
+  const { partitions, sortKey, boundaries } = await analyzeTable({
+    database: input.database,
+    table: input.table,
+    from: input.from,
+    to: input.to,
+    maxChunkBytes: input.maxChunkBytes,
+    query: input.query,
+  })
+
+  const chunks = buildPlannedChunks({
+    planId: input.planId,
+    partitions,
+    boundaries,
+    requireIdempotencyToken: input.requireIdempotencyToken,
+  })
+
+  return { partitions, sortKey, chunks }
+}
+
+export interface AnalyzeTableInput {
+  database: string
+  table: string
+  from?: string
+  to?: string
+  maxChunkBytes: number
+  query: <T>(sql: string) => Promise<T[]>
+}
+
+export interface AnalyzeTableResult {
+  partitions: PartitionInfo[]
+  sortKey?: SortKeyInfo
+  boundaries: ChunkBoundary[]
+}
+
+export async function analyzeTable(input: AnalyzeTableInput): Promise<AnalyzeTableResult> {
+  const { partitions, sortKey } = await introspectTable({
+    database: input.database,
+    table: input.table,
+    from: input.from,
+    to: input.to,
+    query: input.query,
+  })
+
+  const oversizedPartitionIds = partitions
+    .filter(p => p.bytesOnDisk > input.maxChunkBytes)
+    .map(p => p.partitionId)
+
+  let sortKeyRanges: Map<string, { min: string; max: string }> | undefined
+  if (sortKey && oversizedPartitionIds.length > 0) {
+    sortKeyRanges = await querySortKeyRanges({
+      database: input.database,
+      table: input.table,
+      sortKeyColumn: sortKey.column,
+      partitionIds: oversizedPartitionIds,
+      query: input.query,
+    })
+  }
+
+  const boundaries = buildChunkBoundaries({
+    partitions,
+    maxChunkBytes: input.maxChunkBytes,
+    sortKey,
+    sortKeyRanges,
+  })
+
+  return { partitions, sortKey, boundaries }
+}
+
+export function buildPlannedChunks(input: {
+  planId: string
+  partitions: PartitionInfo[]
+  boundaries: ChunkBoundary[]
+  requireIdempotencyToken: boolean
+}): PlannedChunk[] {
+  const chunks: PlannedChunk[] = []
+  const partitionIndex = new Map<string, number>()
+
+  for (const boundary of input.boundaries) {
+    const idx = partitionIndex.get(boundary.partitionId) ?? 0
+    partitionIndex.set(boundary.partitionId, idx + 1)
+
+    const idSeed = `${input.planId}:${boundary.partitionId}:${idx}`
+    const chunkId = hashId(`chunk:${idSeed}`).slice(0, 16)
+    const token = input.requireIdempotencyToken ? hashId(`token:${idSeed}`) : ''
+
+    const partition = input.partitions.find(p => p.partitionId === boundary.partitionId)
+    const from = boundary.sortKeyFrom ?? partition?.minTime ?? ''
+    const to = boundary.sortKeyTo ?? partition?.maxTime ?? ''
+
+    chunks.push({
+      id: chunkId,
+      partitionId: boundary.partitionId,
+      sortKeyFrom: boundary.sortKeyFrom,
+      sortKeyTo: boundary.sortKeyTo,
+      estimatedBytes: boundary.estimatedBytes,
+      idempotencyToken: token,
+      from,
+      to,
+    })
+  }
+
+  return chunks
+}

--- a/packages/plugin-backfill/src/chunking/analyze.ts
+++ b/packages/plugin-backfill/src/chunking/analyze.ts
@@ -1,4 +1,4 @@
-import { hashId } from '../state.js'
+import { hashId, randomPlanId } from '../state.js'
 
 import { buildChunkBoundaries } from './build.js'
 import { introspectTable, querySortKeyRanges } from './introspect.js'
@@ -11,11 +11,11 @@ export interface AnalyzeAndChunkInput {
   to?: string
   maxChunkBytes: number
   requireIdempotencyToken: boolean
-  planId: string
   query: <T>(sql: string) => Promise<T[]>
 }
 
 export interface AnalyzeAndChunkResult {
+  planId: string
   partitions: PartitionInfo[]
   sortKey?: SortKeyInfo
   chunks: PlannedChunk[]
@@ -31,14 +31,16 @@ export async function analyzeAndChunk(input: AnalyzeAndChunkInput): Promise<Anal
     query: input.query,
   })
 
+  const planId = randomPlanId()
+
   const chunks = buildPlannedChunks({
-    planId: input.planId,
+    planId,
     partitions,
     boundaries,
     requireIdempotencyToken: input.requireIdempotencyToken,
   })
 
-  return { partitions, sortKey, chunks }
+  return { planId, partitions, sortKey, chunks }
 }
 
 export interface AnalyzeTableInput {

--- a/packages/plugin-backfill/src/chunking/build.test.ts
+++ b/packages/plugin-backfill/src/chunking/build.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildChunkBoundaries } from './build.js'
+import type { PartitionInfo, SortKeyInfo } from './types.js'
+
+const GiB = 1024 ** 3
+
+describe('buildChunkBoundaries', () => {
+  test('small partition produces one chunk boundary', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 1000, bytesOnDisk: 5 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T23:59:59.000Z' },
+    ]
+
+    const boundaries = buildChunkBoundaries({
+      partitions,
+      maxChunkBytes: 10 * GiB,
+    })
+
+    expect(boundaries).toHaveLength(1)
+    expect(boundaries[0]?.partitionId).toBe('202501')
+    expect(boundaries[0]?.sortKeyFrom).toBeUndefined()
+    expect(boundaries[0]?.sortKeyTo).toBeUndefined()
+    expect(boundaries[0]?.estimatedBytes).toBe(5 * GiB)
+  })
+
+  test('large partition produces multiple sub-chunks with sort key ranges', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 10000, bytesOnDisk: 30 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+    const sortKey: SortKeyInfo = { column: 'event_time', type: 'DateTime', category: 'datetime' }
+    const sortKeyRanges = new Map([
+      ['202501', { min: '2025-01-01 00:00:00', max: '2025-01-31 00:00:00' }],
+    ])
+
+    const boundaries = buildChunkBoundaries({
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      sortKey,
+      sortKeyRanges,
+    })
+
+    expect(boundaries).toHaveLength(3)
+    for (const b of boundaries) {
+      expect(b.partitionId).toBe('202501')
+      expect(b.sortKeyFrom).toBeDefined()
+      expect(b.sortKeyTo).toBeDefined()
+    }
+  })
+
+  test('large partition without sort key produces single chunk', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 10000, bytesOnDisk: 30 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+
+    const boundaries = buildChunkBoundaries({
+      partitions,
+      maxChunkBytes: 10 * GiB,
+    })
+
+    expect(boundaries).toHaveLength(1)
+    expect(boundaries[0]?.estimatedBytes).toBe(30 * GiB)
+  })
+
+  test('mixed sizes produce correct boundary counts', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 500, bytesOnDisk: 5 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+      { partitionId: '202502', rows: 5000, bytesOnDisk: 25 * GiB, minTime: '2025-02-01T00:00:00.000Z', maxTime: '2025-02-28T00:00:00.000Z' },
+    ]
+    const sortKey: SortKeyInfo = { column: 'event_time', type: 'DateTime', category: 'datetime' }
+    const sortKeyRanges = new Map([
+      ['202502', { min: '2025-02-01 00:00:00', max: '2025-02-28 00:00:00' }],
+    ])
+
+    const boundaries = buildChunkBoundaries({
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      sortKey,
+      sortKeyRanges,
+    })
+
+    // First partition: 5 GiB < 10 GiB -> 1 boundary
+    // Second partition: 25 GiB / 10 GiB = 3 sub-boundaries
+    expect(boundaries).toHaveLength(4)
+
+    const p1 = boundaries.filter((b) => b.partitionId === '202501')
+    const p2 = boundaries.filter((b) => b.partitionId === '202502')
+    expect(p1).toHaveLength(1)
+    expect(p2).toHaveLength(3)
+  })
+
+  test('large partition with min === max sort key produces single chunk', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 10000, bytesOnDisk: 30 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+    const sortKey: SortKeyInfo = { column: 'event_type', type: 'String', category: 'string' }
+    const sortKeyRanges = new Map([
+      ['202501', { min: 'click', max: 'click' }],
+    ])
+
+    const boundaries = buildChunkBoundaries({
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      sortKey,
+      sortKeyRanges,
+    })
+
+    expect(boundaries).toHaveLength(1)
+    expect(boundaries[0]?.partitionId).toBe('202501')
+    expect(boundaries[0]?.sortKeyFrom).toBeUndefined()
+    expect(boundaries[0]?.sortKeyTo).toBeUndefined()
+  })
+
+  test('numeric sort key produces numeric range sub-chunks', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 10000, bytesOnDisk: 20 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+    const sortKey: SortKeyInfo = { column: 'id', type: 'UInt64', category: 'numeric' }
+    const sortKeyRanges = new Map([
+      ['202501', { min: '100', max: '200' }],
+    ])
+
+    const boundaries = buildChunkBoundaries({
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      sortKey,
+      sortKeyRanges,
+    })
+
+    expect(boundaries).toHaveLength(2)
+    expect(boundaries[0]?.sortKeyFrom).toBe('100')
+    expect(boundaries[0]?.sortKeyTo).toBe('150')
+    expect(boundaries[1]?.sortKeyFrom).toBe('150')
+    expect(boundaries[1]?.sortKeyTo).toBe('201')
+  })
+})

--- a/packages/plugin-backfill/src/chunking/build.ts
+++ b/packages/plugin-backfill/src/chunking/build.ts
@@ -1,0 +1,60 @@
+import { splitSortKeyRange } from './splitter.js'
+import type { ChunkBoundary, PartitionInfo, SortKeyInfo } from './types.js'
+
+export function buildChunkBoundaries(input: {
+  partitions: PartitionInfo[]
+  maxChunkBytes: number
+  sortKey?: SortKeyInfo
+  sortKeyRanges?: Map<string, { min: string; max: string }>
+}): ChunkBoundary[] {
+  const boundaries: ChunkBoundary[] = []
+
+  for (const partition of input.partitions) {
+    if (partition.bytesOnDisk <= input.maxChunkBytes) {
+      boundaries.push({
+        partitionId: partition.partitionId,
+        estimatedBytes: partition.bytesOnDisk,
+      })
+    } else if (input.sortKey && input.sortKeyRanges) {
+      const range = input.sortKeyRanges.get(partition.partitionId)
+      if (!range) {
+        // No range data — emit as single chunk
+        boundaries.push({
+          partitionId: partition.partitionId,
+          estimatedBytes: partition.bytesOnDisk,
+        })
+        continue
+      }
+
+      // If min === max, splitting would produce empty sub-ranges; emit as single chunk
+      if (range.min === range.max) {
+        boundaries.push({
+          partitionId: partition.partitionId,
+          estimatedBytes: partition.bytesOnDisk,
+        })
+        continue
+      }
+
+      const subCount = Math.ceil(partition.bytesOnDisk / input.maxChunkBytes)
+      const subRanges = splitSortKeyRange(input.sortKey.category, range.min, range.max, subCount)
+      const estimatedBytesPerSub = Math.ceil(partition.bytesOnDisk / subCount)
+
+      for (const sub of subRanges) {
+        boundaries.push({
+          partitionId: partition.partitionId,
+          sortKeyFrom: sub.from,
+          sortKeyTo: sub.to,
+          estimatedBytes: estimatedBytesPerSub,
+        })
+      }
+    } else {
+      // No sort key info — emit as single chunk despite being oversized
+      boundaries.push({
+        partitionId: partition.partitionId,
+        estimatedBytes: partition.bytesOnDisk,
+      })
+    }
+  }
+
+  return boundaries
+}

--- a/packages/plugin-backfill/src/chunking/index.ts
+++ b/packages/plugin-backfill/src/chunking/index.ts
@@ -1,7 +1,0 @@
-export { analyzeAndChunk, analyzeTable, buildPlannedChunks } from './analyze.js'
-export type { AnalyzeAndChunkInput, AnalyzeAndChunkResult, AnalyzeTableInput, AnalyzeTableResult } from './analyze.js'
-export { buildChunkBoundaries } from './build.js'
-export { introspectTable, queryPartitionInfo, querySortKeyInfo, querySortKeyRanges } from './introspect.js'
-export { buildChunkSql, injectSortKeyFilter, rewriteSelectColumns } from './sql.js'
-export { splitSortKeyRange } from './splitter.js'
-export type { ChunkBoundary, PartitionInfo, PlannedChunk, SortKeyInfo } from './types.js'

--- a/packages/plugin-backfill/src/chunking/index.ts
+++ b/packages/plugin-backfill/src/chunking/index.ts
@@ -1,0 +1,7 @@
+export { analyzeAndChunk, analyzeTable, buildPlannedChunks } from './analyze.js'
+export type { AnalyzeAndChunkInput, AnalyzeAndChunkResult, AnalyzeTableInput, AnalyzeTableResult } from './analyze.js'
+export { buildChunkBoundaries } from './build.js'
+export { introspectTable, queryPartitionInfo, querySortKeyInfo, querySortKeyRanges } from './introspect.js'
+export { buildChunkSql, injectSortKeyFilter, rewriteSelectColumns } from './sql.js'
+export { splitSortKeyRange } from './splitter.js'
+export type { ChunkBoundary, PartitionInfo, PlannedChunk, SortKeyInfo } from './types.js'

--- a/packages/plugin-backfill/src/chunking/introspect.test.ts
+++ b/packages/plugin-backfill/src/chunking/introspect.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from 'bun:test'
+
+import { introspectTable, queryPartitionInfo, querySortKeyInfo, querySortKeyRanges } from './introspect.js'
+
+describe('queryPartitionInfo', () => {
+  test('maps system.parts rows to PartitionInfo array', async () => {
+    const mockRows = [
+      { partition_id: '202501', total_rows: '1000', total_bytes: '5000000', min_time: '2025-01-01 00:00:00', max_time: '2025-01-31 23:59:59' },
+      { partition_id: '202502', total_rows: '2000', total_bytes: '8000000', min_time: '2025-02-01 00:00:00', max_time: '2025-02-28 23:59:59' },
+    ]
+
+    const result = await queryPartitionInfo({
+      database: 'default',
+      table: 'events',
+      query: async () => mockRows as never,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.partitionId).toBe('202501')
+    expect(result[0]?.rows).toBe(1000)
+    expect(result[0]?.bytesOnDisk).toBe(5000000)
+    expect(result[1]?.partitionId).toBe('202502')
+    expect(result[1]?.rows).toBe(2000)
+  })
+
+  test('filters out partitions before --from', async () => {
+    const mockRows = [
+      { partition_id: '202501', total_rows: '1000', total_bytes: '5000000', min_time: '2025-01-01 00:00:00', max_time: '2025-01-31 23:59:59' },
+      { partition_id: '202503', total_rows: '3000', total_bytes: '9000000', min_time: '2025-03-01 00:00:00', max_time: '2025-03-31 23:59:59' },
+    ]
+
+    const result = await queryPartitionInfo({
+      database: 'default',
+      table: 'events',
+      from: '2025-02-01T00:00:00.000Z',
+      query: async () => mockRows as never,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.partitionId).toBe('202503')
+  })
+
+  test('filters out partitions at or after --to', async () => {
+    const mockRows = [
+      { partition_id: '202501', total_rows: '1000', total_bytes: '5000000', min_time: '2025-01-01 00:00:00', max_time: '2025-01-31 23:59:59' },
+      { partition_id: '202503', total_rows: '3000', total_bytes: '9000000', min_time: '2025-03-01 00:00:00', max_time: '2025-03-31 23:59:59' },
+    ]
+
+    const result = await queryPartitionInfo({
+      database: 'default',
+      table: 'events',
+      to: '2025-03-01T00:00:00.000Z',
+      query: async () => mockRows as never,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.partitionId).toBe('202501')
+  })
+})
+
+describe('querySortKeyInfo', () => {
+  test('returns sort key info for table with DateTime sorting key', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.tables')) {
+        return [{ sorting_key: 'event_time' }] as T[]
+      }
+      if (sql.includes('system.columns')) {
+        return [{ type: 'DateTime' }] as T[]
+      }
+      return [] as T[]
+    }
+
+    const result = await querySortKeyInfo({
+      database: 'default',
+      table: 'events',
+      query,
+    })
+
+    expect(result).toBeDefined()
+    expect(result?.column).toBe('event_time')
+    expect(result?.type).toBe('DateTime')
+    expect(result?.category).toBe('datetime')
+  })
+
+  test('returns numeric category for Int64 sorting key', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.tables')) return [{ sorting_key: 'id' }] as T[]
+      if (sql.includes('system.columns')) return [{ type: 'Int64' }] as T[]
+      return [] as T[]
+    }
+
+    const result = await querySortKeyInfo({ database: 'default', table: 'events', query })
+
+    expect(result?.category).toBe('numeric')
+  })
+
+  test('returns string category for String sorting key', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.tables')) return [{ sorting_key: 'name' }] as T[]
+      if (sql.includes('system.columns')) return [{ type: 'String' }] as T[]
+      return [] as T[]
+    }
+
+    const result = await querySortKeyInfo({ database: 'default', table: 'events', query })
+
+    expect(result?.category).toBe('string')
+  })
+
+  test('extracts column name from function expression', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.tables')) return [{ sorting_key: 'toDate(event_time)' }] as T[]
+      if (sql.includes('system.columns')) return [{ type: 'DateTime' }] as T[]
+      return [] as T[]
+    }
+
+    const result = await querySortKeyInfo({ database: 'default', table: 'events', query })
+
+    expect(result?.column).toBe('event_time')
+  })
+
+  test('returns undefined when table has no sorting key', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.tables')) return [{ sorting_key: '' }] as T[]
+      return [] as T[]
+    }
+
+    const result = await querySortKeyInfo({ database: 'default', table: 'events', query })
+
+    expect(result).toBeUndefined()
+  })
+
+  test('returns first column from multi-column sorting key', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.tables')) return [{ sorting_key: 'event_time, id' }] as T[]
+      if (sql.includes('system.columns')) return [{ type: 'DateTime' }] as T[]
+      return [] as T[]
+    }
+
+    const result = await querySortKeyInfo({ database: 'default', table: 'events', query })
+
+    expect(result?.column).toBe('event_time')
+  })
+})
+
+describe('querySortKeyRanges', () => {
+  test('returns min/max per partition', async () => {
+    const query = async <T>() => {
+      return [
+        { partition_id: '202501', min_val: '2025-01-01 00:00:00', max_val: '2025-01-31 23:59:59' },
+        { partition_id: '202502', min_val: '2025-02-01 00:00:00', max_val: '2025-02-28 23:59:59' },
+      ] as T[]
+    }
+
+    const result = await querySortKeyRanges({
+      database: 'default',
+      table: 'events',
+      sortKeyColumn: 'event_time',
+      partitionIds: ['202501', '202502'],
+      query,
+    })
+
+    expect(result.size).toBe(2)
+    expect(result.get('202501')?.min).toBe('2025-01-01 00:00:00')
+    expect(result.get('202502')?.max).toBe('2025-02-28 23:59:59')
+  })
+
+  test('returns empty map for empty partition list', async () => {
+    const query = async <T>() => [] as T[]
+
+    const result = await querySortKeyRanges({
+      database: 'default',
+      table: 'events',
+      sortKeyColumn: 'event_time',
+      partitionIds: [],
+      query,
+    })
+
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('introspectTable', () => {
+  test('returns partitions and sort key in a single call', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.parts')) {
+        return [
+          { partition_id: '202501', total_rows: '1000', total_bytes: '5000000', min_time: '2025-01-01 00:00:00', max_time: '2025-01-31 23:59:59' },
+        ] as T[]
+      }
+      if (sql.includes('system.tables')) {
+        return [{ sorting_key: 'event_time' }] as T[]
+      }
+      if (sql.includes('system.columns')) {
+        return [{ type: 'DateTime' }] as T[]
+      }
+      return [] as T[]
+    }
+
+    const result = await introspectTable({
+      database: 'default',
+      table: 'events',
+      query,
+    })
+
+    expect(result.partitions).toHaveLength(1)
+    expect(result.partitions[0]?.partitionId).toBe('202501')
+    expect(result.sortKey).toBeDefined()
+    expect(result.sortKey?.column).toBe('event_time')
+    expect(result.sortKey?.category).toBe('datetime')
+  })
+
+  test('returns undefined sortKey when table has no sorting key', async () => {
+    const query = async <T>(sql: string) => {
+      if (sql.includes('system.parts')) {
+        return [
+          { partition_id: '202501', total_rows: '1000', total_bytes: '5000000', min_time: '2025-01-01 00:00:00', max_time: '2025-01-31 23:59:59' },
+        ] as T[]
+      }
+      if (sql.includes('system.tables')) {
+        return [{ sorting_key: '' }] as T[]
+      }
+      return [] as T[]
+    }
+
+    const result = await introspectTable({
+      database: 'default',
+      table: 'events',
+      query,
+    })
+
+    expect(result.partitions).toHaveLength(1)
+    expect(result.sortKey).toBeUndefined()
+  })
+})

--- a/packages/plugin-backfill/src/chunking/introspect.ts
+++ b/packages/plugin-backfill/src/chunking/introspect.ts
@@ -28,7 +28,7 @@ export async function queryPartitionInfo(input: {
   // tables, so this preliminary query ensures the replica has caught up with
   // all pending writes before we inspect part metadata.
   await input.query(
-    `SELECT 1 FROM ${input.database}.${input.table} LIMIT 0 SETTINGS select_sequential_consistency = 1`
+    `SELECT 1 FROM ${input.database}.${input.table} LIMIT 1 SETTINGS select_sequential_consistency = 1`
   )
 
   const rows = await input.query<{
@@ -118,7 +118,7 @@ export async function querySortKeyRanges(input: {
     min_val: string
     max_val: string
   }>(
-    `SELECT _partition_id AS partition_id, toString(min(${input.sortKeyColumn})) AS min_val, toString(max(${input.sortKeyColumn})) AS max_val FROM ${input.database}.${input.table} WHERE _partition_id IN (${inList}) GROUP BY _partition_id`
+    `SELECT _partition_id AS partition_id, toString(min(${input.sortKeyColumn})) AS min_val, toString(max(${input.sortKeyColumn})) AS max_val FROM ${input.database}.${input.table} WHERE _partition_id IN (${inList}) GROUP BY _partition_id SETTINGS select_sequential_consistency = 1`
   )
 
   const result = new Map<string, { min: string; max: string }>()

--- a/packages/plugin-backfill/src/chunking/introspect.ts
+++ b/packages/plugin-backfill/src/chunking/introspect.ts
@@ -1,0 +1,137 @@
+import type { PartitionInfo, SortKeyInfo } from './types.js'
+
+const NUMERIC_TYPES = new Set([
+  'Int8', 'Int16', 'Int32', 'Int64', 'Int128', 'Int256',
+  'UInt8', 'UInt16', 'UInt32', 'UInt64', 'UInt128', 'UInt256',
+  'Float32', 'Float64',
+])
+
+const DATETIME_TYPES = new Set(['Date', 'Date32', 'DateTime', 'DateTime64'])
+
+function classifySortKeyType(type: string): SortKeyInfo['category'] {
+  if (NUMERIC_TYPES.has(type)) return 'numeric'
+  if (DATETIME_TYPES.has(type)) return 'datetime'
+  if (type.startsWith('DateTime64(')) return 'datetime'
+  if (type.startsWith("DateTime('")) return 'datetime'
+  return 'string'
+}
+
+export async function queryPartitionInfo(input: {
+  database: string
+  table: string
+  from?: string
+  to?: string
+  query: <T>(sql: string) => Promise<T[]>
+}): Promise<PartitionInfo[]> {
+  const rows = await input.query<{
+    partition_id: string
+    total_rows: string
+    total_bytes: string
+    min_time: string
+    max_time: string
+  }>(
+    `SELECT
+  partition_id,
+  toString(sum(rows)) AS total_rows,
+  toString(sum(bytes_on_disk)) AS total_bytes,
+  toString(min(min_time)) AS min_time,
+  toString(max(max_time)) AS max_time
+FROM system.parts
+WHERE database = '${input.database}'
+  AND table = '${input.table}'
+  AND active = 1
+GROUP BY partition_id
+ORDER BY partition_id`
+  )
+
+  const partitions: PartitionInfo[] = rows.map((row) => ({
+    partitionId: row.partition_id,
+    rows: Number(row.total_rows),
+    bytesOnDisk: Number(row.total_bytes),
+    minTime: new Date(row.min_time).toISOString(),
+    maxTime: new Date(row.max_time).toISOString(),
+  }))
+
+  return partitions.filter((p) => {
+    if (input.from && p.maxTime < input.from) return false
+    if (input.to && p.minTime >= input.to) return false
+    return true
+  })
+}
+
+export async function querySortKeyInfo(input: {
+  database: string
+  table: string
+  query: <T>(sql: string) => Promise<T[]>
+}): Promise<SortKeyInfo | undefined> {
+  const tableRows = await input.query<{ sorting_key: string }>(
+    `SELECT sorting_key FROM system.tables WHERE database = '${input.database}' AND name = '${input.table}'`
+  )
+
+  const sortingKey = tableRows[0]?.sorting_key
+  if (!sortingKey) return undefined
+
+  // Parse first column from sorting key (may have expressions like "toDate(event_time)")
+  const firstColumn = sortingKey.split(',')[0]?.trim()
+  if (!firstColumn) return undefined
+
+  // If it's a function call like toDate(col), extract the column name
+  const match = firstColumn.match(/^\w+\((\w+)\)$/)
+  const columnName = match ? match[1] : firstColumn
+  if (!columnName) return undefined
+
+  const columnRows = await input.query<{ type: string }>(
+    `SELECT type FROM system.columns WHERE database = '${input.database}' AND table = '${input.table}' AND name = '${columnName}'`
+  )
+
+  const type = columnRows[0]?.type
+  if (!type) return undefined
+
+  return {
+    column: columnName,
+    type,
+    category: classifySortKeyType(type),
+  }
+}
+
+export async function querySortKeyRanges(input: {
+  database: string
+  table: string
+  sortKeyColumn: string
+  partitionIds: string[]
+  query: <T>(sql: string) => Promise<T[]>
+}): Promise<Map<string, { min: string; max: string }>> {
+  if (input.partitionIds.length === 0) return new Map()
+
+  const inList = input.partitionIds.map((id) => `'${id}'`).join(', ')
+  const rows = await input.query<{
+    partition_id: string
+    min_val: string
+    max_val: string
+  }>(
+    `SELECT _partition_id AS partition_id, toString(min(${input.sortKeyColumn})) AS min_val, toString(max(${input.sortKeyColumn})) AS max_val FROM ${input.database}.${input.table} WHERE _partition_id IN (${inList}) GROUP BY _partition_id`
+  )
+
+  const result = new Map<string, { min: string; max: string }>()
+  for (const row of rows) {
+    result.set(row.partition_id, { min: row.min_val, max: row.max_val })
+  }
+  return result
+}
+
+export async function introspectTable(input: {
+  database: string
+  table: string
+  from?: string
+  to?: string
+  query: <T>(sql: string) => Promise<T[]>
+}): Promise<{ partitions: PartitionInfo[]; sortKey?: SortKeyInfo }> {
+  const partitions = await queryPartitionInfo(input)
+  const sortKey = await querySortKeyInfo({
+    database: input.database,
+    table: input.table,
+    query: input.query,
+  })
+
+  return { partitions, sortKey }
+}

--- a/packages/plugin-backfill/src/chunking/introspect.ts
+++ b/packages/plugin-backfill/src/chunking/introspect.ts
@@ -41,7 +41,8 @@ WHERE database = '${input.database}'
   AND table = '${input.table}'
   AND active = 1
 GROUP BY partition_id
-ORDER BY partition_id`
+ORDER BY partition_id
+SETTINGS select_sequential_consistency = 1`
   )
 
   const partitions: PartitionInfo[] = rows.map((row) => ({

--- a/packages/plugin-backfill/src/chunking/introspect.ts
+++ b/packages/plugin-backfill/src/chunking/introspect.ts
@@ -23,6 +23,14 @@ export async function queryPartitionInfo(input: {
   to?: string
   query: <T>(sql: string) => Promise<T[]>
 }): Promise<PartitionInfo[]> {
+  // Force replica sync on the target table before reading system.parts.
+  // select_sequential_consistency is only effective on user tables, not system
+  // tables, so this preliminary query ensures the replica has caught up with
+  // all pending writes before we inspect part metadata.
+  await input.query(
+    `SELECT 1 FROM ${input.database}.${input.table} LIMIT 0 SETTINGS select_sequential_consistency = 1`
+  )
+
   const rows = await input.query<{
     partition_id: string
     total_rows: string

--- a/packages/plugin-backfill/src/chunking/splitter.test.ts
+++ b/packages/plugin-backfill/src/chunking/splitter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import { splitSortKeyRange, stringToUint64, uint64ToString } from './splitter.js'
+
+describe('splitSortKeyRange', () => {
+  test('numeric: splits into equal-width ranges', () => {
+    const ranges = splitSortKeyRange('numeric', '100', '200', 2)
+
+    expect(ranges).toHaveLength(2)
+    expect(ranges[0]?.from).toBe('100')
+    expect(ranges[0]?.to).toBe('150')
+    expect(ranges[1]?.from).toBe('150')
+    expect(ranges[1]?.to).toBe('201')
+  })
+
+  test('datetime: splits into equal-width time ranges', () => {
+    const ranges = splitSortKeyRange('datetime', '2025-01-01 00:00:00', '2025-01-31 00:00:00', 3)
+
+    expect(ranges).toHaveLength(3)
+    for (const r of ranges) {
+      expect(r.from).toBeDefined()
+      expect(r.to).toBeDefined()
+    }
+  })
+
+  test('string: round-trips through uint64 conversion', () => {
+    const ranges = splitSortKeyRange('string', 'aaa', 'zzz', 2)
+
+    expect(ranges).toHaveLength(2)
+    expect(ranges[0]?.from).toBeDefined()
+    expect(ranges[1]?.to).toBeDefined()
+  })
+})
+
+describe('stringToUint64 / uint64ToString', () => {
+  test('round-trips short strings', () => {
+    const original = 'abc'
+    const n = stringToUint64(original)
+    const back = uint64ToString(n)
+    expect(back).toBe(original)
+  })
+
+  test('round-trips 8-byte strings', () => {
+    const original = 'abcdefgh'
+    const n = stringToUint64(original)
+    const back = uint64ToString(n)
+    expect(back).toBe(original)
+  })
+
+  test('truncates strings longer than 8 bytes', () => {
+    const n = stringToUint64('abcdefghijklmnop')
+    const back = uint64ToString(n)
+    expect(back).toBe('abcdefgh')
+  })
+
+  test('handles embedded zero bytes from arithmetic', () => {
+    // Simulates a computed intermediate where a middle byte is 0x00
+    // e.g. 0x6200000000000001 has zero bytes between 'b' and the trailing 0x01
+    const n = 0x6200000000000001n
+    const result = uint64ToString(n)
+    expect(result).toBe('b\0\0\0\0\0\0\x01')
+    expect(result.length).toBe(8)
+  })
+})

--- a/packages/plugin-backfill/src/chunking/splitter.ts
+++ b/packages/plugin-backfill/src/chunking/splitter.ts
@@ -1,0 +1,86 @@
+import type { SortKeyInfo } from './types.js'
+
+export function splitNumericRange(min: number, max: number, count: number): Array<{ from: string; to: string }> {
+  const span = max - min
+  const step = span / count
+  const ranges: Array<{ from: string; to: string }> = []
+  for (let i = 0; i < count; i++) {
+    const from = min + i * step
+    const to = i === count - 1 ? max + 1 : min + (i + 1) * step
+    ranges.push({ from: String(from), to: String(to) })
+  }
+  return ranges
+}
+
+export function splitDateTimeRange(min: string, max: string, count: number): Array<{ from: string; to: string }> {
+  const minMs = new Date(min).getTime()
+  const maxMs = new Date(max).getTime()
+  const span = maxMs - minMs
+  const step = span / count
+  const ranges: Array<{ from: string; to: string }> = []
+  for (let i = 0; i < count; i++) {
+    const from = new Date(minMs + i * step).toISOString()
+    const to = i === count - 1
+      ? new Date(maxMs + 1).toISOString()
+      : new Date(minMs + (i + 1) * step).toISOString()
+    ranges.push({ from, to })
+  }
+  return ranges
+}
+
+export function stringToUint64(s: string): bigint {
+  let result = 0n
+  const bytes = Math.min(s.length, 8)
+  for (let i = 0; i < bytes; i++) {
+    result = (result << 8n) | BigInt(s.charCodeAt(i))
+  }
+  // Pad remaining bytes with zeros
+  for (let i = bytes; i < 8; i++) {
+    result = result << 8n
+  }
+  return result
+}
+
+export function uint64ToString(n: bigint): string {
+  const chars: string[] = []
+  for (let i = 7; i >= 0; i--) {
+    const byte = Number((n >> BigInt(i * 8)) & 0xffn)
+    chars.push(String.fromCharCode(byte))
+  }
+  // Trim trailing NUL bytes (padding from stringToUint64 for short strings)
+  let end = chars.length
+  while (end > 0 && chars[end - 1] === '\0') end--
+  return chars.slice(0, end).join('')
+}
+
+export function splitStringRange(min: string, max: string, count: number): Array<{ from: string; to: string }> {
+  const minVal = stringToUint64(min)
+  const maxVal = stringToUint64(max)
+  const span = maxVal - minVal
+  const step = span / BigInt(count)
+  const ranges: Array<{ from: string; to: string }> = []
+  for (let i = 0; i < count; i++) {
+    const from = uint64ToString(minVal + BigInt(i) * step)
+    const to = i === count - 1
+      ? uint64ToString(maxVal + 1n)
+      : uint64ToString(minVal + BigInt(i + 1) * step)
+    ranges.push({ from, to })
+  }
+  return ranges
+}
+
+export function splitSortKeyRange(
+  category: SortKeyInfo['category'],
+  min: string,
+  max: string,
+  count: number,
+): Array<{ from: string; to: string }> {
+  switch (category) {
+    case 'numeric':
+      return splitNumericRange(Number(min), Number(max), count)
+    case 'datetime':
+      return splitDateTimeRange(min, max, count)
+    case 'string':
+      return splitStringRange(min, max, count)
+  }
+}

--- a/packages/plugin-backfill/src/chunking/sql.ts
+++ b/packages/plugin-backfill/src/chunking/sql.ts
@@ -1,0 +1,247 @@
+import type { PlannedChunk, SortKeyInfo } from './types.js'
+
+function buildSettingsClause(token: string): string {
+  if (token) {
+    return `SETTINGS async_insert=0, insert_deduplication_token='${token}'`
+  }
+  return `SETTINGS async_insert=0`
+}
+
+function buildSortKeyCondition(
+  sortKeyColumn: string,
+  category: SortKeyInfo['category'],
+  from: string,
+  to: string,
+): string {
+  if (category === 'datetime') {
+    return `  AND ${sortKeyColumn} >= parseDateTimeBestEffort('${from}')\n  AND ${sortKeyColumn} < parseDateTimeBestEffort('${to}')`
+  }
+  // numeric and string use direct comparison
+  return `  AND ${sortKeyColumn} >= '${from}'\n  AND ${sortKeyColumn} < '${to}'`
+}
+
+export function buildChunkSql(input: {
+  planId: string
+  chunk: PlannedChunk
+  target: string
+  sortKey?: SortKeyInfo
+  mvAsQuery?: string
+  targetColumns?: string[]
+}): string {
+  const header = `/* chkit backfill plan=${input.planId} chunk=${input.chunk.id} token=${input.chunk.idempotencyToken} */`
+  const settings = buildSettingsClause(input.chunk.idempotencyToken)
+  const { chunk } = input
+
+  if (input.mvAsQuery) {
+    // MV replay: inject partition + sort key filters into the MV's AS query
+    let filtered = injectPartitionFilter(input.mvAsQuery, chunk.partitionId)
+    if (chunk.sortKeyFrom !== undefined && chunk.sortKeyTo !== undefined && input.sortKey) {
+      filtered = injectSortKeyFilter(
+        filtered,
+        input.sortKey.column,
+        input.sortKey.category,
+        chunk.sortKeyFrom,
+        chunk.sortKeyTo,
+      )
+    }
+    if (input.targetColumns?.length) {
+      filtered = rewriteSelectColumns(filtered, input.targetColumns)
+    }
+    return [header, `INSERT INTO ${input.target}`, filtered, settings].join('\n')
+  }
+
+  // Direct table copy
+  const lines = [
+    header,
+    `INSERT INTO ${input.target}`,
+    `SELECT *`,
+    `FROM ${input.target}`,
+    `WHERE _partition_id = '${chunk.partitionId}'`,
+  ]
+
+  if (chunk.sortKeyFrom !== undefined && chunk.sortKeyTo !== undefined && input.sortKey) {
+    lines.push(buildSortKeyCondition(
+      input.sortKey.column,
+      input.sortKey.category,
+      chunk.sortKeyFrom,
+      chunk.sortKeyTo,
+    ))
+  }
+
+  lines.push(settings)
+  return lines.join('\n')
+}
+
+// --- SQL helpers ---
+
+function injectPartitionFilter(query: string, partitionId: string): string {
+  const condition = `_partition_id = '${partitionId}'`
+  return injectWhereCondition(query, condition)
+}
+
+export function injectSortKeyFilter(
+  query: string,
+  sortKeyColumn: string,
+  category: SortKeyInfo['category'],
+  from: string,
+  to: string,
+): string {
+  let condition: string
+  if (category === 'datetime') {
+    condition = `${sortKeyColumn} >= parseDateTimeBestEffort('${from}')\n  AND ${sortKeyColumn} < parseDateTimeBestEffort('${to}')`
+  } else {
+    condition = `${sortKeyColumn} >= '${from}'\n  AND ${sortKeyColumn} < '${to}'`
+  }
+  return injectWhereCondition(query, condition)
+}
+
+function injectWhereCondition(query: string, condition: string): string {
+  const trimmed = query.trimEnd()
+  const upper = trimmed.toUpperCase()
+
+  interface KWHit { keyword: string; position: number }
+  const hits: KWHit[] = []
+  let depth = 0
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]
+    if (ch === '(') { depth++; continue }
+    if (ch === ')') { depth--; continue }
+    if (ch === "'") {
+      i++
+      while (i < trimmed.length && trimmed[i] !== "'") {
+        if (trimmed[i] === '\\') i++
+        i++
+      }
+      continue
+    }
+    if (depth !== 0) continue
+
+    if (i > 0 && /\S/.test(trimmed[i - 1] ?? '')) continue
+
+    const rest = upper.slice(i)
+    for (const kw of ['WHERE', 'GROUP BY', 'HAVING', 'ORDER BY', 'QUALIFY', 'LIMIT', 'SETTINGS']) {
+      if (rest.startsWith(kw) && (i + kw.length >= trimmed.length || /\s/.test(trimmed[i + kw.length] ?? ''))) {
+        hits.push({ keyword: kw, position: i })
+        break
+      }
+    }
+  }
+
+  const whereHit = hits.find(h => h.keyword === 'WHERE')
+  const trailingKeywords = ['GROUP BY', 'HAVING', 'ORDER BY', 'QUALIFY', 'LIMIT', 'SETTINGS']
+  const firstTrailing = hits
+    .filter(h => trailingKeywords.includes(h.keyword))
+    .filter(h => !whereHit || h.position > whereHit.position)[0]
+
+  const insertAt = firstTrailing ? firstTrailing.position : trimmed.length
+  const before = trimmed.slice(0, insertAt).trimEnd()
+  const after = trimmed.slice(insertAt)
+
+  if (whereHit) {
+    return `${before}\n  AND ${condition}${after ? `\n${after}` : ''}`
+  }
+  return `${before}\nWHERE ${condition}${after ? `\n${after}` : ''}`
+}
+
+export function rewriteSelectColumns(query: string, targetColumns: string[]): string {
+  const trimmed = query.trimEnd()
+  const upper = trimmed.toUpperCase()
+
+  let selectPos = -1
+  let fromPos = -1
+  let depth = 0
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]
+    if (ch === '(') { depth++; continue }
+    if (ch === ')') { depth--; continue }
+    if (ch === "'") {
+      i++
+      while (i < trimmed.length && trimmed[i] !== "'") {
+        if (trimmed[i] === '\\') i++
+        i++
+      }
+      continue
+    }
+    if (depth !== 0) continue
+
+    if (i > 0 && /\S/.test(trimmed[i - 1] ?? '')) continue
+
+    const rest = upper.slice(i)
+    if (selectPos === -1 && rest.startsWith('SELECT') && (i + 6 >= trimmed.length || /\s/.test(trimmed[i + 6] ?? ''))) {
+      selectPos = i
+    } else if (selectPos !== -1 && fromPos === -1 && rest.startsWith('FROM') && (i + 4 >= trimmed.length || /\s/.test(trimmed[i + 4] ?? ''))) {
+      fromPos = i
+    }
+  }
+
+  if (selectPos === -1 || fromPos === -1) return query
+
+  const projStart = selectPos + 6
+  const projText = trimmed.slice(projStart, fromPos).trim()
+
+  const items: string[] = []
+  let itemStart = 0
+  depth = 0
+
+  for (let i = 0; i < projText.length; i++) {
+    const ch = projText[i]
+    if (ch === '(') { depth++; continue }
+    if (ch === ')') { depth--; continue }
+    if (ch === "'") {
+      i++
+      while (i < projText.length && projText[i] !== "'") {
+        if (projText[i] === '\\') i++
+        i++
+      }
+      continue
+    }
+    if (depth === 0 && ch === ',') {
+      items.push(projText.slice(itemStart, i).trim())
+      itemStart = i + 1
+    }
+  }
+  items.push(projText.slice(itemStart).trim())
+
+  const aliasMap = new Map<string, string>()
+  for (const item of items) {
+    if (item === '*') continue
+
+    const itemUpper = item.toUpperCase()
+    let asPos = -1
+    let d = 0
+
+    for (let i = 0; i < item.length; i++) {
+      const ch = item[i]
+      if (ch === '(') { d++; continue }
+      if (ch === ')') { d--; continue }
+      if (ch === "'") {
+        i++
+        while (i < item.length && item[i] !== "'") {
+          if (item[i] === '\\') i++
+          i++
+        }
+        continue
+      }
+      if (d !== 0) continue
+      if (i > 0 && /\S/.test(item[i - 1] ?? '')) continue
+
+      const rest = itemUpper.slice(i)
+      if (rest.startsWith('AS') && (i + 2 >= item.length || /\s/.test(item[i + 2] ?? ''))) {
+        asPos = i
+      }
+    }
+
+    if (asPos !== -1) {
+      const alias = item.slice(asPos + 2).trim()
+      aliasMap.set(alias, item)
+    }
+  }
+
+  const rewrittenCols = targetColumns.map(col => aliasMap.get(col) ?? col)
+
+  const before = trimmed.slice(0, projStart)
+  const after = trimmed.slice(fromPos)
+  return `${before} ${rewrittenCols.join(', ')}\n${after}`
+}

--- a/packages/plugin-backfill/src/chunking/types.ts
+++ b/packages/plugin-backfill/src/chunking/types.ts
@@ -1,0 +1,31 @@
+export interface PartitionInfo {
+  partitionId: string
+  rows: number
+  bytesOnDisk: number
+  minTime: string
+  maxTime: string
+}
+
+export interface SortKeyInfo {
+  column: string
+  type: string
+  category: 'numeric' | 'datetime' | 'string'
+}
+
+export interface ChunkBoundary {
+  partitionId: string
+  sortKeyFrom?: string
+  sortKeyTo?: string
+  estimatedBytes: number
+}
+
+export interface PlannedChunk {
+  id: string
+  partitionId: string
+  sortKeyFrom?: string
+  sortKeyTo?: string
+  estimatedBytes: number
+  idempotencyToken: string
+  from: string
+  to: string
+}

--- a/packages/plugin-backfill/src/executor.ts
+++ b/packages/plugin-backfill/src/executor.ts
@@ -1,0 +1,123 @@
+/**
+ * Generic work-item execution engine with retries, exponential backoff,
+ * and AbortSignal support.  Agnostic to backfill state, SQL, or ClickHouse —
+ * it simply iterates a list of items and calls an `execute` function for each.
+ */
+
+export interface WorkItem {
+  id: string
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped'
+  attempts: number
+}
+
+export interface ExecutorOptions {
+  maxRetries: number
+  retryDelayMs: number
+  // maxParallelChunks: number  // TODO: future concurrency support
+}
+
+export type ProgressEvent = 'item_started' | 'item_done' | 'item_retry' | 'item_failed'
+
+export interface ExecutorHooks<T extends WorkItem> {
+  onProgress?: (item: T, event: ProgressEvent, meta?: { error?: string; attempt?: number; nextAttempt?: number }) => Promise<void>
+}
+
+export interface ExecutorResult<T extends WorkItem> {
+  completed: T[]
+  failed: T[]
+  aborted: boolean
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      resolve()
+    }, { once: true })
+  })
+}
+
+async function executeItem<T extends WorkItem>(
+  item: T,
+  execute: (item: T, signal?: AbortSignal) => Promise<void>,
+  options: ExecutorOptions,
+  hooks?: ExecutorHooks<T>,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  while (item.attempts < options.maxRetries) {
+    if (signal?.aborted) return false
+
+    item.status = 'running'
+    item.attempts += 1
+
+    await hooks?.onProgress?.(item, 'item_started', { attempt: item.attempts })
+
+    let error: string | undefined
+
+    try {
+      await execute(item, signal)
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    }
+
+    if (!error) {
+      item.status = 'done'
+      await hooks?.onProgress?.(item, 'item_done', { attempt: item.attempts })
+      return true
+    }
+
+    if (item.attempts >= options.maxRetries) {
+      item.status = 'failed'
+      await hooks?.onProgress?.(item, 'item_failed', { error, attempt: item.attempts })
+      return false
+    }
+
+    item.status = 'pending'
+    await hooks?.onProgress?.(item, 'item_retry', { error, attempt: item.attempts, nextAttempt: item.attempts + 1 })
+
+    if (options.retryDelayMs > 0) {
+      const delay = options.retryDelayMs * 2 ** (item.attempts - 1)
+      await sleep(delay, signal)
+    }
+  }
+
+  // Should only be reached when maxRetries <= 0
+  item.status = 'failed'
+  return false
+}
+
+export async function executeWorkItems<T extends WorkItem>(
+  items: T[],
+  execute: (item: T, signal?: AbortSignal) => Promise<void>,
+  options: ExecutorOptions,
+  hooks?: ExecutorHooks<T>,
+  signal?: AbortSignal,
+): Promise<ExecutorResult<T>> {
+  const completed: T[] = []
+  const failed: T[] = []
+  let aborted = false
+
+  for (const item of items) {
+    if (signal?.aborted) {
+      aborted = true
+      break
+    }
+
+    const ok = await executeItem(item, execute, options, hooks, signal)
+    if (ok) {
+      completed.push(item)
+    } else if (signal?.aborted) {
+      aborted = true
+      break
+    } else {
+      failed.push(item)
+    }
+  }
+
+  return { completed, failed, aborted }
+}

--- a/packages/plugin-backfill/src/index.ts
+++ b/packages/plugin-backfill/src/index.ts
@@ -1,5 +1,12 @@
 import './table-config.js'
 
 export { backfill, createBackfillPlugin } from './plugin.js'
+export { executeWorkItems } from './executor.js'
+export type { ExecutorHooks, ExecutorOptions, ExecutorResult, ProgressEvent, WorkItem } from './executor.js'
 export type { BackfillPlugin, BackfillPluginOptions, BackfillPluginRegistration } from './types.js'
 export type { BackfillTableConfig } from './table-config.js'
+
+export { analyzeAndChunk, analyzeTable, buildPlannedChunks } from './chunking/index.js'
+export type { AnalyzeAndChunkInput, AnalyzeAndChunkResult, AnalyzeTableInput, AnalyzeTableResult } from './chunking/index.js'
+export { buildChunkSql, injectSortKeyFilter, rewriteSelectColumns } from './chunking/sql.js'
+export type { PlannedChunk } from './chunking/types.js'

--- a/packages/plugin-backfill/src/index.ts
+++ b/packages/plugin-backfill/src/index.ts
@@ -1,12 +1,5 @@
 import './table-config.js'
 
 export { backfill, createBackfillPlugin } from './plugin.js'
-export { executeWorkItems } from './executor.js'
-export type { ExecutorHooks, ExecutorOptions, ExecutorResult, ProgressEvent, WorkItem } from './executor.js'
 export type { BackfillPlugin, BackfillPluginOptions, BackfillPluginRegistration } from './types.js'
 export type { BackfillTableConfig } from './table-config.js'
-
-export { analyzeAndChunk, analyzeTable, buildPlannedChunks } from './chunking/index.js'
-export type { AnalyzeAndChunkInput, AnalyzeAndChunkResult, AnalyzeTableInput, AnalyzeTableResult } from './chunking/index.js'
-export { buildChunkSql, injectSortKeyFilter, rewriteSelectColumns } from './chunking/sql.js'
-export type { PlannedChunk } from './chunking/types.js'

--- a/packages/plugin-backfill/src/options.test.ts
+++ b/packages/plugin-backfill/src/options.test.ts
@@ -6,7 +6,7 @@ describe('@chkit/plugin-backfill options', () => {
   test('normalizes documented defaults', () => {
     const options = normalizeBackfillOptions()
 
-    expect(options.defaults.chunkHours).toBe(6)
+    expect(options.defaults.maxChunkBytes).toBe(10 * 1024 ** 3)
     expect(options.defaults.maxParallelChunks).toBe(1)
     expect(options.defaults.maxRetriesPerChunk).toBe(3)
     expect(options.defaults.requireIdempotencyToken).toBe(true)
@@ -31,7 +31,7 @@ describe('@chkit/plugin-backfill options', () => {
     const base = normalizeBackfillOptions()
     const merged = mergeOptions(base, { defaults: { timeColumn: 'session_date' } })
 
-    expect(merged.defaults.chunkHours).toBe(6)
+    expect(merged.defaults.maxChunkBytes).toBe(10 * 1024 ** 3)
     expect(merged.defaults.maxParallelChunks).toBe(1)
     expect(merged.defaults.maxRetriesPerChunk).toBe(3)
     expect(merged.defaults.requireIdempotencyToken).toBe(true)

--- a/packages/plugin-backfill/src/options.ts
+++ b/packages/plugin-backfill/src/options.ts
@@ -3,7 +3,7 @@ import type { BackfillPluginOptions, NormalizedBackfillDefaults, NormalizedBackf
 
 const DEFAULT_OPTIONS: NormalizedBackfillPluginOptions = {
   defaults: {
-    chunkHours: 6,
+    maxChunkBytes: 10 * 1024 ** 3, // 10 GiB
     maxParallelChunks: 1,
     maxRetriesPerChunk: 3,
     retryDelayMs: 1000,
@@ -174,9 +174,6 @@ export function mergeOptions(
 }
 
 export function validateBaseOptions(options: NormalizedBackfillPluginOptions): void {
-  if (typeof options.defaults.chunkHours !== 'number' || !Number.isFinite(options.defaults.chunkHours)) {
-    throw new BackfillConfigError('defaults.chunkHours is required and must be a finite number.')
-  }
   if (
     typeof options.defaults.maxParallelChunks !== 'number' ||
     !Number.isFinite(options.defaults.maxParallelChunks)
@@ -189,15 +186,11 @@ export function validateBaseOptions(options: NormalizedBackfillPluginOptions): v
   ) {
     throw new BackfillConfigError('defaults.maxRetriesPerChunk is required and must be a finite number.')
   }
-  if (typeof options.limits.minChunkMinutes !== 'number' || !Number.isFinite(options.limits.minChunkMinutes)) {
-    throw new BackfillConfigError('limits.minChunkMinutes is required and must be a finite number.')
-  }
-  if (typeof options.limits.maxWindowHours !== 'number' || !Number.isFinite(options.limits.maxWindowHours)) {
-    throw new BackfillConfigError('limits.maxWindowHours is required and must be a finite number.')
-  }
-  if (options.defaults.chunkHours * 60 < options.limits.minChunkMinutes) {
-    throw new BackfillConfigError(
-      `defaults.chunkHours (${options.defaults.chunkHours}) must be >= limits.minChunkMinutes (${options.limits.minChunkMinutes}m).`
-    )
+  if (
+    typeof options.defaults.maxChunkBytes !== 'number' ||
+    !Number.isFinite(options.defaults.maxChunkBytes) ||
+    options.defaults.maxChunkBytes <= 0
+  ) {
+    throw new BackfillConfigError('defaults.maxChunkBytes is required and must be a positive number.')
   }
 }

--- a/packages/plugin-backfill/src/partition-planner.test.ts
+++ b/packages/plugin-backfill/src/partition-planner.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildChunkBoundaries } from './chunking/build.js'
+import { buildChunkSql } from './chunking/sql.js'
+import { buildPlannedChunks } from './chunking/analyze.js'
+import type { PartitionInfo, SortKeyInfo } from './types.js'
+
+const GiB = 1024 ** 3
+
+function buildChunksWithSql(input: {
+  planId: string
+  target: string
+  partitions: PartitionInfo[]
+  maxChunkBytes: number
+  sortKey?: SortKeyInfo
+  sortKeyRanges?: Map<string, { min: string; max: string }>
+  requireIdempotencyToken: boolean
+  mvAsQuery?: string
+  targetColumns?: string[]
+}) {
+  const boundaries = buildChunkBoundaries({
+    partitions: input.partitions,
+    maxChunkBytes: input.maxChunkBytes,
+    sortKey: input.sortKey,
+    sortKeyRanges: input.sortKeyRanges,
+  })
+
+  const planned = buildPlannedChunks({
+    planId: input.planId,
+    partitions: input.partitions,
+    boundaries,
+    requireIdempotencyToken: input.requireIdempotencyToken,
+  })
+
+  return planned.map(chunk => ({
+    ...chunk,
+    sqlTemplate: buildChunkSql({
+      planId: input.planId,
+      chunk,
+      target: input.target,
+      sortKey: input.sortKey,
+      mvAsQuery: input.mvAsQuery,
+      targetColumns: input.targetColumns,
+    }),
+  }))
+}
+
+describe('buildChunksWithSql', () => {
+  const basePlanId = 'abc1234567890123'
+
+  test('small partition produces one chunk with _partition_id filter only', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 1000, bytesOnDisk: 5 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T23:59:59.000Z' },
+    ]
+
+    const chunks = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      requireIdempotencyToken: true,
+    })
+
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.sqlTemplate).toContain("WHERE _partition_id = '202501'")
+    expect(chunks[0]?.partitionId).toBe('202501')
+    expect(chunks[0]?.estimatedBytes).toBe(5 * GiB)
+  })
+
+  test('large partition with datetime sort key produces sub-chunks with parseDateTimeBestEffort', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 10000, bytesOnDisk: 30 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+    const sortKey: SortKeyInfo = { column: 'event_time', type: 'DateTime', category: 'datetime' }
+    const sortKeyRanges = new Map([
+      ['202501', { min: '2025-01-01 00:00:00', max: '2025-01-31 00:00:00' }],
+    ])
+
+    const chunks = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      sortKey,
+      sortKeyRanges,
+      requireIdempotencyToken: true,
+    })
+
+    expect(chunks).toHaveLength(3)
+    for (const chunk of chunks) {
+      expect(chunk.sqlTemplate).toContain("WHERE _partition_id = '202501'")
+      expect(chunk.sqlTemplate).toContain('event_time >= parseDateTimeBestEffort(')
+      expect(chunk.sqlTemplate).toContain('event_time < parseDateTimeBestEffort(')
+      expect(chunk.partitionId).toBe('202501')
+    }
+  })
+
+  test('chunk IDs are deterministic for same input', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 1000, bytesOnDisk: 5 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+
+    const first = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      requireIdempotencyToken: true,
+    })
+
+    const second = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      requireIdempotencyToken: true,
+    })
+
+    expect(first[0]?.id).toBe(second[0]?.id)
+    expect(first[0]?.idempotencyToken).toBe(second[0]?.idempotencyToken)
+  })
+
+  test('idempotency tokens are empty when not required', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 1000, bytesOnDisk: 5 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+
+    const chunks = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      requireIdempotencyToken: false,
+    })
+
+    expect(chunks[0]?.idempotencyToken).toBe('')
+    expect(chunks[0]?.sqlTemplate).not.toContain('insert_deduplication_token')
+  })
+
+  test('SQL templates include correct INSERT and SELECT structure', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 1000, bytesOnDisk: 5 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+
+    const chunks = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      requireIdempotencyToken: true,
+    })
+
+    const sql = chunks[0]?.sqlTemplate ?? ''
+    expect(sql).toContain(`/* chkit backfill plan=${basePlanId}`)
+    expect(sql).toContain('INSERT INTO default.events')
+    expect(sql).toContain('SELECT *')
+    expect(sql).toContain('FROM default.events')
+    expect(sql).toContain('SETTINGS async_insert=0')
+  })
+
+  test('numeric sort key sub-chunks use direct comparison', () => {
+    const partitions: PartitionInfo[] = [
+      { partitionId: '202501', rows: 10000, bytesOnDisk: 20 * GiB, minTime: '2025-01-01T00:00:00.000Z', maxTime: '2025-01-31T00:00:00.000Z' },
+    ]
+    const sortKey: SortKeyInfo = { column: 'id', type: 'UInt64', category: 'numeric' }
+    const sortKeyRanges = new Map([
+      ['202501', { min: '100', max: '200' }],
+    ])
+
+    const chunks = buildChunksWithSql({
+      planId: basePlanId,
+      target: 'default.events',
+      partitions,
+      maxChunkBytes: 10 * GiB,
+      sortKey,
+      sortKeyRanges,
+      requireIdempotencyToken: false,
+    })
+
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0]?.sqlTemplate).toContain("id >= '100'")
+    expect(chunks[0]?.sqlTemplate).toContain("id < '150'")
+    expect(chunks[0]?.sqlTemplate).not.toContain('parseDateTimeBestEffort')
+  })
+})

--- a/packages/plugin-backfill/src/payload.ts
+++ b/packages/plugin-backfill/src/payload.ts
@@ -14,10 +14,13 @@ export function planPayload(output: BuildBackfillPlanOutput): {
   from: string
   to: string
   chunkCount: number
-  chunkHours: number
-  timeColumn: string
+  maxChunkBytes?: number
+  sortKeyColumn?: string
   planPath: string
   existed: boolean
+  strategy?: string
+  partitionCount?: number
+  totalBytes?: number
 } {
   return {
     ok: true,
@@ -27,10 +30,15 @@ export function planPayload(output: BuildBackfillPlanOutput): {
     from: output.plan.from,
     to: output.plan.to,
     chunkCount: output.plan.chunks.length,
-    chunkHours: output.plan.options.chunkHours,
-    timeColumn: output.plan.options.timeColumn,
+    maxChunkBytes: output.plan.options.maxChunkBytes,
+    sortKeyColumn: output.plan.options.sortKeyColumn,
     planPath: output.planPath,
     existed: output.existed,
+    strategy: output.plan.strategy,
+    partitionCount: output.plan.partitions?.length,
+    totalBytes: output.plan.partitions
+      ? output.plan.partitions.reduce((sum, p) => sum + p.bytesOnDisk, 0)
+      : undefined,
   }
 }
 

--- a/packages/plugin-backfill/src/payload.ts
+++ b/packages/plugin-backfill/src/payload.ts
@@ -17,7 +17,6 @@ export function planPayload(output: BuildBackfillPlanOutput): {
   maxChunkBytes?: number
   sortKeyColumn?: string
   planPath: string
-  existed: boolean
   strategy?: string
   partitionCount?: number
   totalBytes?: number
@@ -33,7 +32,6 @@ export function planPayload(output: BuildBackfillPlanOutput): {
     maxChunkBytes: output.plan.options.maxChunkBytes,
     sortKeyColumn: output.plan.options.sortKeyColumn,
     planPath: output.planPath,
-    existed: output.existed,
     strategy: output.plan.strategy,
     partitionCount: output.plan.partitions?.length,
     totalBytes: output.plan.partitions

--- a/packages/plugin-backfill/src/planner.test.ts
+++ b/packages/plugin-backfill/src/planner.test.ts
@@ -33,7 +33,7 @@ function createMockQuery(opts: {
 }
 
 describe('@chkit/plugin-backfill planning', () => {
-  test('builds deterministic plan id and chunks for identical input', async () => {
+  test('each plan gets a unique random id', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -71,10 +71,8 @@ describe('@chkit/plugin-backfill planning', () => {
         clickhouseQuery: mockQuery,
       })
 
-      expect(first.plan.planId).toBe(second.plan.planId)
-      expect(first.plan.chunks).toEqual(second.plan.chunks)
-      expect(first.existed).toBe(false)
-      expect(second.existed).toBe(true)
+      expect(first.plan.planId).not.toBe(second.plan.planId)
+      expect(first.plan.planId).toMatch(/^[a-f0-9]{16}$/)
       expect(first.plan.chunks).toHaveLength(3)
 
       const chunk = first.plan.chunks[0]
@@ -156,7 +154,7 @@ describe('@chkit/plugin-backfill planning', () => {
     }
   })
 
-  test('different sort keys produce different plan IDs', async () => {
+  test('chunk IDs are deterministic within a plan (derived from planId)', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -167,23 +165,20 @@ describe('@chkit/plugin-backfill planning', () => {
       })
       const options = normalizeBackfillOptions({})
 
-      const planA = await buildBackfillPlan({
+      const output = await buildBackfillPlan({
         target: 'app.events',
         configPath,
         config,
         options,
-        clickhouseQuery: createMockQuery({ sortingKey: 'event_time', sortKeyType: 'DateTime' }),
+        clickhouseQuery: createMockQuery(),
       })
 
-      const planB = await buildBackfillPlan({
-        target: 'app.events',
-        configPath,
-        config,
-        options,
-        clickhouseQuery: createMockQuery({ sortingKey: 'created_at', sortKeyType: 'DateTime' }),
-      })
-
-      expect(planA.plan.planId).not.toBe(planB.plan.planId)
+      const chunkIds = output.plan.chunks.map(c => c.id)
+      const uniqueIds = new Set(chunkIds)
+      expect(uniqueIds.size).toBe(chunkIds.length)
+      for (const id of chunkIds) {
+        expect(id).toMatch(/^[a-f0-9]{16}$/)
+      }
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -642,7 +637,7 @@ describe('environment binding in plan', () => {
     }
   })
 
-  test('different environments produce different plan IDs', async () => {
+  test('plan includes environment from different clickhouse configs', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -670,7 +665,9 @@ describe('environment binding in plan', () => {
         clickhouse: { url: 'https://prod.ch.cloud:8443', database: 'analytics' },
       })
 
-      expect(staging.plan.planId).not.toBe(production.plan.planId)
+      expect(staging.plan.environment?.url).toBe('https://staging.ch.cloud:8443')
+      expect(production.plan.environment?.url).toBe('https://prod.ch.cloud:8443')
+      expect(staging.plan.environment?.fingerprint).not.toBe(production.plan.environment?.fingerprint)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/packages/plugin-backfill/src/planner.test.ts
+++ b/packages/plugin-backfill/src/planner.test.ts
@@ -6,8 +6,31 @@ import { tmpdir } from 'node:os'
 import { resolveConfig } from '@chkit/core'
 
 import { normalizeBackfillOptions } from './options.js'
-import { buildBackfillPlan, injectTimeFilter, rewriteSelectColumns } from './planner.js'
+import { buildBackfillPlan } from './planner.js'
+import { injectSortKeyFilter, rewriteSelectColumns } from './chunking/sql.js'
 import { computeBackfillStateDir, computeEnvironmentFingerprint } from './state.js'
+
+function createMockQuery(opts: {
+  partitions?: Array<{ partition_id: string; total_rows: string; total_bytes: string; min_time: string; max_time: string }>
+  sortingKey?: string
+  sortKeyType?: string
+  sortKeyRanges?: Array<{ partition_id: string; min_val: string; max_val: string }>
+} = {}): <T>(sql: string) => Promise<T[]> {
+  const partitions = opts.partitions ?? [
+    { partition_id: '202601', total_rows: '1000', total_bytes: '500000', min_time: '2026-01-01 00:00:00', max_time: '2026-01-01 18:00:00' },
+  ]
+  const sortingKey = opts.sortingKey ?? 'event_time'
+  const sortKeyType = opts.sortKeyType ?? 'DateTime'
+  const sortKeyRanges = opts.sortKeyRanges ?? []
+
+  return async <T>(sql: string) => {
+    if (sql.includes('system.parts')) return partitions as T[]
+    if (sql.includes('system.tables')) return [{ sorting_key: sortingKey }] as T[]
+    if (sql.includes('system.columns')) return [{ type: sortKeyType }] as T[]
+    if (sql.includes('min(') && sql.includes('max(')) return sortKeyRanges as T[]
+    return [] as T[]
+  }
+}
 
 describe('@chkit/plugin-backfill planning', () => {
   test('builds deterministic plan id and chunks for identical input', async () => {
@@ -20,25 +43,32 @@ describe('@chkit/plugin-backfill planning', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery({
+        partitions: [
+          { partition_id: '202601a', total_rows: '500', total_bytes: '250000', min_time: '2026-01-01 00:00:00', max_time: '2026-01-01 06:00:00' },
+          { partition_id: '202601b', total_rows: '500', total_bytes: '250000', min_time: '2026-01-01 06:00:00', max_time: '2026-01-01 12:00:00' },
+          { partition_id: '202601c', total_rows: '500', total_bytes: '250000', min_time: '2026-01-01 12:00:00', max_time: '2026-01-01 18:00:00' },
+        ],
+      })
 
       const first = await buildBackfillPlan({
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T18:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
       const second = await buildBackfillPlan({
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T18:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
       expect(first.plan.planId).toBe(second.plan.planId)
@@ -50,7 +80,6 @@ describe('@chkit/plugin-backfill planning', () => {
       const chunk = first.plan.chunks[0]
       expect(chunk?.idempotencyToken.length).toBe(64)
       expect(chunk?.sqlTemplate).toContain('INSERT INTO app.events')
-      expect(chunk?.sqlTemplate).toContain('parseDateTimeBestEffort(')
       expect(chunk?.sqlTemplate).toContain(`insert_deduplication_token='${chunk?.idempotencyToken}'`)
     } finally {
       await rm(dir, { recursive: true, force: true })
@@ -67,16 +96,23 @@ describe('@chkit/plugin-backfill planning', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery({
+        partitions: [
+          { partition_id: '202601a', total_rows: '250', total_bytes: '125000', min_time: '2026-01-01 00:00:00', max_time: '2026-01-01 02:00:00' },
+          { partition_id: '202601b', total_rows: '250', total_bytes: '125000', min_time: '2026-01-01 02:00:00', max_time: '2026-01-01 04:00:00' },
+          { partition_id: '202601c', total_rows: '250', total_bytes: '125000', min_time: '2026-01-01 04:00:00', max_time: '2026-01-01 06:00:00' },
+          { partition_id: '202601d', total_rows: '250', total_bytes: '125000', min_time: '2026-01-01 06:00:00', max_time: '2026-01-01 07:00:00' },
+        ],
+      })
 
       const output = await buildBackfillPlan({
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T07:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
-        chunkHours: 2,
+        clickhouseQuery: mockQuery,
       })
 
       const raw = await readFile(output.planPath, 'utf8')
@@ -89,7 +125,7 @@ describe('@chkit/plugin-backfill planning', () => {
     }
   })
 
-  test('uses provided time column name in SQL template', async () => {
+  test('detects sort key column from ClickHouse metadata', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -99,28 +135,28 @@ describe('@chkit/plugin-backfill planning', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery({
+        sortingKey: 'session_date',
+        sortKeyType: 'Date',
+      })
 
       const output = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'session_date',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
-      const chunk = output.plan.chunks[0]
-      expect(chunk?.sqlTemplate).toContain("WHERE session_date >= parseDateTimeBestEffort('")
-      expect(chunk?.sqlTemplate).toContain("AND session_date < parseDateTimeBestEffort('")
-      expect(chunk?.sqlTemplate).not.toContain('event_time')
-      expect(output.plan.options.timeColumn).toBe('session_date')
+      expect(output.plan.sortKey?.column).toBe('session_date')
+      expect(output.plan.sortKey?.category).toBe('datetime')
+      expect(output.plan.options.sortKeyColumn).toBe('session_date')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
   })
 
-  test('different time columns produce different plan IDs', async () => {
+  test('different sort keys produce different plan IDs', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -133,22 +169,18 @@ describe('@chkit/plugin-backfill planning', () => {
 
       const planA = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery({ sortingKey: 'event_time', sortKeyType: 'DateTime' }),
       })
 
       const planB = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'created_at',
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery({ sortingKey: 'created_at', sortKeyType: 'DateTime' }),
       })
 
       expect(planA.plan.planId).not.toBe(planB.plan.planId)
@@ -175,7 +207,7 @@ describe('@chkit/plugin-backfill planning', () => {
     expect(overriddenDir).toBe(resolve('/tmp/project/custom-state'))
   })
 
-  test('generates MV replay SQL with inline time filter when schema contains materialized view', async () => {
+  test('generates MV replay SQL when schema contains materialized view', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
     const schemaPath = join(dir, 'schema.ts')
@@ -210,28 +242,23 @@ export const events_mv = {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery()
 
       const output = await buildBackfillPlan({
         target: 'app.events_agg',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
       expect(output.plan.strategy).toBe('mv_replay')
 
       const chunk = output.plan.chunks[0]
       expect(chunk?.sqlTemplate).toContain('INSERT INTO app.events_agg')
-      // Time filter is injected directly into the MV query (before GROUP BY), not via CTE
       expect(chunk?.sqlTemplate).not.toContain('WITH _backfill_source AS (')
-      expect(chunk?.sqlTemplate).not.toContain('SELECT * FROM _backfill_source')
       expect(chunk?.sqlTemplate).toContain('SELECT toStartOfHour(event_time)')
       expect(chunk?.sqlTemplate).toContain('FROM app.events')
-      expect(chunk?.sqlTemplate).toContain("WHERE event_time >= parseDateTimeBestEffort('")
-      expect(chunk?.sqlTemplate).toContain("AND event_time < parseDateTimeBestEffort('")
       expect(chunk?.sqlTemplate).toContain('GROUP BY event_time')
       expect(chunk?.sqlTemplate).toContain('SETTINGS async_insert=0')
       expect(chunk?.sqlTemplate).toContain(`insert_deduplication_token='${chunk?.idempotencyToken}'`)
@@ -279,24 +306,21 @@ export const sessions_mv = {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery()
 
       const output = await buildBackfillPlan({
         target: 'app.session_analytics',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'session_date',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
       expect(output.plan.strategy).toBe('mv_replay')
 
       const chunk = output.plan.chunks[0]
-      // INSERT should NOT include explicit column list (rewriteSelectColumns handles ordering)
       expect(chunk?.sqlTemplate).toContain('INSERT INTO app.session_analytics')
       expect(chunk?.sqlTemplate).not.toContain('INSERT INTO app.session_analytics (')
-      // SELECT must be rewritten with columns in target table order
       expect(chunk?.sqlTemplate).toContain(
         "SELECT session_date, session_id, extractAll(content, 'skill') AS skills, extractAll(content, 'cmd') AS slash_commands, ingested_at"
       )
@@ -317,15 +341,14 @@ export const sessions_mv = {
       const options = normalizeBackfillOptions({
         defaults: { requireIdempotencyToken: false },
       })
+      const mockQuery = createMockQuery()
 
       const output = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
       const chunk = output.plan.chunks[0]
@@ -337,7 +360,7 @@ export const sessions_mv = {
     }
   })
 
-  test('falls back to table strategy when no schema matches MV target', async () => {
+  test('uses partition strategy when no MV is found', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -347,25 +370,49 @@ export const sessions_mv = {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery()
 
       const output = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: mockQuery,
       })
 
-      expect(output.plan.strategy).toBe('table')
+      expect(output.plan.strategy).toBe('partition')
 
       const chunk = output.plan.chunks[0]
       expect(chunk?.sqlTemplate).toContain('INSERT INTO app.events')
       expect(chunk?.sqlTemplate).toContain('FROM app.events')
-      expect(chunk?.sqlTemplate).toContain('parseDateTimeBestEffort(')
+      expect(chunk?.sqlTemplate).toContain('_partition_id')
       expect(chunk?.sqlTemplate).toContain('SETTINGS async_insert=0')
-      expect(chunk?.sqlTemplate).not.toContain('_backfill_source')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('throws when no partitions found', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
+    const configPath = join(dir, 'clickhouse.config.ts')
+
+    try {
+      const config = resolveConfig({
+        schema: './schema.ts',
+        metaDir: './chkit/meta',
+      })
+      const options = normalizeBackfillOptions({})
+      const mockQuery = createMockQuery({ partitions: [] })
+
+      await expect(
+        buildBackfillPlan({
+          target: 'app.events',
+          configPath,
+          config,
+          options,
+          clickhouseQuery: mockQuery,
+        })
+      ).rejects.toThrow('No partitions found')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -418,39 +465,37 @@ describe('rewriteSelectColumns', () => {
   })
 })
 
-describe('injectTimeFilter', () => {
+describe('injectSortKeyFilter', () => {
   const from = '2025-01-01T00:00:00.000Z'
   const to = '2025-01-01T06:00:00.000Z'
 
-  test('injects WHERE before GROUP BY when query has no WHERE clause', () => {
+  test('injects WHERE before GROUP BY for datetime filter', () => {
     const query = 'SELECT toStartOfHour(event_time) AS event_time, count() AS count FROM app.events GROUP BY event_time'
-    const result = injectTimeFilter(query, 'event_time', from, to)
+    const result = injectSortKeyFilter(query, 'event_time', 'datetime', from, to)
 
     expect(result).toContain("WHERE event_time >= parseDateTimeBestEffort('2025-01-01T00:00:00.000Z')")
     expect(result).toContain("AND event_time < parseDateTimeBestEffort('2025-01-01T06:00:00.000Z')")
     expect(result).toContain('GROUP BY event_time')
-    // WHERE must appear before GROUP BY
     expect(result.indexOf('WHERE')).toBeLessThan(result.indexOf('GROUP BY'))
   })
 
   test('appends AND to existing WHERE clause', () => {
     const query = 'SELECT * FROM app.events WHERE status = 1'
-    const result = injectTimeFilter(query, 'event_time', from, to)
+    const result = injectSortKeyFilter(query, 'event_time', 'datetime', from, to)
 
     expect(result).toContain('WHERE status = 1')
     expect(result).toContain("AND event_time >= parseDateTimeBestEffort('")
     expect(result).toContain("AND event_time < parseDateTimeBestEffort('")
-    // Should NOT add a second WHERE
     expect(result.match(/WHERE/g)?.length).toBe(1)
   })
 
-  test('appends AND before GROUP BY when query has WHERE and GROUP BY', () => {
-    const query = 'SELECT id, count() AS c FROM app.events WHERE status = 1 GROUP BY id'
-    const result = injectTimeFilter(query, 'ts', from, to)
+  test('numeric sort key uses direct comparison', () => {
+    const query = 'SELECT * FROM app.events WHERE status = 1'
+    const result = injectSortKeyFilter(query, 'id', 'numeric', '100', '200')
 
-    expect(result).toContain('WHERE status = 1')
-    expect(result).toContain("AND ts >= parseDateTimeBestEffort('")
-    expect(result.indexOf('AND ts')).toBeLessThan(result.indexOf('GROUP BY'))
+    expect(result).toContain("AND id >= '100'")
+    expect(result).toContain("AND id < '200'")
+    expect(result).not.toContain('parseDateTimeBestEffort')
   })
 
   test('handles query with WHERE and QUALIFY', () => {
@@ -460,14 +505,14 @@ describe('injectTimeFilter', () => {
       'WHERE length(timestamps) > 0',
       "QUALIFY ROW_NUMBER() OVER (PARTITION BY s.id ORDER BY s.ts DESC) = 1",
     ].join('\n')
-    const result = injectTimeFilter(query, 'session_date', from, to)
+    const result = injectSortKeyFilter(query, 'session_date', 'datetime', from, to)
 
     expect(result).toContain('WHERE length(timestamps) > 0')
     expect(result).toContain("AND session_date >= parseDateTimeBestEffort('")
     expect(result.indexOf('AND session_date')).toBeLessThan(result.indexOf('QUALIFY'))
   })
 
-  test('handles MV query with WITH column expressions (Array-producing aliases)', () => {
+  test('handles MV query with WITH column expressions', () => {
     const query = [
       'WITH',
       "  arrayDistinct(arrayFilter(x -> x != '', extractAll(content, '\\\\w+'))) AS _skills",
@@ -478,18 +523,16 @@ describe('injectTimeFilter', () => {
       'FROM app.sessions',
       'WHERE length(content) > 0',
     ].join('\n')
-    const result = injectTimeFilter(query, 'ts', from, to)
+    const result = injectSortKeyFilter(query, 'ts', 'datetime', from, to)
 
-    // Should append AND, not add new WHERE
     expect(result.match(/WHERE/g)?.length).toBe(1)
     expect(result).toContain("AND ts >= parseDateTimeBestEffort('")
-    // WITH clause must remain intact
     expect(result).toContain('arrayDistinct')
   })
 
   test('injects WHERE at end when query has no WHERE and no trailing clauses', () => {
     const query = 'SELECT * FROM app.events'
-    const result = injectTimeFilter(query, 'event_time', from, to)
+    const result = injectSortKeyFilter(query, 'event_time', 'datetime', from, to)
 
     expect(result).toContain("WHERE event_time >= parseDateTimeBestEffort('")
     expect(result).toContain("AND event_time < parseDateTimeBestEffort('")
@@ -497,12 +540,10 @@ describe('injectTimeFilter', () => {
 
   test('ignores WHERE inside parenthesized subquery', () => {
     const query = 'SELECT * FROM (SELECT * FROM app.events WHERE inner = 1) AS sub GROUP BY id'
-    const result = injectTimeFilter(query, 'ts', from, to)
+    const result = injectSortKeyFilter(query, 'ts', 'datetime', from, to)
 
-    // The inner WHERE is inside parens, so it must inject a new top-level WHERE before GROUP BY
     expect(result).toContain("WHERE ts >= parseDateTimeBestEffort('")
     expect(result.indexOf("WHERE ts")).toBeLessThan(result.indexOf('GROUP BY'))
-    // Inner WHERE must remain intact
     expect(result).toContain('WHERE inner = 1')
   })
 })
@@ -560,13 +601,11 @@ describe('environment binding in plan', () => {
 
       const output = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
         clickhouse: { url: 'https://my-cluster.ch.cloud:8443', database: 'analytics' },
+        clickhouseQuery: createMockQuery(),
       })
 
       expect(output.plan.environment).toBeDefined()
@@ -578,7 +617,7 @@ describe('environment binding in plan', () => {
     }
   })
 
-  test('plan omits environment when clickhouse is not provided', async () => {
+  test('plan omits environment when clickhouse connection info is not provided', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -591,12 +630,10 @@ describe('environment binding in plan', () => {
 
       const output = await buildBackfillPlan({
         target: 'app.events',
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       expect(output.plan.environment).toBeUndefined()
@@ -617,12 +654,10 @@ describe('environment binding in plan', () => {
       const options = normalizeBackfillOptions({})
       const common = {
         target: 'app.events' as const,
-        from: '2026-01-01T00:00:00.000Z',
-        to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       }
 
       const staging = await buildBackfillPlan({

--- a/packages/plugin-backfill/src/planner.ts
+++ b/packages/plugin-backfill/src/planner.ts
@@ -1,10 +1,9 @@
 import { dirname } from 'node:path'
-import { unlink } from 'node:fs/promises'
 
 import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 import type { ResolvedChxConfig } from '@chkit/core'
 
-import { analyzeTable, buildPlannedChunks } from './chunking/index.js'
+import { analyzeAndChunk } from './chunking/analyze.js'
 import { buildChunkSql } from './chunking/sql.js'
 import { findMvForTarget } from './detect.js'
 import { BackfillConfigError } from './errors.js'
@@ -12,10 +11,6 @@ import {
   backfillPaths,
   computeBackfillStateDir,
   computeEnvironmentFingerprint,
-  hashId,
-  planIdentity,
-  readExistingPlan,
-  stableSerialize,
   writeJson,
 } from './state.js'
 import type {
@@ -35,7 +30,6 @@ export async function buildBackfillPlan(input: {
   config: Pick<ResolvedChxConfig, 'metaDir' | 'schema'>
   options: NormalizedBackfillPluginOptions
   maxChunkBytes?: number
-  force?: boolean
   clickhouse?: { url: string; database: string }
   clickhouseQuery: <T>(sql: string) => Promise<T[]>
 }): Promise<BuildBackfillPlanOutput> {
@@ -47,13 +41,14 @@ export async function buildBackfillPlan(input: {
   const env = computeEnvironmentFingerprint(input.clickhouse)
   const maxChunkBytes = input.maxChunkBytes ?? DEFAULT_MAX_CHUNK_BYTES
 
-  // 1. Analyze table: introspect partitions, sort key, and build chunk boundaries
-  const { partitions, sortKey, boundaries } = await analyzeTable({
+  // 1. Analyze table and build planned chunks
+  const { planId, partitions, sortKey, chunks: plannedChunks } = await analyzeAndChunk({
     database,
     table,
     from: input.from,
     to: input.to,
     maxChunkBytes,
+    requireIdempotencyToken: input.options.defaults.requireIdempotencyToken,
     query: input.clickhouseQuery,
   })
 
@@ -63,26 +58,14 @@ export async function buildBackfillPlan(input: {
     )
   }
 
-  // 2. Compute plan identity (requires partition data for derived time bounds)
   const firstPartition = partitions[0] as PartitionInfo
   const derivedFrom = input.from ?? partitions.reduce((min, p) => (p.minTime < min ? p.minTime : min), firstPartition.minTime)
   const derivedTo = input.to ?? partitions.reduce((max, p) => (p.maxTime > max ? p.maxTime : max), firstPartition.maxTime)
 
-  const chunkParam = `partition:${maxChunkBytes}`
-  const sortKeyColumn = sortKey?.column ?? ''
-  const planId = hashId(planIdentity(input.target, derivedFrom, derivedTo, chunkParam, sortKeyColumn, env?.fingerprint)).slice(0, 16)
   const stateDir = computeBackfillStateDir(input.config, input.configPath, input.options)
   const paths = backfillPaths(stateDir, planId)
 
-  // 3. Build planned chunks from boundaries (now that we have planId for deterministic IDs)
-  const plannedChunks = buildPlannedChunks({
-    planId,
-    partitions,
-    boundaries,
-    requireIdempotencyToken: input.options.defaults.requireIdempotencyToken,
-  })
-
-  // 4. Detect MV for replay strategy
+  // 2. Detect MV for replay strategy
   let mvAsQuery: string | undefined
   let targetColumns: string[] | undefined
 
@@ -104,7 +87,7 @@ export async function buildBackfillPlan(input: {
     // Schema load failed — fall back to direct copy
   }
 
-  // 5. Stamp SQL on each planned chunk to produce BackfillChunk[]
+  // 3. Stamp SQL on each planned chunk to produce BackfillChunk[]
   const chunks: BackfillChunk[] = plannedChunks.map(planned => {
     const sqlTemplate = buildChunkSql({
       planId,
@@ -155,41 +138,10 @@ export async function buildBackfillPlan(input: {
     limits: input.options.limits,
   }
 
-  return persistPlan(plan, paths, input.force)
-}
-
-async function persistPlan(
-  plan: BuildBackfillPlanOutput['plan'],
-  paths: ReturnType<typeof backfillPaths>,
-  force?: boolean
-): Promise<BuildBackfillPlanOutput> {
-  if (force) {
-    for (const filePath of [paths.planPath, paths.runPath, paths.eventPath]) {
-      await unlink(filePath).catch((err: NodeJS.ErrnoException) => {
-        if (err.code !== 'ENOENT') throw err
-      })
-    }
-  }
-
-  const existing = await readExistingPlan(paths.planPath)
-  if (existing) {
-    if (stableSerialize(existing) !== stableSerialize(plan)) {
-      throw new BackfillConfigError(
-        `Backfill plan already exists at ${paths.planPath} but differs from current planning output. Remove it if you intentionally changed planning parameters.`
-      )
-    }
-    return {
-      plan: existing,
-      planPath: paths.planPath,
-      existed: true,
-    }
-  }
-
   await writeJson(paths.planPath, plan)
 
   return {
     plan,
     planPath: paths.planPath,
-    existed: false,
   }
 }

--- a/packages/plugin-backfill/src/planner.ts
+++ b/packages/plugin-backfill/src/planner.ts
@@ -4,6 +4,8 @@ import { unlink } from 'node:fs/promises'
 import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 import type { ResolvedChxConfig } from '@chkit/core'
 
+import { analyzeTable, buildPlannedChunks } from './chunking/index.js'
+import { buildChunkSql } from './chunking/sql.js'
 import { findMvForTarget } from './detect.js'
 import { BackfillConfigError } from './errors.js'
 import {
@@ -18,399 +20,150 @@ import {
 } from './state.js'
 import type {
   BackfillChunk,
-  BackfillPluginLimits,
   BuildBackfillPlanOutput,
   NormalizedBackfillPluginOptions,
+  PartitionInfo,
 } from './types.js'
 
-function ensureHoursWithinLimits(input: {
-  from: string
-  to: string
-  limits: Required<BackfillPluginLimits>
-  forceLargeWindow: boolean
-}): void {
-  const fromMillis = new Date(input.from).getTime()
-  const toMillis = new Date(input.to).getTime()
-  if (toMillis <= fromMillis) {
-    throw new BackfillConfigError('Invalid backfill window. Expected --to to be after --from.')
-  }
-
-  const durationHours = (toMillis - fromMillis) / (1000 * 60 * 60)
-  if (durationHours > input.limits.maxWindowHours && !input.forceLargeWindow) {
-    throw new BackfillConfigError(
-      `Requested window (${durationHours.toFixed(2)} hours) exceeds limits.maxWindowHours=${input.limits.maxWindowHours}. Retry with --force-large-window to acknowledge risk.`
-    )
-  }
-}
-
-function buildSettingsClause(token: string): string {
-  if (token) {
-    return `SETTINGS async_insert=0, insert_deduplication_token='${token}'`
-  }
-  return `SETTINGS async_insert=0`
-}
-
-/**
- * Inject a time-range filter directly into a SQL query.
- *
- * Scans for top-level (not inside parentheses or string literals) SQL keywords
- * to determine where to place the condition:
- * - If a top-level WHERE exists, appends AND conditions at its end.
- * - Otherwise, inserts a WHERE clause before trailing clauses (GROUP BY, etc.).
- *
- * This avoids wrapping the query in a CTE, which causes ClickHouse to infer
- * Nullable wrappers on Array/Map columns — an illegal type combination.
- */
-export function injectTimeFilter(
-  query: string,
-  timeColumn: string,
-  from: string,
-  to: string,
-): string {
-  const trimmed = query.trimEnd()
-  const upper = trimmed.toUpperCase()
-
-  // Scan for top-level keyword positions (outside parens and string literals)
-  type KWHit = { keyword: string; position: number }
-  const hits: KWHit[] = []
-  let depth = 0
-
-  for (let i = 0; i < trimmed.length; i++) {
-    const ch = trimmed[i]
-    if (ch === '(') { depth++; continue }
-    if (ch === ')') { depth--; continue }
-    if (ch === "'") {
-      i++
-      while (i < trimmed.length && trimmed[i] !== "'") {
-        if (trimmed[i] === '\\') i++
-        i++
-      }
-      continue
-    }
-    if (depth !== 0) continue
-
-    // Must be preceded by whitespace or be at start
-    if (i > 0 && /\S/.test(trimmed[i - 1] ?? '')) continue
-
-    const rest = upper.slice(i)
-    for (const kw of ['WHERE', 'GROUP BY', 'HAVING', 'ORDER BY', 'QUALIFY', 'LIMIT', 'SETTINGS']) {
-      if (rest.startsWith(kw) && (i + kw.length >= trimmed.length || /\s/.test(trimmed[i + kw.length] ?? ''))) {
-        hits.push({ keyword: kw, position: i })
-        break
-      }
-    }
-  }
-
-  const whereHit = hits.find(h => h.keyword === 'WHERE')
-  const trailingKeywords = ['GROUP BY', 'HAVING', 'ORDER BY', 'QUALIFY', 'LIMIT', 'SETTINGS']
-  const firstTrailing = hits
-    .filter(h => trailingKeywords.includes(h.keyword))
-    .filter(h => !whereHit || h.position > whereHit.position)[0]
-
-  const timeCondition =
-    `${timeColumn} >= parseDateTimeBestEffort('${from}')\n  AND ${timeColumn} < parseDateTimeBestEffort('${to}')`
-
-  const insertAt = firstTrailing ? firstTrailing.position : trimmed.length
-  const before = trimmed.slice(0, insertAt).trimEnd()
-  const after = trimmed.slice(insertAt)
-
-  if (whereHit) {
-    return `${before}\n  AND ${timeCondition}${after ? `\n${after}` : ''}`
-  }
-  return `${before}\nWHERE ${timeCondition}${after ? `\n${after}` : ''}`
-}
-
-/**
- * Rewrite a SQL query's SELECT projection so its output columns are in the
- * same positional order as `targetColumns`.
- *
- * Parses the existing SELECT clause to build an alias→expression map,
- * then emits columns in `targetColumns` order. Columns that came from
- * a `*` expansion are emitted as bare names; aliased expressions (e.g.
- * `_skills as skills`) are preserved with their original expression.
- */
-export function rewriteSelectColumns(query: string, targetColumns: string[]): string {
-  const trimmed = query.trimEnd()
-  const upper = trimmed.toUpperCase()
-
-  // Scan for top-level SELECT and FROM positions (outside parens and strings)
-  let selectPos = -1
-  let fromPos = -1
-  let depth = 0
-
-  for (let i = 0; i < trimmed.length; i++) {
-    const ch = trimmed[i]
-    if (ch === '(') { depth++; continue }
-    if (ch === ')') { depth--; continue }
-    if (ch === "'") {
-      i++
-      while (i < trimmed.length && trimmed[i] !== "'") {
-        if (trimmed[i] === '\\') i++
-        i++
-      }
-      continue
-    }
-    if (depth !== 0) continue
-
-    if (i > 0 && /\S/.test(trimmed[i - 1] ?? '')) continue
-
-    const rest = upper.slice(i)
-    if (selectPos === -1 && rest.startsWith('SELECT') && (i + 6 >= trimmed.length || /\s/.test(trimmed[i + 6] ?? ''))) {
-      selectPos = i
-    } else if (selectPos !== -1 && fromPos === -1 && rest.startsWith('FROM') && (i + 4 >= trimmed.length || /\s/.test(trimmed[i + 4] ?? ''))) {
-      fromPos = i
-    }
-  }
-
-  if (selectPos === -1 || fromPos === -1) return query
-
-  const projStart = selectPos + 6
-  const projText = trimmed.slice(projStart, fromPos).trim()
-
-  // Split projection by top-level commas
-  const items: string[] = []
-  let itemStart = 0
-  depth = 0
-
-  for (let i = 0; i < projText.length; i++) {
-    const ch = projText[i]
-    if (ch === '(') { depth++; continue }
-    if (ch === ')') { depth--; continue }
-    if (ch === "'") {
-      i++
-      while (i < projText.length && projText[i] !== "'") {
-        if (projText[i] === '\\') i++
-        i++
-      }
-      continue
-    }
-    if (depth === 0 && ch === ',') {
-      items.push(projText.slice(itemStart, i).trim())
-      itemStart = i + 1
-    }
-  }
-  items.push(projText.slice(itemStart).trim())
-
-  // Build alias → expression map from non-star items
-  const aliasMap = new Map<string, string>()
-  for (const item of items) {
-    if (item === '*') continue
-
-    const itemUpper = item.toUpperCase()
-    let asPos = -1
-    let d = 0
-
-    for (let i = 0; i < item.length; i++) {
-      const ch = item[i]
-      if (ch === '(') { d++; continue }
-      if (ch === ')') { d--; continue }
-      if (ch === "'") {
-        i++
-        while (i < item.length && item[i] !== "'") {
-          if (item[i] === '\\') i++
-          i++
-        }
-        continue
-      }
-      if (d !== 0) continue
-      if (i > 0 && /\S/.test(item[i - 1] ?? '')) continue
-
-      const rest = itemUpper.slice(i)
-      if (rest.startsWith('AS') && (i + 2 >= item.length || /\s/.test(item[i + 2] ?? ''))) {
-        asPos = i
-      }
-    }
-
-    if (asPos !== -1) {
-      const alias = item.slice(asPos + 2).trim()
-      aliasMap.set(alias, item)
-    }
-  }
-
-  // Emit columns in target order
-  const rewrittenCols = targetColumns.map(col => aliasMap.get(col) ?? col)
-
-  const before = trimmed.slice(0, projStart)
-  const after = trimmed.slice(fromPos)
-  return `${before} ${rewrittenCols.join(', ')}\n${after}`
-}
-
-function buildChunkSqlTemplate(chunk: {
-  planId: string
-  chunkId: string
-  token: string
-  target: string
-  from: string
-  to: string
-  timeColumn: string
-  mvAsQuery?: string
-  targetColumns?: string[]
-}): string {
-  const header = `/* chkit backfill plan=${chunk.planId} chunk=${chunk.chunkId} token=${chunk.token} */`
-  const settings = buildSettingsClause(chunk.token)
-
-  if (chunk.mvAsQuery) {
-    const filtered = injectTimeFilter(chunk.mvAsQuery, chunk.timeColumn, chunk.from, chunk.to)
-    if (chunk.targetColumns?.length) {
-      const reordered = rewriteSelectColumns(filtered, chunk.targetColumns)
-      return [header, `INSERT INTO ${chunk.target}`, reordered, settings].join('\n')
-    }
-    return [header, `INSERT INTO ${chunk.target}`, filtered, settings].join('\n')
-  }
-
-  return [
-    header,
-    `INSERT INTO ${chunk.target}`,
-    `SELECT *`,
-    `FROM ${chunk.target}`,
-    `WHERE ${chunk.timeColumn} >= parseDateTimeBestEffort('${chunk.from}')`,
-    `  AND ${chunk.timeColumn} < parseDateTimeBestEffort('${chunk.to}')`,
-    settings,
-  ].join('\n')
-}
-
-function buildChunks(input: {
-  planId: string
-  target: string
-  from: string
-  to: string
-  chunkHours: number
-  requireIdempotencyToken: boolean
-  timeColumn: string
-  mvAsQuery?: string
-  targetColumns?: string[]
-}): BackfillChunk[] {
-  const fromMillis = new Date(input.from).getTime()
-  const toMillis = new Date(input.to).getTime()
-  const chunkMillis = input.chunkHours * 60 * 60 * 1000
-
-  const chunks: BackfillChunk[] = []
-  let current = fromMillis
-
-  while (current < toMillis) {
-    const next = Math.min(current + chunkMillis, toMillis)
-    const chunkFrom = new Date(current).toISOString()
-    const chunkTo = new Date(next).toISOString()
-    const idSeed = `${input.planId}:${chunkFrom}:${chunkTo}`
-    const chunkId = hashId(`chunk:${idSeed}`).slice(0, 16)
-    const token = input.requireIdempotencyToken ? hashId(`token:${idSeed}`) : ''
-
-    chunks.push({
-      id: chunkId,
-      from: chunkFrom,
-      to: chunkTo,
-      status: 'pending',
-      attempts: 0,
-      idempotencyToken: token,
-      sqlTemplate: buildChunkSqlTemplate({
-        planId: input.planId,
-        chunkId,
-        token,
-        target: input.target,
-        from: chunkFrom,
-        to: chunkTo,
-        timeColumn: input.timeColumn,
-        mvAsQuery: input.mvAsQuery,
-        targetColumns: input.targetColumns,
-      }),
-    })
-
-    current = next
-  }
-
-  return chunks
-}
+const DEFAULT_MAX_CHUNK_BYTES = 10 * 1024 ** 3 // 10 GiB
 
 export async function buildBackfillPlan(input: {
   target: string
-  from: string
-  to: string
-  timeColumn: string
+  from?: string
+  to?: string
   configPath: string
   config: Pick<ResolvedChxConfig, 'metaDir' | 'schema'>
   options: NormalizedBackfillPluginOptions
-  chunkHours?: number
-  forceLargeWindow?: boolean
+  maxChunkBytes?: number
   force?: boolean
   clickhouse?: { url: string; database: string }
+  clickhouseQuery: <T>(sql: string) => Promise<T[]>
 }): Promise<BuildBackfillPlanOutput> {
-  const chunkHours = input.chunkHours ?? input.options.defaults.chunkHours
-  if (chunkHours * 60 < input.options.limits.minChunkMinutes) {
+  const [database, table] = input.target.split('.')
+  if (!database || !table) {
+    throw new BackfillConfigError('Invalid target format. Expected <database.table>.')
+  }
+
+  const env = computeEnvironmentFingerprint(input.clickhouse)
+  const maxChunkBytes = input.maxChunkBytes ?? DEFAULT_MAX_CHUNK_BYTES
+
+  // 1. Analyze table: introspect partitions, sort key, and build chunk boundaries
+  const { partitions, sortKey, boundaries } = await analyzeTable({
+    database,
+    table,
+    from: input.from,
+    to: input.to,
+    maxChunkBytes,
+    query: input.clickhouseQuery,
+  })
+
+  if (partitions.length === 0) {
     throw new BackfillConfigError(
-      `Chunk size ${chunkHours}h is below limits.minChunkMinutes=${input.options.limits.minChunkMinutes}.`
+      `No partitions found for ${input.target}${input.from || input.to ? ' within the specified time range' : ''}. The table may be empty.`
     )
   }
 
-  ensureHoursWithinLimits({
-    from: input.from,
-    to: input.to,
-    limits: input.options.limits,
-    forceLargeWindow: input.forceLargeWindow ?? false,
-  })
+  // 2. Compute plan identity (requires partition data for derived time bounds)
+  const firstPartition = partitions[0] as PartitionInfo
+  const derivedFrom = input.from ?? partitions.reduce((min, p) => (p.minTime < min ? p.minTime : min), firstPartition.minTime)
+  const derivedTo = input.to ?? partitions.reduce((max, p) => (p.maxTime > max ? p.maxTime : max), firstPartition.maxTime)
 
-  const env = computeEnvironmentFingerprint(input.clickhouse)
-  const planId = hashId(planIdentity(input.target, input.from, input.to, chunkHours, input.timeColumn, env?.fingerprint)).slice(0, 16)
+  const chunkParam = `partition:${maxChunkBytes}`
+  const sortKeyColumn = sortKey?.column ?? ''
+  const planId = hashId(planIdentity(input.target, derivedFrom, derivedTo, chunkParam, sortKeyColumn, env?.fingerprint)).slice(0, 16)
   const stateDir = computeBackfillStateDir(input.config, input.configPath, input.options)
   const paths = backfillPaths(stateDir, planId)
 
-  let strategy: 'table' | 'mv_replay' = 'table'
+  // 3. Build planned chunks from boundaries (now that we have planId for deterministic IDs)
+  const plannedChunks = buildPlannedChunks({
+    planId,
+    partitions,
+    boundaries,
+    requireIdempotencyToken: input.options.defaults.requireIdempotencyToken,
+  })
+
+  // 4. Detect MV for replay strategy
   let mvAsQuery: string | undefined
   let targetColumns: string[] | undefined
 
-  const [database, table] = input.target.split('.')
-  if (database && table) {
-    try {
-      const definitions = await loadSchemaDefinitions(input.config.schema, {
-        cwd: dirname(input.configPath),
-      })
-      const mv = findMvForTarget(definitions, database, table)
-      if (mv) {
-        strategy = 'mv_replay'
-        mvAsQuery = mv.as
-        const tableDef = definitions.find(
-          (d) => d.kind === 'table' && d.database === database && d.name === table
-        )
-        if (tableDef && tableDef.kind === 'table') {
-          targetColumns = tableDef.columns.map((c) => c.name)
-        }
+  try {
+    const definitions = await loadSchemaDefinitions(input.config.schema, {
+      cwd: dirname(input.configPath),
+    })
+    const mv = findMvForTarget(definitions, database, table)
+    if (mv) {
+      mvAsQuery = mv.as
+      const tableDef = definitions.find(
+        (d) => d.kind === 'table' && d.database === database && d.name === table
+      )
+      if (tableDef && tableDef.kind === 'table') {
+        targetColumns = tableDef.columns.map((c) => c.name)
       }
-    } catch {
-      // Schema load failed — fall back to plain table strategy
     }
+  } catch {
+    // Schema load failed — fall back to direct copy
   }
+
+  // 5. Stamp SQL on each planned chunk to produce BackfillChunk[]
+  const chunks: BackfillChunk[] = plannedChunks.map(planned => {
+    const sqlTemplate = buildChunkSql({
+      planId,
+      chunk: planned,
+      target: input.target,
+      sortKey,
+      mvAsQuery,
+      targetColumns,
+    })
+
+    return {
+      id: planned.id,
+      from: planned.from,
+      to: planned.to,
+      status: 'pending' as const,
+      attempts: 0,
+      idempotencyToken: planned.idempotencyToken,
+      sqlTemplate,
+      partitionId: planned.partitionId,
+      estimatedBytes: planned.estimatedBytes,
+      ...(planned.sortKeyFrom !== undefined ? { sortKeyFrom: planned.sortKeyFrom } : {}),
+      ...(planned.sortKeyTo !== undefined ? { sortKeyTo: planned.sortKeyTo } : {}),
+    }
+  })
+
+  const strategy = mvAsQuery ? 'mv_replay' : 'partition'
 
   const plan = {
     planId,
     target: input.target,
     createdAt: '1970-01-01T00:00:00.000Z',
     status: 'planned' as const,
-    strategy,
+    strategy: strategy as 'partition' | 'mv_replay',
     ...(env ? { environment: env } : {}),
-    from: input.from,
-    to: input.to,
-    chunks: buildChunks({
-      planId,
-      target: input.target,
-      from: input.from,
-      to: input.to,
-      chunkHours,
-      requireIdempotencyToken: input.options.defaults.requireIdempotencyToken,
-      timeColumn: input.timeColumn,
-      mvAsQuery,
-      targetColumns,
-    }),
+    from: derivedFrom,
+    to: derivedTo,
+    chunks,
+    partitions,
+    sortKey,
     options: {
-      chunkHours,
+      maxChunkBytes,
       maxParallelChunks: input.options.defaults.maxParallelChunks,
       maxRetriesPerChunk: input.options.defaults.maxRetriesPerChunk,
       requireIdempotencyToken: input.options.defaults.requireIdempotencyToken,
-      timeColumn: input.timeColumn,
+      sortKeyColumn: sortKey?.column,
     },
     policy: input.options.policy,
     limits: input.options.limits,
   }
 
-  if (input.force) {
+  return persistPlan(plan, paths, input.force)
+}
+
+async function persistPlan(
+  plan: BuildBackfillPlanOutput['plan'],
+  paths: ReturnType<typeof backfillPaths>,
+  force?: boolean
+): Promise<BuildBackfillPlanOutput> {
+  if (force) {
     for (const filePath of [paths.planPath, paths.runPath, paths.eventPath]) {
       await unlink(filePath).catch((err: NodeJS.ErrnoException) => {
         if (err.code !== 'ENOENT') throw err

--- a/packages/plugin-backfill/src/plugin.test.ts
+++ b/packages/plugin-backfill/src/plugin.test.ts
@@ -5,7 +5,7 @@ import { backfill, createBackfillPlugin } from './plugin.js'
 describe('@chkit/plugin-backfill plugin surface', () => {
   test('exposes commands and typed registration helper', () => {
     const plugin = createBackfillPlugin()
-    const registration = backfill({ defaults: { chunkHours: 4 } })
+    const registration = backfill({ defaults: { maxParallelChunks: 4 } })
 
     expect(plugin.manifest.name).toBe('backfill')
     expect(plugin.manifest.apiVersion).toBe(1)
@@ -19,6 +19,6 @@ describe('@chkit/plugin-backfill plugin surface', () => {
     ])
     expect(registration.name).toBe('backfill')
     expect(registration.enabled).toBe(true)
-    expect(registration.options?.defaults?.chunkHours).toBe(4)
+    expect(registration.options?.defaults?.maxParallelChunks).toBe(4)
   })
 })

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -1,6 +1,3 @@
-import process from 'node:process'
-import { createInterface } from 'node:readline/promises'
-
 import { createClickHouseExecutor } from '@chkit/clickhouse'
 import { wrapPluginRun } from '@chkit/core'
 
@@ -16,108 +13,26 @@ import {
   parseRunArgs,
   parseStatusArgs,
 } from './args.js'
-import { loadTimeColumnInfo } from './detect.js'
 import { BackfillConfigError } from './errors.js'
 import { normalizeBackfillOptions, mergeOptions, validateBaseOptions } from './options.js'
 import { planPayload, runPayload, statusPayload, cancelPayload, doctorPayload } from './payload.js'
 import { buildBackfillPlan } from './planner.js'
-import {
-  cancelBackfillRun,
-  evaluateBackfillCheck,
-  executeBackfillRun,
-  getBackfillDoctorReport,
-  getBackfillStatus,
-  resumeBackfillRun,
-} from './runtime.js'
+import { evaluateBackfillCheck } from './check.js'
+import { cancelBackfillRun, getBackfillDoctorReport, getBackfillStatus } from './queries.js'
+import { executeBackfillRun, resumeBackfillRun } from './runtime.js'
 import type {
   BackfillPlugin,
   BackfillPluginOptions,
   BackfillPluginRegistration,
   NormalizedBackfillPluginOptions,
-  TimeColumnCandidate,
 } from './types.js'
 
-async function resolveTimeColumn(input: {
-  flagValue?: string
-  defaults: NormalizedBackfillPluginOptions['defaults']
-  target: string
-  schemaGlobs: string | string[]
-  configPath: string
-  jsonMode: boolean
-}): Promise<string> {
-  if (input.flagValue) return input.flagValue
-
-  const { schemaTimeColumn, candidates } = await loadTimeColumnInfo(
-    input.target,
-    input.schemaGlobs,
-    input.configPath
-  )
-
-  if (schemaTimeColumn) return schemaTimeColumn
-  if (input.defaults.timeColumn) return input.defaults.timeColumn
-
-  if (candidates.length === 0) {
-    throw new BackfillConfigError(
-      `Cannot determine time column for ${input.target}. Specify --time-column <column>, set plugins.backfill.timeColumn in table schema, or set defaults.timeColumn in plugin config.`
-    )
-  }
-
-  if (input.jsonMode) {
-    // biome-ignore lint/style/noNonNullAssertion: length checked above
-    return candidates[0]!.name
-  }
-
-  if (candidates.length === 1) {
-    return confirmSingleCandidate(candidates[0] as TimeColumnCandidate, input.target)
-  }
-
-  return selectFromCandidates(candidates, input.target)
-}
-
-async function confirmSingleCandidate(
-  candidate: TimeColumnCandidate,
-  target: string
-): Promise<string> {
-  const label = `${candidate.name} (${candidate.type}${candidate.source === 'order_by' ? ', in ORDER BY' : ''})`
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  try {
-    const response = await rl.question(`Detected time column for ${target}: ${label}\nUse ${candidate.name}? [Y/n]: `)
-    const trimmed = response.trim().toLowerCase()
-    if (trimmed === '' || trimmed === 'y' || trimmed === 'yes') {
-      return candidate.name
-    }
-    throw new BackfillConfigError(
-      `Time column not confirmed. Specify --time-column <column> explicitly.`
-    )
-  } finally {
-    rl.close()
-  }
-}
-
-async function selectFromCandidates(
-  candidates: TimeColumnCandidate[],
-  target: string
-): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  try {
-    console.log(`Detected time column candidates for ${target}:`)
-    for (let i = 0; i < candidates.length; i++) {
-      const c = candidates[i] as TimeColumnCandidate
-      const suffix = c.source === 'order_by' ? ', in ORDER BY' : ''
-      console.log(`  ${i + 1}. ${c.name} (${c.type}${suffix})`)
-    }
-    const response = await rl.question(`Select time column [1-${candidates.length}]: `)
-    const index = Number(response.trim()) - 1
-    if (!Number.isInteger(index) || index < 0 || index >= candidates.length) {
-      throw new BackfillConfigError(
-        `Invalid selection. Specify --time-column <column> explicitly.`
-      )
-    }
-    // biome-ignore lint/style/noNonNullAssertion: index bounds checked above
-    return candidates[index]!.name
-  } finally {
-    rl.close()
-  }
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`
+  return `${bytes} B`
 }
 
 type BackfillCommandContext = Parameters<BackfillPlugin['commands'][number]['run']>[0]
@@ -167,39 +82,52 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
           label: 'Backfill plan',
           async run({ context, effectiveOptions }) {
             const parsed = parsePlanArgs(context.flags)
-            const timeColumn = await resolveTimeColumn({
-              flagValue: parsed.timeColumn,
-              defaults: effectiveOptions.defaults,
-              target: parsed.target,
-              schemaGlobs: context.config.schema,
-              configPath: context.configPath,
-              jsonMode: context.jsonMode,
-            })
 
-            const output = await buildBackfillPlan({
-              target: parsed.target,
-              from: parsed.from,
-              to: parsed.to,
-              timeColumn,
-              config: context.config,
-              configPath: context.configPath,
-              options: effectiveOptions,
-              chunkHours: parsed.chunkHours,
-              forceLargeWindow: parsed.forceLargeWindow,
-              force: parsed.force,
-              clickhouse: context.config.clickhouse,
-            })
-
-            const payload = planPayload(output)
-            if (context.jsonMode) {
-              context.print(payload)
-            } else {
-              context.print(
-                `Backfill plan ${payload.planId} for ${payload.target} (${payload.chunkCount} chunks at ${payload.chunkHours}h, time column: ${payload.timeColumn}) -> ${payload.planPath}${payload.existed ? ' [existing]' : ''}`
+            if (!context.config.clickhouse) {
+              throw new BackfillConfigError(
+                'ClickHouse connection is required for backfill planning. Configure clickhouse in your clickhouse.config.ts.'
               )
             }
 
-            return 0
+            const db = createClickHouseExecutor(context.config.clickhouse)
+
+            try {
+              const output = await buildBackfillPlan({
+                target: parsed.target,
+                from: parsed.from,
+                to: parsed.to,
+                config: context.config,
+                configPath: context.configPath,
+                options: effectiveOptions,
+                maxChunkBytes: parsed.maxChunkBytes,
+                force: parsed.force,
+                clickhouse: context.config.clickhouse,
+                clickhouseQuery: async <T>(sql: string) => {
+                  const result = await db.query(sql)
+                  return result as T[]
+                },
+              })
+
+              const payload = planPayload(output)
+              if (context.jsonMode) {
+                context.print(payload)
+              } else {
+                const partitionCount = output.plan.partitions?.length ?? 0
+                const totalBytes = output.plan.partitions
+                  ? formatBytes(output.plan.partitions.reduce((sum, p) => sum + p.bytesOnDisk, 0))
+                  : 'unknown'
+                const sortKeyLabel = output.plan.sortKey
+                  ? `, sort key: ${output.plan.sortKey.column} (${output.plan.sortKey.category})`
+                  : ''
+                context.print(
+                  `Backfill plan ${payload.planId} for ${payload.target} (${payload.chunkCount} chunks across ${partitionCount} partitions, ~${totalBytes}${sortKeyLabel}) -> ${payload.planPath}${payload.existed ? ' [existing]' : ''}`
+                )
+              }
+
+              return 0
+            } finally {
+              await db.close()
+            }
           },
         }),
       },

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -24,6 +24,7 @@ import type {
   BackfillPlugin,
   BackfillPluginOptions,
   BackfillPluginRegistration,
+  ExecuteBackfillRunOutput,
   NormalizedBackfillPluginOptions,
 } from './types.js'
 
@@ -36,6 +37,40 @@ function formatBytes(bytes: number): string {
 }
 
 type BackfillCommandContext = Parameters<BackfillPlugin['commands'][number]['run']>[0]
+
+function formatRunOutput(
+  output: ExecuteBackfillRunOutput,
+  command: string,
+  context: Pick<BackfillCommandContext, 'jsonMode' | 'print'>,
+): number {
+  const payload = {
+    ...runPayload(output),
+    command,
+  }
+  if (payload.noop) {
+    if (!context.jsonMode) {
+      context.print(
+        `Plan ${payload.planId} is already completed (${payload.chunkCounts.done}/${payload.chunkCounts.total} chunks done). Nothing to do.`
+      )
+    } else {
+      context.print(payload)
+    }
+    return 0
+  }
+  if (context.jsonMode) {
+    context.print(payload)
+  } else {
+    let line = `Backfill ${command} ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total}, ${payload.rowsWritten} rows written)`
+    if (payload.lastError) line += ` \u2014 ${payload.lastError}`
+    context.print(line)
+    if (payload.status === 'completed' && payload.rowsWritten === 0) {
+      context.print(
+        'Warning: 0 rows written across all chunks. Verify that source data exists in the time range and passes the query\'s WHERE filters.'
+      )
+    }
+  }
+  return payload.ok ? 0 : 1
+}
 
 function createBackfillCommand(
   base: NormalizedBackfillPluginOptions,
@@ -100,7 +135,6 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                 configPath: context.configPath,
                 options: effectiveOptions,
                 maxChunkBytes: parsed.maxChunkBytes,
-                force: parsed.force,
                 clickhouse: context.config.clickhouse,
                 clickhouseQuery: async <T>(sql: string) => {
                   const result = await db.query(sql)
@@ -120,7 +154,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                   ? `, sort key: ${output.plan.sortKey.column} (${output.plan.sortKey.category})`
                   : ''
                 context.print(
-                  `Backfill plan ${payload.planId} for ${payload.target} (${payload.chunkCount} chunks across ${partitionCount} partitions, ~${totalBytes}${sortKeyLabel}) -> ${payload.planPath}${payload.existed ? ' [existing]' : ''}`
+                  `Backfill plan ${payload.planId} for ${payload.target} (${payload.chunkCount} chunks across ${partitionCount} partitions, ~${totalBytes}${sortKeyLabel}) -> ${payload.planPath}`
                 )
               }
 
@@ -166,33 +200,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                 clickhouse: context.config.clickhouse,
               })
 
-              const payload = {
-                ...runPayload(output),
-                command: 'run' as const,
-              }
-              if (payload.noop) {
-                if (!context.jsonMode) {
-                  context.print(
-                    `Plan ${payload.planId} is already completed (${payload.chunkCounts.done}/${payload.chunkCounts.total} chunks done). Nothing to do.`
-                  )
-                } else {
-                  context.print(payload)
-                }
-                return 0
-              }
-              if (context.jsonMode) {
-                context.print(payload)
-              } else {
-                let line = `Backfill run ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total}, ${payload.rowsWritten} rows written)`
-                if (payload.lastError) line += ` \u2014 ${payload.lastError}`
-                context.print(line)
-                if (payload.status === 'completed' && payload.rowsWritten === 0) {
-                  context.print(
-                    'Warning: 0 rows written across all chunks. Verify that source data exists in the time range and passes the query\'s WHERE filters.'
-                  )
-                }
-              }
-              return payload.ok ? 0 : 1
+              return formatRunOutput(output, 'run', context)
             } finally {
               await db?.close()
             }
@@ -230,33 +238,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
                 clickhouse: context.config.clickhouse,
               })
 
-              const payload = {
-                ...runPayload(output),
-                command: 'resume' as const,
-              }
-              if (payload.noop) {
-                if (!context.jsonMode) {
-                  context.print(
-                    `Plan ${payload.planId} is already completed (${payload.chunkCounts.done}/${payload.chunkCounts.total} chunks done). Nothing to do.`
-                  )
-                } else {
-                  context.print(payload)
-                }
-                return 0
-              }
-              if (context.jsonMode) {
-                context.print(payload)
-              } else {
-                let line = `Backfill resume ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total}, ${payload.rowsWritten} rows written)`
-                if (payload.lastError) line += ` \u2014 ${payload.lastError}`
-                context.print(line)
-                if (payload.status === 'completed' && payload.rowsWritten === 0) {
-                  context.print(
-                    'Warning: 0 rows written across all chunks. Verify that source data exists in the time range and passes the query\'s WHERE filters.'
-                  )
-                }
-              }
-              return payload.ok ? 0 : 1
+              return formatRunOutput(output, 'resume', context)
             } finally {
               await db?.close()
             }
@@ -383,7 +365,7 @@ export function createBackfillPlugin(options: BackfillPluginOptions = {}): Backf
 
 export function backfill(options: BackfillPluginOptions = {}): BackfillPluginRegistration {
   return {
-    plugin: createBackfillPlugin(),
+    plugin: createBackfillPlugin(options),
     name: 'backfill',
     enabled: true,
     options,

--- a/packages/plugin-backfill/src/queries.ts
+++ b/packages/plugin-backfill/src/queries.ts
@@ -1,0 +1,175 @@
+import type { ResolvedChxConfig } from '@chkit/core'
+
+import { BackfillConfigError } from './errors.js'
+import {
+  backfillPaths,
+  nowIso,
+  persistRunAndEvent,
+  readPlan,
+  readRun,
+  summarizeRunStatus,
+} from './state.js'
+import type {
+  BackfillDoctorReport,
+  BackfillStatusSummary,
+  NormalizedBackfillPluginOptions,
+} from './types.js'
+
+export async function getBackfillStatus(input: {
+  planId: string
+  configPath: string
+  config: Pick<ResolvedChxConfig, 'metaDir'>
+  options: NormalizedBackfillPluginOptions
+}): Promise<BackfillStatusSummary> {
+  const { plan, stateDir } = await readPlan({
+    planId: input.planId,
+    configPath: input.configPath,
+    config: input.config,
+    options: input.options,
+  })
+  const paths = backfillPaths(stateDir, plan.planId)
+  const run = await readRun(paths.runPath)
+
+  if (!run) {
+    return {
+      planId: plan.planId,
+      target: plan.target,
+      status: 'planned',
+      totals: {
+        total: plan.chunks.length,
+        pending: plan.chunks.length,
+        running: 0,
+        done: 0,
+        failed: 0,
+        skipped: 0,
+      },
+      attempts: 0,
+      rowsWritten: 0,
+      updatedAt: plan.createdAt,
+      runPath: paths.runPath,
+      eventPath: paths.eventPath,
+    }
+  }
+
+  return summarizeRunStatus(run, paths.runPath, paths.eventPath)
+}
+
+export async function cancelBackfillRun(input: {
+  planId: string
+  configPath: string
+  config: Pick<ResolvedChxConfig, 'metaDir'>
+  options: NormalizedBackfillPluginOptions
+}): Promise<BackfillStatusSummary> {
+  const { plan, stateDir } = await readPlan({
+    planId: input.planId,
+    configPath: input.configPath,
+    config: input.config,
+    options: input.options,
+  })
+  const paths = backfillPaths(stateDir, plan.planId)
+  const run = await readRun(paths.runPath)
+
+  if (!run) {
+    throw new BackfillConfigError(
+      `Run state not found for plan ${plan.planId}. Start with backfill run before cancel.`
+    )
+  }
+  if (run.status === 'completed') {
+    throw new BackfillConfigError(`Run already completed for plan ${plan.planId}; cannot cancel.`)
+  }
+  if (run.status === 'cancelled') {
+    return summarizeRunStatus(run, paths.runPath, paths.eventPath)
+  }
+
+  run.status = 'cancelled'
+  run.completedAt = nowIso()
+  run.lastError = 'Cancelled by operator'
+  for (const chunk of run.chunks) {
+    if (chunk.status === 'running') {
+      chunk.status = 'pending'
+    }
+  }
+
+  await persistRunAndEvent({
+    run,
+    runPath: paths.runPath,
+    eventPath: paths.eventPath,
+    event: {
+      type: 'run_cancelled',
+      planId: plan.planId,
+    },
+  })
+
+  return summarizeRunStatus(run, paths.runPath, paths.eventPath)
+}
+
+export async function getBackfillDoctorReport(input: {
+  planId: string
+  configPath: string
+  config: Pick<ResolvedChxConfig, 'metaDir'>
+  options: NormalizedBackfillPluginOptions
+}): Promise<BackfillDoctorReport> {
+  const { plan, stateDir } = await readPlan({
+    planId: input.planId,
+    configPath: input.configPath,
+    config: input.config,
+    options: input.options,
+  })
+  const paths = backfillPaths(stateDir, plan.planId)
+  const run = await readRun(paths.runPath)
+
+  const status = run
+    ? summarizeRunStatus(run, paths.runPath, paths.eventPath)
+    : {
+        planId: plan.planId,
+        target: plan.target,
+        status: 'planned' as const,
+        totals: { total: plan.chunks.length, pending: plan.chunks.length, running: 0, done: 0, failed: 0, skipped: 0 },
+        attempts: 0,
+        rowsWritten: 0,
+        updatedAt: plan.createdAt,
+        runPath: paths.runPath,
+        eventPath: paths.eventPath,
+      }
+
+  const issueCodes: string[] = []
+  const recommendations: string[] = []
+  const failedChunkIds: string[] = []
+
+  for (const chunk of run?.chunks ?? []) {
+    if (chunk.status === 'failed') failedChunkIds.push(chunk.id)
+  }
+
+  if (status.status === 'planned') {
+    issueCodes.push('backfill_plan_missing')
+    recommendations.push(`Run: chkit plugin backfill run --plan-id ${status.planId}`)
+  }
+  if (status.status === 'failed') {
+    issueCodes.push('backfill_chunk_failed_retry_exhausted')
+    recommendations.push(`Inspect status: chkit plugin backfill status --plan-id ${status.planId}`)
+    recommendations.push(
+      `Retry failed chunks: chkit plugin backfill resume --plan-id ${status.planId} --replay-failed`
+    )
+  }
+  if (status.status === 'cancelled') {
+    issueCodes.push('backfill_required_pending')
+    recommendations.push(
+      `Resume execution: chkit plugin backfill resume --plan-id ${status.planId} --replay-failed`
+    )
+  }
+  if (status.status === 'running') {
+    issueCodes.push('backfill_required_pending')
+    recommendations.push(`Monitor progress: chkit plugin backfill status --plan-id ${status.planId}`)
+  }
+  if (issueCodes.length === 0) {
+    recommendations.push('No remediation required.')
+  }
+
+  return {
+    planId: status.planId,
+    status: status.status,
+    issueCodes,
+    recommendations,
+    failedChunkIds,
+  }
+}

--- a/packages/plugin-backfill/src/runtime.test.ts
+++ b/packages/plugin-backfill/src/runtime.test.ts
@@ -7,14 +7,26 @@ import { resolveConfig } from '@chkit/core'
 
 import { normalizeBackfillOptions } from './options.js'
 import { buildBackfillPlan } from './planner.js'
-import {
-  cancelBackfillRun,
-  evaluateBackfillCheck,
-  executeBackfillRun,
-  getBackfillDoctorReport,
-  getBackfillStatus,
-  resumeBackfillRun,
-} from './runtime.js'
+import { evaluateBackfillCheck } from './check.js'
+import { cancelBackfillRun, getBackfillDoctorReport, getBackfillStatus } from './queries.js'
+import { executeBackfillRun, resumeBackfillRun } from './runtime.js'
+
+function createMockQuery(opts: {
+  partitions?: Array<{ partition_id: string; total_rows: string; total_bytes: string; min_time: string; max_time: string }>
+} = {}): <T>(sql: string) => Promise<T[]> {
+  const partitions = opts.partitions ?? [
+    { partition_id: '202601a', total_rows: '500', total_bytes: '250000', min_time: '2026-01-01 00:00:00', max_time: '2026-01-01 02:00:00' },
+    { partition_id: '202601b', total_rows: '500', total_bytes: '250000', min_time: '2026-01-01 02:00:00', max_time: '2026-01-01 04:00:00' },
+    { partition_id: '202601c', total_rows: '500', total_bytes: '250000', min_time: '2026-01-01 04:00:00', max_time: '2026-01-01 06:00:00' },
+  ]
+
+  return async <T>(sql: string) => {
+    if (sql.includes('system.parts')) return partitions as T[]
+    if (sql.includes('system.tables')) return [{ sorting_key: 'event_time' }] as T[]
+    if (sql.includes('system.columns')) return [{ type: 'DateTime' }] as T[]
+    return [] as T[]
+  }
+}
 
 describe('@chkit/plugin-backfill run lifecycle', () => {
   test('runs plan chunks and reports completed status', async () => {
@@ -26,7 +38,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         schema: './schema.ts',
         metaDir: './chkit/meta',
       })
-      const options = normalizeBackfillOptions({ defaults: { chunkHours: 2 } })
+      const options = normalizeBackfillOptions({})
 
       const planned = await buildBackfillPlan({
         target: 'app.events',
@@ -35,6 +47,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       const ran = await executeBackfillRun({
@@ -74,7 +87,6 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
       })
       const options = normalizeBackfillOptions({
         defaults: {
-          chunkHours: 2,
           maxRetriesPerChunk: 1,
           retryDelayMs: 0,
         },
@@ -87,6 +99,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       const failChunkId = planned.plan.chunks[1]?.id
@@ -143,10 +156,10 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         metaDir: './chkit/meta',
       })
       const planOptions = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 1, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 1, retryDelayMs: 0 },
       })
       const changedOptions = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 5, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 5, retryDelayMs: 0 },
       })
 
       const planned = await buildBackfillPlan({
@@ -156,6 +169,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         configPath,
         config,
         options: planOptions,
+        clickhouseQuery: createMockQuery(),
       })
       const failChunkId = planned.plan.chunks[1]?.id
       expect(failChunkId).toBeTruthy()
@@ -202,7 +216,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         schema: './schema.ts',
         metaDir: './chkit/meta',
       })
-      const options = normalizeBackfillOptions({ defaults: { chunkHours: 2 } })
+      const options = normalizeBackfillOptions({})
 
       const planned = await buildBackfillPlan({
         target: 'app.events',
@@ -211,6 +225,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
       await executeBackfillRun({
         planId: planned.plan.planId,
@@ -229,7 +244,7 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
       ).rejects.toThrow('already completed')
 
       const options2 = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 1, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 1, retryDelayMs: 0 },
       })
       const planned2 = await buildBackfillPlan({
         target: 'app.events',
@@ -238,6 +253,13 @@ describe('@chkit/plugin-backfill run lifecycle', () => {
         configPath,
         config,
         options: options2,
+        clickhouseQuery: createMockQuery({
+          partitions: [
+            { partition_id: '202601d', total_rows: '500', total_bytes: '250000', min_time: '2026-01-02 00:00:00', max_time: '2026-01-02 02:00:00' },
+            { partition_id: '202601e', total_rows: '500', total_bytes: '250000', min_time: '2026-01-02 02:00:00', max_time: '2026-01-02 04:00:00' },
+            { partition_id: '202601f', total_rows: '500', total_bytes: '250000', min_time: '2026-01-02 04:00:00', max_time: '2026-01-02 06:00:00' },
+          ],
+        }),
       })
       await executeBackfillRun({
         planId: planned2.plan.planId,
@@ -280,7 +302,7 @@ describe('@chkit/plugin-backfill execute callback', () => {
         schema: './schema.ts',
         metaDir: './chkit/meta',
       })
-      const options = normalizeBackfillOptions({ defaults: { chunkHours: 2 } })
+      const options = normalizeBackfillOptions({})
 
       const planned = await buildBackfillPlan({
         target: 'app.events',
@@ -289,6 +311,7 @@ describe('@chkit/plugin-backfill execute callback', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       const executedSql: string[] = []
@@ -325,7 +348,7 @@ describe('@chkit/plugin-backfill execute callback', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 3, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 3, retryDelayMs: 0 },
       })
 
       const planned = await buildBackfillPlan({
@@ -335,6 +358,7 @@ describe('@chkit/plugin-backfill execute callback', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       let callCount = 0
@@ -375,7 +399,7 @@ describe('@chkit/plugin-backfill execute callback', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 2, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 2, retryDelayMs: 0 },
       })
 
       const planned = await buildBackfillPlan({
@@ -385,6 +409,7 @@ describe('@chkit/plugin-backfill execute callback', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       let callCount = 0
@@ -423,7 +448,7 @@ describe('@chkit/plugin-backfill continue past failures', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 1, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 1, retryDelayMs: 0 },
       })
 
       const planned = await buildBackfillPlan({
@@ -433,6 +458,7 @@ describe('@chkit/plugin-backfill continue past failures', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       const failChunkId = planned.plan.chunks[0]?.id
@@ -469,7 +495,7 @@ describe('@chkit/plugin-backfill continue past failures', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 1, retryDelayMs: 0 },
+        defaults: { maxRetriesPerChunk: 1, retryDelayMs: 0 },
       })
 
       const planned = await buildBackfillPlan({
@@ -479,6 +505,7 @@ describe('@chkit/plugin-backfill continue past failures', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       const failChunkId = planned.plan.chunks[1]?.id
@@ -494,7 +521,6 @@ describe('@chkit/plugin-backfill continue past failures', () => {
         },
       })
 
-      // Resume WITHOUT --replay-failed — should still retry the failed chunk
       const resumed = await resumeBackfillRun({
         planId: planned.plan.planId,
         configPath,
@@ -530,6 +556,7 @@ describe('@chkit/plugin-backfill check integration', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       const checkResult = await evaluateBackfillCheck({
@@ -566,6 +593,7 @@ describe('@chkit/plugin-backfill check integration', () => {
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
       await executeBackfillRun({
         planId: planned.plan.planId,
@@ -600,7 +628,7 @@ describe('@chkit/plugin-backfill environment binding', () => {
         schema: './schema.ts',
         metaDir: './chkit/meta',
       })
-      const options = normalizeBackfillOptions({ defaults: { chunkHours: 2 } })
+      const options = normalizeBackfillOptions({})
       const stagingCh = { url: 'https://staging.ch.cloud:8443', database: 'analytics' }
       const prodCh = { url: 'https://prod.ch.cloud:8443', database: 'analytics' }
 
@@ -608,11 +636,11 @@ describe('@chkit/plugin-backfill environment binding', () => {
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
         clickhouse: stagingCh,
+        clickhouseQuery: createMockQuery(),
       })
 
       await expect(
@@ -638,7 +666,7 @@ describe('@chkit/plugin-backfill environment binding', () => {
         schema: './schema.ts',
         metaDir: './chkit/meta',
       })
-      const options = normalizeBackfillOptions({ defaults: { chunkHours: 2 } })
+      const options = normalizeBackfillOptions({})
       const stagingCh = { url: 'https://staging.ch.cloud:8443', database: 'analytics' }
       const prodCh = { url: 'https://prod.ch.cloud:8443', database: 'analytics' }
 
@@ -646,11 +674,11 @@ describe('@chkit/plugin-backfill environment binding', () => {
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
         clickhouse: stagingCh,
+        clickhouseQuery: createMockQuery(),
       })
 
       const ran = await executeBackfillRun({
@@ -668,7 +696,7 @@ describe('@chkit/plugin-backfill environment binding', () => {
     }
   })
 
-  test('plans without environment can run against any environment (backward compat)', async () => {
+  test('plans without environment connection info can run against any environment', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
     const configPath = join(dir, 'clickhouse.config.ts')
 
@@ -677,22 +705,20 @@ describe('@chkit/plugin-backfill environment binding', () => {
         schema: './schema.ts',
         metaDir: './chkit/meta',
       })
-      const options = normalizeBackfillOptions({ defaults: { chunkHours: 2 } })
+      const options = normalizeBackfillOptions({})
 
-      // Plan without clickhouse (no environment info)
       const planned = await buildBackfillPlan({
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
+        clickhouseQuery: createMockQuery(),
       })
 
       expect(planned.plan.environment).toBeUndefined()
 
-      // Run against a specific environment — should succeed
       const ran = await executeBackfillRun({
         planId: planned.plan.planId,
         configPath,
@@ -717,7 +743,7 @@ describe('@chkit/plugin-backfill environment binding', () => {
         metaDir: './chkit/meta',
       })
       const options = normalizeBackfillOptions({
-        defaults: { chunkHours: 2, maxRetriesPerChunk: 1 },
+        defaults: { maxRetriesPerChunk: 1 },
       })
       const stagingCh = { url: 'https://staging.ch.cloud:8443', database: 'analytics' }
       const prodCh = { url: 'https://prod.ch.cloud:8443', database: 'analytics' }
@@ -726,14 +752,13 @@ describe('@chkit/plugin-backfill environment binding', () => {
         target: 'app.events',
         from: '2026-01-01T00:00:00.000Z',
         to: '2026-01-01T06:00:00.000Z',
-        timeColumn: 'event_time',
         configPath,
         config,
         options,
         clickhouse: stagingCh,
+        clickhouseQuery: createMockQuery(),
       })
 
-      // Run with staging to create run state, with a simulated failure
       await executeBackfillRun({
         planId: planned.plan.planId,
         configPath,
@@ -745,7 +770,6 @@ describe('@chkit/plugin-backfill environment binding', () => {
         clickhouse: stagingCh,
       })
 
-      // Resume with production should fail
       await expect(
         resumeBackfillRun({
           planId: planned.plan.planId,

--- a/packages/plugin-backfill/src/runtime.ts
+++ b/packages/plugin-backfill/src/runtime.ts
@@ -1,17 +1,14 @@
-import { join } from 'node:path'
-import process from 'node:process'
-
 import type { ResolvedChxConfig } from '@chkit/core'
 
 import { BackfillConfigError } from './errors.js'
+import { executeWorkItems } from './executor.js'
+import type { ProgressEvent, WorkItem } from './executor.js'
 import {
   backfillPaths,
   collectActiveRunTargets,
-  computeBackfillStateDir,
   createRunState,
   ensureEnvironmentMatch,
   ensureRunCompatibility,
-  listPlanIds,
   nowIso,
   persistRunAndEvent,
   readPlan,
@@ -19,224 +16,33 @@ import {
   summarizeRunStatus,
 } from './state.js'
 import type {
-  BackfillDoctorReport,
-  BackfillPlanState,
   BackfillExecutionOptions,
-  BackfillPluginCheckResult,
+  BackfillPlanState,
   BackfillRunChunkState,
   BackfillRunState,
-  BackfillStatusSummary,
   ExecuteBackfillRunOutput,
   NormalizedBackfillPluginOptions,
 } from './types.js'
 
-export async function evaluateBackfillCheck(input: {
-  configPath: string
-  config: Pick<ResolvedChxConfig, 'metaDir'>
-  options: NormalizedBackfillPluginOptions
-}): Promise<BackfillPluginCheckResult> {
-  const stateDir = computeBackfillStateDir(input.config, input.configPath, input.options)
-  const plansDir = join(stateDir, 'plans')
-  const runsDir = join(stateDir, 'runs')
-
-  const planIds = await listPlanIds(plansDir)
-  if (planIds.length === 0) {
-    return {
-      plugin: 'backfill',
-      evaluated: true,
-      ok: true,
-      findings: [],
-      metadata: {
-        requiredCount: 0,
-        activeRuns: 0,
-        failedRuns: 0,
-      },
-    }
-  }
-
-  let requiredCount = 0
-  let activeRuns = 0
-  let failedRuns = 0
-
-  for (const planId of planIds) {
-    const runPath = join(runsDir, `${planId}.json`)
-    const run = await readRun(runPath)
-    if (!run) {
-      requiredCount += 1
-      continue
-    }
-
-    if (run.status === 'running') activeRuns += 1
-    if (run.status === 'failed') failedRuns += 1
-    if (run.status !== 'completed') requiredCount += 1
-  }
-
-  const findings: BackfillPluginCheckResult['findings'] = []
-  if (requiredCount > 0) {
-    findings.push({
-      code: 'backfill_required_pending',
-      message: `Required backfills pending completion: ${requiredCount}`,
-      severity: input.options.policy.failCheckOnRequiredPendingBackfill ? 'error' : 'warn',
-      metadata: {
-        requiredCount,
-      },
-    })
-  }
-
-  if (failedRuns > 0) {
-    findings.push({
-      code: 'backfill_chunk_failed_retry_exhausted',
-      message: `Backfill runs failed after retry budget: ${failedRuns}`,
-      severity: 'error',
-      metadata: {
-        failedRuns,
-      },
-    })
-  }
-
-  if (!input.options.policy.failCheckOnRequiredPendingBackfill) {
-    findings.push({
-      code: 'backfill_policy_relaxed',
-      message: 'Backfill check policy is relaxed: failCheckOnRequiredPendingBackfill=false.',
-      severity: 'warn',
-    })
-  }
-
-  const ok = findings.every((finding) => finding.severity !== 'error')
-  return {
-    plugin: 'backfill',
-    evaluated: true,
-    ok,
-    findings,
-    metadata: {
-      requiredCount,
-      activeRuns,
-      failedRuns,
-    },
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-async function executeChunk(input: {
-  run: BackfillRunState
+/** Adapter that bridges a BackfillRunChunkState to the generic WorkItem interface. */
+interface ChunkWorkItem extends WorkItem {
   chunk: BackfillRunChunkState
-  maxRetries: number
-  retryDelayMs: number
-  runPath: string
-  eventPath: string
-  execute?: (sql: string) => Promise<undefined | { rowsWritten?: number }>
-  simulation?: {
-    failChunkId?: string
-    failCount?: number
-  }
-}): Promise<{ ok: true } | { ok: false; error: string }> {
-  const failureBudget = input.simulation?.failCount ?? 0
+  sqlTemplate: string
+}
 
-  while (input.chunk.attempts < input.maxRetries) {
-    input.chunk.status = 'running'
-    input.chunk.attempts += 1
-    input.chunk.startedAt = nowIso()
+function toWorkItems(chunks: BackfillRunChunkState[]): ChunkWorkItem[] {
+  return chunks.map((chunk) => ({
+    id: chunk.id,
+    status: chunk.status,
+    attempts: chunk.attempts,
+    chunk,
+    sqlTemplate: chunk.sqlTemplate,
+  }))
+}
 
-    await persistRunAndEvent({
-      run: input.run,
-      runPath: input.runPath,
-      eventPath: input.eventPath,
-      event: {
-        type: 'chunk_started',
-        planId: input.run.planId,
-        chunkId: input.chunk.id,
-        attempt: input.chunk.attempts,
-      },
-    })
-
-    const shouldSimulateFailure =
-      input.simulation?.failChunkId === input.chunk.id && input.chunk.attempts <= failureBudget
-
-    let attemptError: string | undefined
-    let executionResult: undefined | { rowsWritten?: number } | undefined
-
-    if (shouldSimulateFailure) {
-      attemptError = `Simulated failure for chunk ${input.chunk.id} attempt ${input.chunk.attempts}`
-    } else if (input.execute) {
-      try {
-        executionResult = await input.execute(input.chunk.sqlTemplate)
-      } catch (error) {
-        attemptError = error instanceof Error ? error.message : String(error)
-      }
-    }
-
-    if (!attemptError) {
-      input.chunk.status = 'done'
-      input.chunk.completedAt = nowIso()
-      input.chunk.lastError = undefined
-      if (executionResult && typeof executionResult === 'object' && typeof executionResult.rowsWritten === 'number') {
-        input.chunk.rowsWritten = executionResult.rowsWritten
-      }
-
-      await persistRunAndEvent({
-        run: input.run,
-        runPath: input.runPath,
-        eventPath: input.eventPath,
-        event: {
-          type: 'chunk_done',
-          planId: input.run.planId,
-          chunkId: input.chunk.id,
-          attempt: input.chunk.attempts,
-        },
-      })
-
-      return { ok: true }
-    }
-
-    input.chunk.lastError = attemptError
-
-    if (input.chunk.attempts >= input.maxRetries) {
-      input.chunk.status = 'failed'
-
-      await persistRunAndEvent({
-        run: input.run,
-        runPath: input.runPath,
-        eventPath: input.eventPath,
-        event: {
-          type: 'chunk_failed_retry_exhausted',
-          planId: input.run.planId,
-          chunkId: input.chunk.id,
-          attempt: input.chunk.attempts,
-          message: attemptError,
-        },
-      })
-
-      return { ok: false, error: attemptError }
-    }
-
-    input.chunk.status = 'pending'
-
-    await persistRunAndEvent({
-      run: input.run,
-      runPath: input.runPath,
-      eventPath: input.eventPath,
-      event: {
-        type: 'chunk_retry_scheduled',
-        planId: input.run.planId,
-        chunkId: input.chunk.id,
-        attempt: input.chunk.attempts,
-        nextAttempt: input.chunk.attempts + 1,
-      },
-    })
-
-    if (input.retryDelayMs > 0) {
-      const delay = input.retryDelayMs * 2 ** (input.chunk.attempts - 1)
-      await sleep(delay)
-    }
-  }
-
-  return {
-    ok: false,
-    error: `Retry budget exhausted for chunk ${input.chunk.id}`,
-  }
+function syncBackFromWorkItem(item: ChunkWorkItem): void {
+  item.chunk.status = item.status
+  item.chunk.attempts = item.attempts
 }
 
 async function executeRunLoop(input: {
@@ -251,9 +57,9 @@ async function executeRunLoop(input: {
   execute?: (sql: string) => Promise<undefined | { rowsWritten?: number }>
 }): Promise<ExecuteBackfillRunOutput> {
   const maxRetries = input.plan.options.maxRetriesPerChunk
-  let aborted = false
+  const ac = new AbortController()
 
-  const onSignal = () => { aborted = true }
+  const onSignal = () => { ac.abort() }
   process.on('SIGINT', onSignal)
   process.on('SIGTERM', onSignal)
 
@@ -274,17 +80,15 @@ async function executeRunLoop(input: {
       },
     })
 
+    // Prepare chunks: apply skip/reset logic, then filter to executable set.
+    const executableItems: ChunkWorkItem[] = []
     for (const chunk of input.run.chunks) {
-      if (aborted) break
-
       if (chunk.status === 'done' && !input.run.replayDone) continue
 
       if (chunk.status === 'failed') {
         if (!input.run.replayFailed) {
-          // Skip previously failed chunk — continue to remaining chunks
           continue
         }
-
         chunk.status = 'pending'
         chunk.attempts = 0
         chunk.lastError = undefined
@@ -296,23 +100,106 @@ async function executeRunLoop(input: {
         chunk.status = 'pending'
       }
 
-      await executeChunk({
-        run: input.run,
-        chunk,
-        maxRetries,
-        retryDelayMs: input.retryDelayMs,
-        runPath: input.paths.runPath,
-        eventPath: input.paths.eventPath,
-        execute: input.execute,
-        simulation: input.execution.simulation,
-      })
-
+      executableItems.push(...toWorkItems([chunk]))
     }
 
-    // Determine final run status after all chunks have been attempted
+    // Simulation support: wrap the execute function to inject failures.
+    const failureBudget = input.execution.simulation?.failCount ?? 0
+    const failChunkId = input.execution.simulation?.failChunkId
+
+    const wrappedExecute = async (item: ChunkWorkItem): Promise<void> => {
+      // The executor has already incremented item.attempts and set
+      // item.status = 'running' before calling execute.  Use item.attempts
+      // (already incremented) for the simulation budget check.
+      const shouldSimulateFailure =
+        failChunkId === item.id && item.attempts <= failureBudget
+
+      if (shouldSimulateFailure) {
+        throw new Error(`Simulated failure for chunk ${item.id} attempt ${item.attempts}`)
+      }
+
+      if (input.execute) {
+        const result = await input.execute(item.sqlTemplate)
+        if (result && typeof result === 'object' && typeof result.rowsWritten === 'number') {
+          item.chunk.rowsWritten = result.rowsWritten
+        }
+      }
+    }
+
+    const result = await executeWorkItems(
+      executableItems,
+      wrappedExecute,
+      { maxRetries, retryDelayMs: input.retryDelayMs },
+      {
+        onProgress: async (item: ChunkWorkItem, event: ProgressEvent, meta) => {
+          // Keep the chunk state in sync with the work item
+          syncBackFromWorkItem(item)
+
+          if (event === 'item_started') {
+            item.chunk.startedAt = nowIso()
+            await persistRunAndEvent({
+              run: input.run,
+              runPath: input.paths.runPath,
+              eventPath: input.paths.eventPath,
+              event: {
+                type: 'chunk_started',
+                planId: input.run.planId,
+                chunkId: item.id,
+                attempt: item.attempts,
+              },
+            })
+          } else if (event === 'item_done') {
+            item.chunk.completedAt = nowIso()
+            item.chunk.lastError = undefined
+            await persistRunAndEvent({
+              run: input.run,
+              runPath: input.paths.runPath,
+              eventPath: input.paths.eventPath,
+              event: {
+                type: 'chunk_done',
+                planId: input.run.planId,
+                chunkId: item.id,
+                attempt: item.attempts,
+              },
+            })
+          } else if (event === 'item_retry') {
+            item.chunk.lastError = meta?.error
+            await persistRunAndEvent({
+              run: input.run,
+              runPath: input.paths.runPath,
+              eventPath: input.paths.eventPath,
+              event: {
+                type: 'chunk_retry_scheduled',
+                planId: input.run.planId,
+                chunkId: item.id,
+                attempt: item.attempts,
+                nextAttempt: meta?.nextAttempt,
+              },
+            })
+          } else if (event === 'item_failed') {
+            item.chunk.lastError = meta?.error
+            await persistRunAndEvent({
+              run: input.run,
+              runPath: input.paths.runPath,
+              eventPath: input.paths.eventPath,
+              event: {
+                type: 'chunk_failed_retry_exhausted',
+                planId: input.run.planId,
+                chunkId: item.id,
+                attempt: item.attempts,
+                message: meta?.error,
+              },
+            })
+          }
+        },
+      },
+      ac.signal,
+    )
+
+    // Determine final run status
     const failedChunks = input.run.chunks.filter((c) => c.status === 'failed')
 
-    if (!aborted && failedChunks.length > 0) {
+    if (!result.aborted && failedChunks.length > 0) {
       input.run.status = 'failed'
       input.run.lastError =
         failedChunks[failedChunks.length - 1]?.lastError ?? 'One or more chunks failed'
@@ -338,7 +225,7 @@ async function executeRunLoop(input: {
       }
     }
 
-    if (!aborted) {
+    if (!result.aborted) {
       input.run.status = 'completed'
       input.run.completedAt = nowIso()
       input.run.lastError = undefined
@@ -540,142 +427,4 @@ export async function resumeBackfillRun(input: {
     retryDelayMs: input.options.defaults.retryDelayMs,
     execute: input.execute,
   })
-}
-
-export async function getBackfillStatus(input: {
-  planId: string
-  configPath: string
-  config: Pick<ResolvedChxConfig, 'metaDir'>
-  options: NormalizedBackfillPluginOptions
-}): Promise<BackfillStatusSummary> {
-  const { plan, stateDir } = await readPlan({
-    planId: input.planId,
-    configPath: input.configPath,
-    config: input.config,
-    options: input.options,
-  })
-  const paths = backfillPaths(stateDir, plan.planId)
-  const run = await readRun(paths.runPath)
-
-  if (!run) {
-    return {
-      planId: plan.planId,
-      target: plan.target,
-      status: 'planned',
-      totals: {
-        total: plan.chunks.length,
-        pending: plan.chunks.length,
-        running: 0,
-        done: 0,
-        failed: 0,
-        skipped: 0,
-      },
-      attempts: 0,
-      rowsWritten: 0,
-      updatedAt: plan.createdAt,
-      runPath: paths.runPath,
-      eventPath: paths.eventPath,
-    }
-  }
-
-  return summarizeRunStatus(run, paths.runPath, paths.eventPath)
-}
-
-export async function cancelBackfillRun(input: {
-  planId: string
-  configPath: string
-  config: Pick<ResolvedChxConfig, 'metaDir'>
-  options: NormalizedBackfillPluginOptions
-}): Promise<BackfillStatusSummary> {
-  const { plan, stateDir } = await readPlan({
-    planId: input.planId,
-    configPath: input.configPath,
-    config: input.config,
-    options: input.options,
-  })
-  const paths = backfillPaths(stateDir, plan.planId)
-  const run = await readRun(paths.runPath)
-
-  if (!run) {
-    throw new BackfillConfigError(
-      `Run state not found for plan ${plan.planId}. Start with backfill run before cancel.`
-    )
-  }
-  if (run.status === 'completed') {
-    throw new BackfillConfigError(`Run already completed for plan ${plan.planId}; cannot cancel.`)
-  }
-  if (run.status === 'cancelled') {
-    return summarizeRunStatus(run, paths.runPath, paths.eventPath)
-  }
-
-  run.status = 'cancelled'
-  run.completedAt = nowIso()
-  run.lastError = 'Cancelled by operator'
-  for (const chunk of run.chunks) {
-    if (chunk.status === 'running') {
-      chunk.status = 'pending'
-    }
-  }
-
-  await persistRunAndEvent({
-    run,
-    runPath: paths.runPath,
-    eventPath: paths.eventPath,
-    event: {
-      type: 'run_cancelled',
-      planId: plan.planId,
-    },
-  })
-
-  return summarizeRunStatus(run, paths.runPath, paths.eventPath)
-}
-
-export async function getBackfillDoctorReport(input: {
-  planId: string
-  configPath: string
-  config: Pick<ResolvedChxConfig, 'metaDir'>
-  options: NormalizedBackfillPluginOptions
-}): Promise<BackfillDoctorReport> {
-  const status = await getBackfillStatus(input)
-  const issueCodes: string[] = []
-  const recommendations: string[] = []
-  const failedChunkIds: string[] = []
-
-  const run = await readRun(status.runPath)
-  for (const chunk of run?.chunks ?? []) {
-    if (chunk.status === 'failed') failedChunkIds.push(chunk.id)
-  }
-
-  if (status.status === 'planned') {
-    issueCodes.push('backfill_plan_missing')
-    recommendations.push(`Run: chkit plugin backfill run --plan-id ${status.planId}`)
-  }
-  if (status.status === 'failed') {
-    issueCodes.push('backfill_chunk_failed_retry_exhausted')
-    recommendations.push(`Inspect status: chkit plugin backfill status --plan-id ${status.planId}`)
-    recommendations.push(
-      `Retry failed chunks: chkit plugin backfill resume --plan-id ${status.planId} --replay-failed`
-    )
-  }
-  if (status.status === 'cancelled') {
-    issueCodes.push('backfill_required_pending')
-    recommendations.push(
-      `Resume execution: chkit plugin backfill resume --plan-id ${status.planId} --replay-failed`
-    )
-  }
-  if (status.status === 'running') {
-    issueCodes.push('backfill_required_pending')
-    recommendations.push(`Monitor progress: chkit plugin backfill status --plan-id ${status.planId}`)
-  }
-  if (issueCodes.length === 0) {
-    recommendations.push('No remediation required.')
-  }
-
-  return {
-    planId: status.planId,
-    status: status.status,
-    issueCodes,
-    recommendations,
-    failedChunkIds,
-  }
 }

--- a/packages/plugin-backfill/src/state.ts
+++ b/packages/plugin-backfill/src/state.ts
@@ -65,11 +65,11 @@ export function planIdentity(
   target: string,
   from: string,
   to: string,
-  chunkHours: number,
+  chunkParam: number | string,
   timeColumn: string,
   envFingerprint?: string
 ): string {
-  const base = `${target}|${from}|${to}|${chunkHours}|${timeColumn}`
+  const base = `${target}|${from}|${to}|${chunkParam}|${timeColumn}`
   return envFingerprint ? `${base}|${envFingerprint}` : base
 }
 

--- a/packages/plugin-backfill/src/state.ts
+++ b/packages/plugin-backfill/src/state.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -61,16 +61,8 @@ export function computeCompatibilityToken(input: {
   )
 }
 
-export function planIdentity(
-  target: string,
-  from: string,
-  to: string,
-  chunkParam: number | string,
-  timeColumn: string,
-  envFingerprint?: string
-): string {
-  const base = `${target}|${from}|${to}|${chunkParam}|${timeColumn}`
-  return envFingerprint ? `${base}|${envFingerprint}` : base
+export function randomPlanId(): string {
+  return randomBytes(8).toString('hex')
 }
 
 export function computeEnvironmentFingerprint(
@@ -145,10 +137,6 @@ export async function writeJson(filePath: string, value: unknown): Promise<void>
 async function appendEvent(eventPath: string, event: Record<string, unknown>): Promise<void> {
   await mkdir(dirname(eventPath), { recursive: true })
   await appendFile(eventPath, `${JSON.stringify({ at: nowIso(), ...event })}\n`, 'utf8')
-}
-
-export async function readExistingPlan(planPath: string): Promise<BackfillPlanState | null> {
-  return readJsonMaybe<BackfillPlanState>(planPath)
 }
 
 export async function readPlan(input: {

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -178,7 +178,6 @@ export interface BackfillPluginCheckResult {
 export interface BuildBackfillPlanOutput {
   plan: BackfillPlanState
   planPath: string
-  existed: boolean
 }
 
 export interface ReadPlanOutput {
@@ -281,7 +280,6 @@ export interface ParsedPlanArgs {
   from?: string
   to?: string
   maxChunkBytes?: number
-  force: boolean
 }
 
 export interface ParsedRunArgs {

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -1,5 +1,7 @@
 import type { ChxInlinePluginRegistration, ResolvedChxConfig } from '@chkit/core'
 
+import type { PartitionInfo, SortKeyInfo } from './chunking/types.js'
+
 export interface BackfillPluginDefaults {
   chunkHours?: number
   maxParallelChunks?: number
@@ -29,7 +31,8 @@ export interface BackfillPluginOptions {
 }
 
 export interface NormalizedBackfillDefaults {
-  chunkHours: number
+  chunkHours?: number
+  maxChunkBytes: number
   maxParallelChunks: number
   maxRetriesPerChunk: number
   retryDelayMs: number
@@ -52,6 +55,8 @@ export interface BackfillEnvironment {
 
 export type BackfillPlanStatus = 'planned' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled'
 
+export type { ChunkBoundary, PartitionInfo, PlannedChunk, SortKeyInfo } from './chunking/types.js'
+
 export interface BackfillChunk {
   id: string
   from: string
@@ -61,6 +66,10 @@ export interface BackfillChunk {
   idempotencyToken: string
   sqlTemplate: string
   lastError?: string
+  partitionId: string
+  estimatedBytes: number
+  sortKeyFrom?: string
+  sortKeyTo?: string
 }
 
 export interface BackfillPlanState {
@@ -68,17 +77,21 @@ export interface BackfillPlanState {
   target: string
   createdAt: string
   status: BackfillPlanStatus
-  strategy?: 'table' | 'mv_replay'
+  strategy?: 'table' | 'mv_replay' | 'partition'
   environment?: BackfillEnvironment
   from: string
   to: string
   chunks: BackfillChunk[]
+  partitions?: PartitionInfo[]
+  sortKey?: SortKeyInfo
   options: {
-    chunkHours: number
+    chunkHours?: number
+    maxChunkBytes?: number
     maxParallelChunks: number
     maxRetriesPerChunk: number
     requireIdempotencyToken: boolean
-    timeColumn: string
+    timeColumn?: string
+    sortKeyColumn?: string
   }
   policy: Required<BackfillPluginPolicy>
   limits: Required<BackfillPluginLimits>
@@ -265,11 +278,9 @@ export interface TimeColumnCandidate {
 
 export interface ParsedPlanArgs {
   target: string
-  from: string
-  to: string
-  chunkHours?: number
-  timeColumn?: string
-  forceLargeWindow: boolean
+  from?: string
+  to?: string
+  maxChunkBytes?: number
   force: boolean
 }
 


### PR DESCRIPTION
## Summary
- Reorganize plugin-backfill into independent, composable subsystems (chunking analysis, SQL generation, execution engine) to support both same-instance backfill and future remote-copy use cases
- Extract `chunking/` subsystem with `analyzeTable` + `buildPlannedChunks` (boundary computation without SQL) and separate `chunking/sql.ts` for SQL template generation — different strategies can stamp different SQL onto the same chunk boundaries
- Extract generic `executor.ts` with retry/backoff, `AbortSignal` support, and `onProgress` hook — domain-agnostic, reusable for any chunk-based workload
- Split `runtime.ts` into execution (`runtime.ts`), read-only queries (`queries.ts`), and check hook (`check.ts`); fix unused imports, redundant disk reads, and type inconsistencies (`partitionId`/`estimatedBytes` now required on `BackfillChunk`)
- Export `analyzeAndChunk`, `analyzeTable`, `buildPlannedChunks`, `buildChunkSql`, `executeWorkItems` from package index for external script consumption

## Test plan
- [x] All 111 existing tests pass (0 failures)
- [x] TypeScript typechecks clean
- [x] Full `bun verify` passes (typecheck + lint + test + build across all packages)
- [x] Partition-planner tests rewritten to use new `buildPlannedChunks` + `buildChunkSql` API directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)