### PR TITLE
fix: use ReplacingMergeTree for journal table on ClickHouse Cloud

### DIFF
--- a/.changeset/journal-replacing-mergetree.md
+++ b/.changeset/journal-replacing-mergetree.md
@@ -1,0 +1,6 @@
+---
+"chkit": patch
+"@chkit/plugin-codegen": patch
+---
+
+Use ReplacingMergeTree(applied_at) instead of MergeTree() for the _chkit_migrations journal table. This ensures the FINAL keyword works correctly on ClickHouse Cloud, where SharedMergeTree does not support FINAL but SharedReplacingMergeTree does.

--- a/packages/cli/src/bin/journal-store.ts
+++ b/packages/cli/src/bin/journal-store.ts
@@ -43,7 +43,7 @@ export function createJournalStore(db: ClickHouseExecutor): JournalStore {
     applied_at DateTime64(3, 'UTC'),
     checksum String,
     chkit_version String
-) ENGINE = MergeTree()
+) ENGINE = ReplacingMergeTree(applied_at)
 ORDER BY (name)
 SETTINGS index_granularity = 1`
   let bootstrapped = false

--- a/packages/plugin-codegen/src/generators/migration-artifacts.ts
+++ b/packages/plugin-codegen/src/generators/migration-artifacts.ts
@@ -88,7 +88,7 @@ export async function runMigrations(
       applied_at DateTime64(3, 'UTC') DEFAULT now64(3),
       checksum String,
       chkit_version String DEFAULT 'runtime'
-    ) ENGINE = MergeTree() ORDER BY (name)
+    ) ENGINE = ReplacingMergeTree(applied_at) ORDER BY (name)
   \`)
 
   // Read already-applied migrations


### PR DESCRIPTION
## Summary
- Changes the `_chkit_migrations` journal table engine from `MergeTree()` to `ReplacingMergeTree(applied_at)` in both the CLI runtime (`journal-store.ts`) and the codegen template (`migration-artifacts.ts`)
- On ClickHouse Cloud, `SharedMergeTree` does not support `FINAL`, but `SharedReplacingMergeTree` does — this fix ensures duplicate migration entries are correctly collapsed
- The `FINAL` keyword on the journal `SELECT` query is preserved

## Test plan
- [x] `bun verify` passes (typecheck, lint, test, build)
- [ ] E2E: run `chkit migrate` against ClickHouse Cloud and verify journal table uses ReplacingMergeTree

🤖 Generated with [Claude Code](https://claude.com/claude-code)