### PR TITLE
[codex] fix fallow dead code

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@astrojs/starlight": "^0.37.6",
     "astro": "^5.6.1",
-    "sharp": "^0.34.2",
-    "zod": "^3.25.76"
+    "sharp": "^0.34.2"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -23,17 +23,16 @@
     },
     "apps/docs": {
       "name": "@chkit/docs",
-      "version": "0.0.2-beta.9",
+      "version": "0.0.2-beta.10",
       "dependencies": {
         "@astrojs/starlight": "^0.37.6",
         "astro": "^5.6.1",
         "sharp": "^0.34.2",
-        "zod": "^3.25.76",
       },
     },
     "packages/cli": {
       "name": "chkit",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "bin": {
         "chkit": "./dist/bin/chkit.js",
       },
@@ -41,14 +40,13 @@
         "@chkit/clickhouse": "workspace:*",
         "@chkit/codegen": "workspace:*",
         "@chkit/core": "workspace:*",
-        "@clickhouse/client": "^1.11.0",
         "@logtape/logtape": "^2.0.5",
         "fast-glob": "^3.3.2",
       },
     },
     "packages/clickhouse": {
       "name": "@chkit/clickhouse",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "@clickhouse/client": "^1.11.0",
@@ -58,14 +56,14 @@
     },
     "packages/codegen": {
       "name": "@chkit/codegen",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "@chkit/core": "workspace:*",
       },
     },
     "packages/core": {
       "name": "@chkit/core",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "fast-glob": "^3.3.2",
       },
@@ -75,7 +73,7 @@
     },
     "packages/plugin-backfill": {
       "name": "@chkit/plugin-backfill",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -86,7 +84,7 @@
     },
     "packages/plugin-codegen": {
       "name": "@chkit/plugin-codegen",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "zod": "^4.3.6",
@@ -94,7 +92,7 @@
     },
     "packages/plugin-obsessiondb": {
       "name": "@chkit/plugin-obsessiondb",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -105,7 +103,7 @@
     },
     "packages/plugin-pull": {
       "name": "@chkit/plugin-pull",
-      "version": "0.1.0-beta.20",
+      "version": "0.1.0-beta.21",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,11 +39,10 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@clickhouse/client": "^1.11.0",
+    "fast-glob": "^3.3.2",
     "@chkit/clickhouse": "workspace:*",
     "@chkit/codegen": "workspace:*",
     "@chkit/core": "workspace:*",
-    "@logtape/logtape": "^2.0.5",
-    "fast-glob": "^3.3.2"
+    "@logtape/logtape": "^2.0.5"
   }
 }

--- a/packages/cli/src/bin/command-dispatch.ts
+++ b/packages/cli/src/bin/command-dispatch.ts
@@ -10,7 +10,7 @@ import type { PluginRuntime } from './plugin-runtime.js'
 import { loadSchemaDefinitions } from './schema-loader.js'
 import { resolveTableScope, tableKeysFromDefinitions } from './table-scope.js'
 
-export function stripGlobalFlags(argv: string[]): {
+function stripGlobalFlags(argv: string[]): {
   jsonMode: boolean
   tableSelector: string | undefined
   rest: string[]

--- a/packages/cli/src/bin/commands/drift.ts
+++ b/packages/cli/src/bin/commands/drift.ts
@@ -16,7 +16,7 @@ import { emitJson } from '../json-output.js'
 import { readSnapshot } from '../migration-store.js'
 import { resolveTableScope, tableKeysFromDefinitions, type TableScope } from '../table-scope.js'
 
-export interface DriftPayload {
+interface DriftPayload {
   scope?: TableScope
   snapshotFile: string
   expectedCount: number

--- a/packages/cli/src/bin/internal-plugins/skill-hint.ts
+++ b/packages/cli/src/bin/internal-plugins/skill-hint.ts
@@ -9,7 +9,7 @@ export type AgentKind = 'claude' | 'cursor' | 'copilot' | 'windsurf' | 'roo' | '
 
 interface AgentInfo { name: string; skillsDir: string }
 
-export const AGENT_REGISTRY: Record<Exclude<AgentKind, 'unknown'>, AgentInfo> = {
+const AGENT_REGISTRY: Record<Exclude<AgentKind, 'unknown'>, AgentInfo> = {
   claude:   { name: 'Claude Code', skillsDir: '.claude/skills' },
   cursor:   { name: 'Cursor',      skillsDir: '.agents/skills' },
   copilot:  { name: 'Copilot',     skillsDir: '.agents/skills' },
@@ -33,7 +33,7 @@ const AGENT_MARKERS: { path: string; agent: AgentKind }[] = [
   { path: '.trae', agent: 'trae' },
 ]
 
-export interface AgentRootResult { root: string; agent: AgentKind }
+interface AgentRootResult { root: string; agent: AgentKind }
 
 /**
  * Walk up from `cwd` to find the best directory for installing agent skills.

--- a/packages/cli/src/bin/journal-store.ts
+++ b/packages/cli/src/bin/journal-store.ts
@@ -1,11 +1,10 @@
-import { createClickHouseExecutor, isUnknownDatabaseError, type ClickHouseExecutor } from '@chkit/clickhouse'
-import type { ChxConfig } from '@chkit/core'
+import { isUnknownDatabaseError, type ClickHouseExecutor } from '@chkit/clickhouse'
 
 import type { MigrationJournal, MigrationJournalEntry } from './migration-store.js'
 import { CLI_VERSION } from './version.js'
 import { debug } from './debug.js'
 
-export interface JournalStore {
+interface JournalStore {
   readJournal(): Promise<MigrationJournal>
   appendEntry(entry: MigrationJournalEntry): Promise<void>
   readonly databaseMissing: boolean
@@ -151,11 +150,4 @@ SETTINGS index_granularity = 1`
       }
     },
   }
-}
-
-export function createJournalStoreFromConfig(
-  clickhouseConfig: NonNullable<ChxConfig['clickhouse']>
-): { journalStore: JournalStore; db: ClickHouseExecutor } {
-  const db = createClickHouseExecutor(clickhouseConfig)
-  return { journalStore: createJournalStore(db), db }
 }

--- a/packages/cli/src/bin/json-output.ts
+++ b/packages/cli/src/bin/json-output.ts
@@ -1,4 +1,4 @@
-export type Command =
+type Command =
   | 'generate'
   | 'migrate'
   | 'status'
@@ -18,7 +18,7 @@ export function printOutput(value: unknown, jsonMode: boolean): void {
   }
 }
 
-export function jsonPayload<T extends object>(command: Command, payload: T): T & {
+function jsonPayload<T extends object>(command: Command, payload: T): T & {
   command: Command
   schemaVersion: number
 } {

--- a/packages/cli/src/bin/lib.ts
+++ b/packages/cli/src/bin/lib.ts
@@ -1,36 +1,5 @@
 export { CLI_VERSION } from './version.js'
 
-export {
-  DEFAULT_CONFIG_FILE,
-  loadConfig,
-  resolveDirs,
-  writeIfMissing,
-} from './config.js'
-export {
-  createJournalStore,
-  createJournalStoreFromConfig,
-  type JournalStore,
-} from './journal-store.js'
-export {
-  checksumSQL,
-  findChecksumMismatches,
-  listMigrations,
-  parseJSONOrThrow,
-  readSnapshot,
-  summarizePlan,
-  type ChecksumMismatch,
-  type MigrationJournal,
-  type MigrationJournalEntry,
-} from './migration-store.js'
-export { emitJson, jsonPayload, printOutput, type Command } from './json-output.js'
-export {
-  collectDestructiveOperationMarkers,
-  extractMigrationOperationSummaries,
-  extractDestructiveOperationSummaries,
-  extractExecutableStatements,
-  migrationContainsDangerOperation,
-  parseOperationLine,
-  type MigrationOperationSummary,
-  type DestructiveOperationMarker,
-} from './safety-markers.js'
+export { readSnapshot, summarizePlan } from './migration-store.js'
+export { emitJson } from './json-output.js'
 export { loadSchemaDefinitions } from './schema-loader.js'

--- a/packages/cli/src/bin/migration-store.ts
+++ b/packages/cli/src/bin/migration-store.ts
@@ -18,13 +18,13 @@ export interface MigrationJournal {
   applied: MigrationJournalEntry[]
 }
 
-export interface ChecksumMismatch {
+interface ChecksumMismatch {
   name: string
   expected: string
   actual: string
 }
 
-export function parseJSONOrThrow<T>(raw: string, filePath: string, kind: string): T {
+function parseJSONOrThrow<T>(raw: string, filePath: string, kind: string): T {
   try {
     return JSON.parse(raw) as T
   } catch {

--- a/packages/cli/src/bin/safety-markers.ts
+++ b/packages/cli/src/bin/safety-markers.ts
@@ -14,7 +14,7 @@ export interface DestructiveOperationMarker {
   summary: string
 }
 
-export interface MigrationOperationSummary {
+interface MigrationOperationSummary {
   type: string
   key: string
   risk: string
@@ -25,7 +25,7 @@ export function migrationContainsDangerOperation(sql: string): boolean {
   return extractDestructiveOperationSummaries(sql).length > 0
 }
 
-export function extractDestructiveOperationSummaries(sql: string): string[] {
+function extractDestructiveOperationSummaries(sql: string): string[] {
   return sql
     .split('\n')
     .map((line) => line.trim())
@@ -33,7 +33,7 @@ export function extractDestructiveOperationSummaries(sql: string): string[] {
     .map((line) => line.replace(/^-- operation:\s*/, ''))
 }
 
-export function parseOperationLine(summary: string): MigrationOperationSummary | null {
+function parseOperationLine(summary: string): MigrationOperationSummary | null {
   const match = summary.match(/^([a-z_]+)\s+key=([^\s]+)\s+risk=([a-z_]+)$/)
   if (!match) return null
   return {

--- a/packages/cli/src/bin/table-scope.ts
+++ b/packages/cli/src/bin/table-scope.ts
@@ -18,7 +18,7 @@ export interface TableScope {
   matchCount: number
 }
 
-export interface TableScopeFilterResult {
+interface TableScopeFilterResult {
   plan: MigrationPlan
   omittedOperationCount: number
 }
@@ -30,7 +30,7 @@ interface TableRenameMapping {
   newName: string
 }
 
-export function tableKey(database: string, name: string): string {
+function tableKey(database: string, name: string): string {
   return `${database}.${name}`
 }
 

--- a/packages/cli/src/drift.ts
+++ b/packages/cli/src/drift.ts
@@ -8,7 +8,7 @@ import {
 } from '@chkit/core'
 import { diffByName, diffNamedShapeMaps, diffSettings } from './drift-diff.js'
 
-export type TableDriftReasonCode =
+type TableDriftReasonCode =
   | 'missing_column'
   | 'extra_column'
   | 'changed_column'
@@ -22,10 +22,10 @@ export type TableDriftReasonCode =
   | 'unique_key_mismatch'
   | 'projection_mismatch'
 
-export type ObjectDriftReasonCode = 'missing_object' | 'extra_object' | 'kind_mismatch'
-export type DriftReasonCode = ObjectDriftReasonCode | TableDriftReasonCode
+type ObjectDriftReasonCode = 'missing_object' | 'extra_object' | 'kind_mismatch'
+type DriftReasonCode = ObjectDriftReasonCode | TableDriftReasonCode
 
-export interface SchemaObjectShape {
+interface SchemaObjectShape {
   kind: 'table' | 'view' | 'materialized_view'
   database: string
   name: string
@@ -38,7 +38,7 @@ export interface ObjectDriftDetail {
   actualKind?: SchemaObjectShape['kind']
 }
 
-export interface ActualTableShape {
+interface ActualTableShape {
   columns: ColumnDefinition[]
   settings: Record<string, string>
   indexes: SkipIndexDefinition[]
@@ -68,7 +68,7 @@ export interface TableDriftDetail {
   projectionDiffs: string[]
 }
 
-export interface DriftReasonSummary {
+interface DriftReasonSummary {
   counts: Partial<Record<DriftReasonCode, number>>
   total: number
   object: number

--- a/packages/core/src/diff-primitives.ts
+++ b/packages/core/src/diff-primitives.ts
@@ -1,10 +1,10 @@
-export interface NamedDiffChange<T> {
+interface NamedDiffChange<T> {
   name: string
   oldItem: T
   newItem: T
 }
 
-export interface NamedDiffResult<T> {
+interface NamedDiffResult<T> {
   added: T[]
   removed: T[]
   changed: NamedDiffChange<T>[]
@@ -48,7 +48,7 @@ export function diffByName<T>(
   }
 }
 
-export interface SettingDiffResult {
+interface SettingDiffResult {
   changes: Array<
     | { kind: 'modify'; key: string; value: string | number | boolean }
     | { kind: 'reset'; key: string }
@@ -79,7 +79,7 @@ export function diffSettings(
   }
 }
 
-export interface ClauseComparison {
+interface ClauseComparison {
   oldValue: string
   newValue: string
 }

--- a/packages/core/src/sql.ts
+++ b/packages/core/src/sql.ts
@@ -101,7 +101,7 @@ function renderDependsOn(dependsOn: Array<{ database: string; name: string }>): 
  *                [DEPENDS ON <list>] [SETTINGS <kv>] [APPEND]
  * Note: EMPTY belongs after TO in CREATE, so it's NOT included here.
  */
-export function renderRefreshClause(refresh: MaterializedViewRefresh): string {
+function renderRefreshClause(refresh: MaterializedViewRefresh): string {
   const parts: string[] = []
   if (refresh.every) parts.push(`REFRESH EVERY ${refresh.every}`)
   else if (refresh.after) parts.push(`REFRESH AFTER ${refresh.after}`)

--- a/packages/plugin-backfill/src/chunking/boundary-codec.ts
+++ b/packages/plugin-backfill/src/chunking/boundary-codec.ts
@@ -6,7 +6,7 @@ import type {
   SortKey,
 } from './types.js'
 
-export function encodeBoundary(
+function encodeBoundary(
   value: string | undefined,
   sortKey: SortKey | undefined,
 ): string | undefined {
@@ -17,7 +17,7 @@ export function encodeBoundary(
   return value
 }
 
-export function decodeBoundary(
+function decodeBoundary(
   value: string | undefined,
   sortKey: SortKey | undefined,
 ): string | undefined {
@@ -28,7 +28,7 @@ export function decodeBoundary(
   return value
 }
 
-export function encodeRangesForPlan(
+function encodeRangesForPlan(
   ranges: ChunkRange[],
   sortKeys: SortKey[],
 ): ChunkRange[] {
@@ -39,7 +39,7 @@ export function encodeRangesForPlan(
   }))
 }
 
-export function decodeRangesFromPlan(
+function decodeRangesFromPlan(
   ranges: ChunkRange[],
   sortKeys: SortKey[],
 ): ChunkRange[] {
@@ -72,7 +72,7 @@ function decodeFocusedValue(
   }
 }
 
-export function encodeChunkForPlan(chunk: Chunk, sortKeys: SortKey[]): Chunk {
+function encodeChunkForPlan(chunk: Chunk, sortKeys: SortKey[]): Chunk {
   return {
     ...chunk,
     ranges: encodeRangesForPlan(chunk.ranges, sortKeys),
@@ -83,7 +83,7 @@ export function encodeChunkForPlan(chunk: Chunk, sortKeys: SortKey[]): Chunk {
   }
 }
 
-export function decodeChunkFromPlan(chunk: Chunk, sortKeys: SortKey[]): Chunk {
+function decodeChunkFromPlan(chunk: Chunk, sortKeys: SortKey[]): Chunk {
   return {
     ...chunk,
     ranges: decodeRangesFromPlan(chunk.ranges, sortKeys),

--- a/packages/plugin-backfill/src/chunking/services/row-probe.ts
+++ b/packages/plugin-backfill/src/chunking/services/row-probe.ts
@@ -53,32 +53,6 @@ export async function countRowsExact(
   return Number(rows[0]?.cnt ?? 0)
 }
 
-export async function countRows(
-  context: QueryContext,
-  partitionId: string,
-  ranges: ChunkRange[],
-  sortKeys: SortKey[],
-): Promise<number> {
-  const filter: EstimateFilter = {
-    partitionId,
-    ranges,
-    exactDimensionIndex: undefined,
-    exactValue: undefined,
-  }
-  return countRowsExact(context, filter, sortKeys)
-}
-
-export async function countPartitionRows(
-  context: QueryContext,
-  partitionId: string,
-): Promise<number> {
-  const rows = await context.query<{ cnt: string }>(
-    `SELECT count() AS cnt FROM ${context.database}.${context.table} WHERE _partition_id = '${partitionId}'`,
-    context.querySettings,
-  )
-  return Number(rows[0]?.cnt ?? 0)
-}
-
 export async function getSortKeyRange(
   context: QueryContext,
   partitionId: string,

--- a/packages/plugin-backfill/src/chunking/sql.ts
+++ b/packages/plugin-backfill/src/chunking/sql.ts
@@ -9,11 +9,11 @@ import type {
 } from './types.js'
 
 
-export function quoteSqlString(value: string): string {
+function quoteSqlString(value: string): string {
   return `'${value.replaceAll('\\', '\\\\').replaceAll('\'', '\\\'')}'`
 }
 
-export function formatBound(value: string, sortKey: SortKey): string {
+function formatBound(value: string, sortKey: SortKey): string {
   if (sortKey.category === 'datetime') {
     return `parseDateTimeBestEffort(${quoteSqlString(value)})`
   }

--- a/packages/plugin-backfill/src/chunking/strategies/equal-width-split.ts
+++ b/packages/plugin-backfill/src/chunking/strategies/equal-width-split.ts
@@ -10,7 +10,7 @@ import type {
 import { replaceChunkRange } from '../utils/ranges.js'
 import { buildEvenlySpacedBoundaries } from './quantile-range-split.js'
 
-export const DEFAULT_OVERSAMPLING_MULTIPLIER = 3
+const DEFAULT_OVERSAMPLING_MULTIPLIER = 3
 const ESTIMATE_CONCURRENCY = 50
 
 export async function splitSliceWithEqualWidthRanges(

--- a/packages/plugin-backfill/src/chunking/strategies/refinement.ts
+++ b/packages/plugin-backfill/src/chunking/strategies/refinement.ts
@@ -55,7 +55,7 @@ export async function refinePartitionSlices(
   }
 }
 
-export function buildPartitionDiagnostics(
+function buildPartitionDiagnostics(
   partition: Partition,
   slices: PartitionSlice[],
   usedDistributionFallback: boolean,

--- a/packages/plugin-backfill/src/chunking/strategies/temporal-bucket-split.ts
+++ b/packages/plugin-backfill/src/chunking/strategies/temporal-bucket-split.ts
@@ -47,7 +47,7 @@ export async function splitSliceWithTemporalBuckets(
   return buildTemporalSlices(partition, slice, dimensionIndex, hourBuckets, context.targetChunkBytes)
 }
 
-export function getPartitionEndExclusive(partition: Partition): string {
+function getPartitionEndExclusive(partition: Partition): string {
   return new Date(parsePlannerDateTime(partition.maxTime) + 1000).toISOString()
 }
 

--- a/packages/plugin-backfill/src/chunking/types.ts
+++ b/packages/plugin-backfill/src/chunking/types.ts
@@ -2,7 +2,7 @@ export type RowProbeStrategy = 'explain-estimate' | 'count'
 
 export type SortKeyCategory = 'numeric' | 'datetime' | 'string'
 
-export type SortKeyBoundaryEncoding = 'literal' | 'hex-latin1'
+type SortKeyBoundaryEncoding = 'literal' | 'hex-latin1'
 
 export type EstimateConfidence = 'high' | 'low' | 'exact'
 
@@ -47,7 +47,7 @@ export interface FocusedValue {
   value: string
 }
 
-export interface ChunkAnalysis {
+interface ChunkAnalysis {
   focusedValue?: FocusedValue
   lineage: ChunkDerivationStep[]
 }
@@ -87,7 +87,7 @@ export interface TableProfile {
   sortKeys: SortKey[]
 }
 
-export interface ChunkPlanStats {
+interface ChunkPlanStats {
   totalPartitions: number
   oversizedPartitions: number
   focusedChunks: number
@@ -152,10 +152,6 @@ export interface PartitionSlice {
 export interface PartitionBuildResult {
   slices: PartitionSlice[]
   diagnostics: PartitionDiagnostics
-}
-
-export interface PlanChunkOptions {
-  requireIdempotencyToken: boolean
 }
 
 export interface GenerateChunkPlanInput {

--- a/packages/plugin-backfill/src/detect.ts
+++ b/packages/plugin-backfill/src/detect.ts
@@ -1,6 +1,3 @@
-import { dirname } from 'node:path'
-
-import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 import type { MaterializedViewDefinition, SchemaDefinition, TableDefinition } from '@chkit/core'
 
 import './table-config.js'
@@ -94,53 +91,4 @@ export function detectCandidatesFromTable(table: TableDefinition): TimeColumnCan
 
 export function extractSchemaTimeColumn(table: TableDefinition): string | undefined {
   return table.plugins?.backfill?.timeColumn
-}
-
-export async function loadTimeColumnInfo(
-  target: string,
-  schemaGlobs: string | string[],
-  configPath: string
-): Promise<{ schemaTimeColumn: string | undefined; candidates: TimeColumnCandidate[] }> {
-  let definitions: SchemaDefinition[]
-  try {
-    definitions = await loadSchemaDefinitions(schemaGlobs, {
-      cwd: dirname(configPath),
-    })
-  } catch {
-    return { schemaTimeColumn: undefined, candidates: [] }
-  }
-
-  const [database, table] = target.split('.')
-  if (!database || !table) return { schemaTimeColumn: undefined, candidates: [] }
-
-  const resolved = findTableForTarget(definitions, database, table)
-  if (!resolved) return { schemaTimeColumn: undefined, candidates: [] }
-
-  return {
-    schemaTimeColumn: extractSchemaTimeColumn(resolved),
-    candidates: detectCandidatesFromTable(resolved),
-  }
-}
-
-export async function detectTimeColumnCandidates(
-  target: string,
-  schemaGlobs: string | string[],
-  configPath: string
-): Promise<TimeColumnCandidate[]> {
-  let definitions: SchemaDefinition[]
-  try {
-    definitions = await loadSchemaDefinitions(schemaGlobs, {
-      cwd: dirname(configPath),
-    })
-  } catch {
-    return []
-  }
-
-  const [database, table] = target.split('.')
-  if (!database || !table) return []
-
-  const resolved = findTableForTarget(definitions, database, table)
-  if (!resolved) return []
-
-  return detectCandidatesFromTable(resolved)
 }

--- a/packages/plugin-backfill/src/options.ts
+++ b/packages/plugin-backfill/src/options.ts
@@ -112,30 +112,24 @@ export const RunSchema = z.object({
   pollIntervalMs: z.number().nonnegative().default(5000),
   stateDir: z.string().min(1).optional(),
 })
-export type RunOptions = z.infer<typeof RunSchema>
+type RunOptions = z.infer<typeof RunSchema>
 
 export const ResumeSchema = RunSchema.extend({
   replayFailed: z.boolean().default(false),
 })
-export type ResumeOptions = z.infer<typeof ResumeSchema>
+type ResumeOptions = z.infer<typeof ResumeSchema>
 
-export const StatusSchema = z.object({
+const StatusSchema = z.object({
   planId: z.string(),
   stateDir: z.string().min(1).optional(),
 })
-export type StatusOptions = z.infer<typeof StatusSchema>
-
-export const CancelSchema = StatusSchema
-export type CancelOptions = StatusOptions
-
-export const DoctorSchema = StatusSchema
-export type DoctorOptions = StatusOptions
+type StatusOptions = z.infer<typeof StatusSchema>
 
 export const CheckSchema = z.object({
   stateDir: z.string().min(1).optional(),
   failCheckOnRequiredPendingBackfill: z.boolean().default(true),
 })
-export type CheckOptions = z.infer<typeof CheckSchema>
+type CheckOptions = z.infer<typeof CheckSchema>
 
 // ───── CLI flag definitions ─────
 

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -8,7 +8,6 @@ import type { PluginConfig } from './options.js'
 
 /** @deprecated Use {@link PluginConfig} instead. */
 export type BackfillPluginOptions = PluginConfig
-export type { PluginConfig }
 
 export interface BackfillEnvironment {
   fingerprint: string
@@ -18,20 +17,7 @@ export interface BackfillEnvironment {
 
 export type BackfillPlanStatus = 'planned' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled'
 
-export type {
-  Chunk,
-  ChunkDerivationStep,
-  ChunkPlan,
-  ChunkRange,
-  EstimateConfidence,
-  EstimateReason,
-  FocusedValue,
-  Partition,
-  PartitionDiagnostics,
-  SortKey,
-} from './chunking/types.js'
-
-export interface BackfillExecutionPlan {
+interface BackfillExecutionPlan {
   mode: 'copy' | 'mv_replay'
   sourceTarget: string
   mvAsQuery?: string
@@ -96,7 +82,7 @@ export interface BackfillStatusSummary {
   lastError?: string
 }
 
-export interface BackfillPluginCheckContext {
+interface BackfillPluginCheckContext {
   command: 'check'
   config: ResolvedChxConfig
   configPath: string
@@ -151,7 +137,7 @@ export interface BackfillDoctorReport {
   failedChunkIds: string[]
 }
 
-export interface BackfillPluginCommandContext {
+interface BackfillPluginCommandContext {
   args: string[]
   flags: Record<string, string | string[] | boolean | undefined>
   jsonMode: boolean

--- a/packages/plugin-codegen/src/naming.ts
+++ b/packages/plugin-codegen/src/naming.ts
@@ -29,7 +29,7 @@ function rawCase(input: string): string {
   return sanitized.length > 0 ? sanitized : 'item'
 }
 
-export function isValidIdentifier(input: string): boolean {
+function isValidIdentifier(input: string): boolean {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(input)
 }
 

--- a/packages/plugin-codegen/src/options.ts
+++ b/packages/plugin-codegen/src/options.ts
@@ -23,7 +23,7 @@ export type PluginConfig = z.input<typeof PluginConfigSchema>
 
 // ───── Codegen command schema ─────
 
-export const CodegenSchema = z.object({
+const CodegenSchema = z.object({
   outFile: z.string().min(1).default('./src/generated/chkit-types.ts'),
   emitZod: z.boolean().default(false),
   tableNameStyle: z.enum(['pascal', 'camel', 'raw']).default('pascal'),
@@ -36,7 +36,7 @@ export const CodegenSchema = z.object({
   emitMigrations: z.boolean().default(false),
   migrationsOutFile: z.string().min(1).default('./src/generated/chkit-migrations.ts'),
 })
-export type CodegenOptions = z.infer<typeof CodegenSchema>
+type CodegenOptions = z.infer<typeof CodegenSchema>
 
 // ───── CLI flag definitions ─────
 

--- a/packages/plugin-obsessiondb/src/api-request.ts
+++ b/packages/plugin-obsessiondb/src/api-request.ts
@@ -1,5 +1,3 @@
-import type { Credentials } from './auth/index.js'
-
 export class SessionExpiredError extends Error {
   constructor() {
     super('Session expired. Run `chkit obsessiondb login` to re-authenticate.')
@@ -8,31 +6,4 @@ export class SessionExpiredError extends Error {
 
 export function isSessionExpiredError(error: unknown): boolean {
   return error instanceof SessionExpiredError
-}
-
-export async function apiRequest<T>(
-  path: string,
-  creds: Credentials,
-  body?: unknown
-): Promise<T> {
-  const res = await fetch(`${creds.base_url}${path}`, {
-    method: body !== undefined ? 'POST' : 'GET',
-    headers: {
-      Authorization: `Bearer ${creds.access_token}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'chkit-cli',
-    },
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-  })
-
-  if (res.status === 401) {
-    throw new SessionExpiredError()
-  }
-
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`API error: ${res.status} ${text}`)
-  }
-
-  return (await res.json()) as T
 }

--- a/packages/plugin-obsessiondb/src/auth/api-client.ts
+++ b/packages/plugin-obsessiondb/src/auth/api-client.ts
@@ -1,4 +1,4 @@
-export interface DeviceCodeResponse {
+interface DeviceCodeResponse {
   device_code: string
   user_code: string
   verification_uri: string
@@ -7,7 +7,7 @@ export interface DeviceCodeResponse {
   interval: number
 }
 
-export interface SessionResponse {
+interface SessionResponse {
   user: {
     id: string
     name: string

--- a/packages/plugin-obsessiondb/src/auth/commands.ts
+++ b/packages/plugin-obsessiondb/src/auth/commands.ts
@@ -20,7 +20,7 @@ interface PluginCommand {
   run: (context: PluginCommandContext) => Promise<number>
 }
 
-export const LOGIN_COMMAND: PluginCommand = {
+const LOGIN_COMMAND: PluginCommand = {
   name: 'login',
   description: 'Authenticate with ObsessionDB',
   flags: [
@@ -36,7 +36,7 @@ export const LOGIN_COMMAND: PluginCommand = {
   },
 }
 
-export const LOGOUT_COMMAND: PluginCommand = {
+const LOGOUT_COMMAND: PluginCommand = {
   name: 'logout',
   description: 'Remove stored ObsessionDB credentials',
   async run(context) {
@@ -44,7 +44,7 @@ export const LOGOUT_COMMAND: PluginCommand = {
   },
 }
 
-export const WHOAMI_COMMAND: PluginCommand = {
+const WHOAMI_COMMAND: PluginCommand = {
   name: 'whoami',
   description: 'Show current ObsessionDB user',
   async run(context) {

--- a/packages/plugin-obsessiondb/src/backfill/client.ts
+++ b/packages/plugin-obsessiondb/src/backfill/client.ts
@@ -1,6 +1,6 @@
 import type { Credentials } from '../auth/index.js'
 import { createApiClient, type ApiClient } from '../client.js'
-export { SessionExpiredError, isSessionExpiredError } from '../api-request.js'
+export { isSessionExpiredError } from '../api-request.js'
 
 export type JobsClient = ApiClient['jobs']
 

--- a/packages/plugin-obsessiondb/src/backfill/index.ts
+++ b/packages/plugin-obsessiondb/src/backfill/index.ts
@@ -1,11 +1,5 @@
 export { handleBackfillCommand } from './handler.js'
 export { createJobsClient, type JobsClient } from './client.js'
-export {
-  jobsContract,
-  jobStatusSchema,
-  jobSummarySchema,
-  jobDetailSchema,
-} from '../contract/jobs.js'
 
 export const BACKFILL_EXTEND_COMMANDS = [
   {

--- a/packages/plugin-obsessiondb/src/contract/index.ts
+++ b/packages/plugin-obsessiondb/src/contract/index.ts
@@ -1,3 +1,3 @@
-export { serviceSchema, serviceStatusSchema, servicesContract } from './services.js'
-export { jobsContract, jobDetailSchema, jobSummarySchema, jobStatusSchema } from './jobs.js'
+export { serviceSchema, servicesContract } from './services.js'
+export { jobsContract } from './jobs.js'
 export { workbenchContract } from './workbench.js'

--- a/packages/plugin-obsessiondb/src/contract/jobs.ts
+++ b/packages/plugin-obsessiondb/src/contract/jobs.ts
@@ -5,11 +5,11 @@
 import { oc } from '@orpc/contract'
 import { z } from 'zod'
 
-export const jobStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'cancelled'])
+const jobStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'cancelled'])
 
-export const taskStatusSchema = z.enum(['pending', 'running', 'done', 'failed'])
+const taskStatusSchema = z.enum(['pending', 'running', 'done', 'failed'])
 
-export const jobTaskSchema = z.object({
+const jobTaskSchema = z.object({
   id: z.string(),
   taskIndex: z.number().int(),
   status: taskStatusSchema,
@@ -24,7 +24,7 @@ export const jobTaskSchema = z.object({
   finishedAt: z.string().datetime().nullable(),
 })
 
-export const jobSummarySchema = z.object({
+const jobSummarySchema = z.object({
   id: z.string(),
   serviceId: z.string(),
   type: z.string(),
@@ -38,7 +38,7 @@ export const jobSummarySchema = z.object({
   updatedAt: z.string().datetime(),
 })
 
-export const jobDetailSchema = jobSummarySchema.extend({
+const jobDetailSchema = jobSummarySchema.extend({
   workflowId: z.string().nullable(),
   metadata: z.record(z.unknown()).nullable(),
   tasks: z.array(jobTaskSchema),

--- a/packages/plugin-obsessiondb/src/contract/services.ts
+++ b/packages/plugin-obsessiondb/src/contract/services.ts
@@ -5,7 +5,7 @@
 import { oc } from '@orpc/contract'
 import { z } from 'zod'
 
-export const serviceStatusSchema = z.enum([
+const serviceStatusSchema = z.enum([
   'provisioning',
   'running',
   'scaling',

--- a/packages/plugin-obsessiondb/src/service/storage.ts
+++ b/packages/plugin-obsessiondb/src/service/storage.ts
@@ -1,9 +1,9 @@
-import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
 import type { SelectedService } from './types.js'
 
-export function getServicePath(configPath: string): string {
+function getServicePath(configPath: string): string {
   const configDir = resolve(configPath, '..')
   return join(configDir, '.chkit', 'obsessiondb.json')
 }
@@ -32,12 +32,4 @@ export async function saveSelectedService(configPath: string, service: SelectedS
   const filePath = getServicePath(configPath)
   await mkdir(dirname(filePath), { recursive: true })
   await writeFile(filePath, JSON.stringify(service, null, 2) + '\n')
-}
-
-export async function clearSelectedService(configPath: string): Promise<void> {
-  try {
-    await unlink(getServicePath(configPath))
-  } catch {
-    // Already gone — no-op
-  }
 }


### PR DESCRIPTION
## Summary

Fixes the Fallow dead-code report by removing unused exports, stale barrel re-exports, unused local declarations, and unused package dependencies.

## What changed

- Removed unused value and type exports across CLI, core, backfill, codegen, and ObsessionDB plugin packages.
- Removed unused local declarations that became visible after export cleanup.
- Removed unused dependencies from package manifests and reconciled `bun.lock`.
- Kept the unrelated local `.gitignore` change out of this commit.

## Impact

This reduces the public/internal TypeScript surface area to only the symbols with known consumers and clears the dead-code gate without changing runtime behavior for used APIs.

## Validation

- `bunx fallow dead-code` passes with no issues.
- `bun run typecheck` passes.
- `bun run lint` exits successfully, with existing unrelated style warnings still reported.
- `bun run build` passes.
- `bun run fallow:pr` reports dead code clean, with existing duplication/health advisories still present.
- `bun run test` is blocked by missing ClickHouse e2e env (`CLICKHOUSE_URL` or `CLICKHOUSE_HOST`) in `packages/core/src/sql-validation.e2e.test.ts`.