### PR TITLE
Identify chkit in ClickHouse requests via User-Agent

### DIFF
--- a/.changeset/clickhouse-user-agent.md
+++ b/.changeset/clickhouse-user-agent.md
@@ -1,0 +1,6 @@
+---
+"@chkit/clickhouse": patch
+"chkit": patch
+---
+
+Identify chkit in ClickHouse requests by setting the HTTP `User-Agent` to `chkit/<version>` (e.g. `chkit/0.1.0-beta.21 clickhouse-js/1.17.0 (lv:nodejs/...; os:...)`), making it easy to filter chkit traffic in ClickHouse query logs.

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { createClient, type ClickHouseSettings } from '@clickhouse/client'
 import {
   normalizeSQLFragment,
@@ -18,6 +19,9 @@ import {
   parseTTLFromCreateTableQuery,
   parseUniqueKeyFromCreateTableQuery,
 } from './create-table-parser.js'
+
+const pkg = createRequire(import.meta.url)('../package.json') as { version: string }
+const CHKIT_APPLICATION_ID = `chkit/${pkg.version}`
 
 export interface QueryStatus {
   status: 'running' | 'finished' | 'failed' | 'unknown'
@@ -358,6 +362,7 @@ export function createStatelessClickHouseClient(
     username: config.username,
     password: config.password,
     database: config.database,
+    application: CHKIT_APPLICATION_ID,
     clickhouse_settings: clickhouseSettings,
   })
 }
@@ -379,6 +384,7 @@ export function createSessionClickHouseClient(
     password: config.password,
     database: config.database,
     session_id: sessionId,
+    application: CHKIT_APPLICATION_ID,
     clickhouse_settings: clickhouseSettings,
   })
 }
@@ -399,6 +405,7 @@ function createExecutorWithClient(config: ClickHouseConfig, client: ClickHouseCl
             url: config.url,
             username: config.username,
             password: config.password,
+            application: CHKIT_APPLICATION_ID,
             clickhouse_settings: { wait_end_of_query: 1, async_insert: 0 },
           })
           try {


### PR DESCRIPTION
## Summary
- Set `application: chkit/<version>` on every `@clickhouse/client` `createClient` call in `packages/clickhouse/src/index.ts` (stateless, session, and unknown-database fallback). The library prepends this to its default User-Agent, so all chkit HTTP requests to ClickHouse now identify themselves (e.g. `chkit/0.1.0-beta.21 clickhouse-js/1.17.0 (lv:nodejs/...; os:...)`), making chkit traffic filterable in ClickHouse query logs.
- Version is read at module load from `@chkit/clickhouse`'s own `package.json` via `createRequire`, matching the existing pattern in `packages/cli/src/bin/version.ts`. Since all chkit ClickHouse traffic funnels through this package, no caller changes are needed — CLI, plugins (pull, backfill, codegen, obsessiondb), and the e2e testkit are all covered.

## Test plan
- [x] `bun verify` passes (typecheck, lint, test, build).
- [x] Verified on a local HTTP listener that requests now carry `User-Agent: chkit/0.1.0-beta.21 clickhouse-js/1.17.0 (lv:nodejs/...; os:darwin)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)