### PR TITLE
[codex] Remove .entire folder

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,4 +1,0 @@
-tmp/
-settings.local.json
-metadata/
-logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,5 +1,0 @@
-{
-  "strategy": "manual-commit",
-  "enabled": true,
-  "telemetry": true
-}


### PR DESCRIPTION
Removes the tracked `.entire` directory from the repository by deleting `.entire/.gitignore` and `.entire/settings.json`.
This drops the committed manual-commit and telemetry settings that were living under that folder.
User impact is limited to removing those repository-tracked workspace config files; no application code changes are included.
No automated checks were run because the diff only deletes metadata/config files.
