### PR TITLE
Add chkit query command with ObsessionDB --service override

### DIFF
--- a/.changeset/add-query-command.md
+++ b/.changeset/add-query-command.md
@@ -1,0 +1,6 @@
+---
+"chkit": patch
+"@chkit/plugin-obsessiondb": patch
+---
+
+Add `chkit query "<sql>"` command that runs an ad-hoc SQL query against the configured target (default ClickHouse, or the active plugin executor). When the ObsessionDB plugin is loaded, all ClickHouse-bound commands (`generate`, `migrate`, `status`, `drift`, `check`, `query`) accept `--service <name>` to override the selected service by name for that single invocation.

--- a/apps/docs/src/content/docs/cli/overview.md
+++ b/apps/docs/src/content/docs/cli/overview.md
@@ -17,6 +17,7 @@ The `chkit` CLI manages ClickHouse schemas, migrations, drift detection, and CI 
 | [`chkit status`](/cli/status/) | Show migration status (total, applied, pending, checksum mismatches) |
 | [`chkit drift`](/cli/drift/) | Compare snapshot against live ClickHouse and report differences |
 | [`chkit check`](/cli/check/) | Run policy checks for CI gates (pending, checksums, drift, plugins) |
+| [`chkit query`](/cli/query/) | Run an ad-hoc SQL query against the configured target |
 | [`chkit pull`](/cli/pull/) | Introspect live ClickHouse and generate a TypeScript schema file |
 | [`chkit codegen`](/cli/codegen/) | Generate TypeScript types from schema definitions |
 | [`chkit plugin`](/cli/plugin/) | List or run plugin commands |

--- a/apps/docs/src/content/docs/cli/query.md
+++ b/apps/docs/src/content/docs/cli/query.md
@@ -1,0 +1,84 @@
+---
+title: "chkit query"
+description: "Run a SQL query against the configured ClickHouse target."
+sidebar:
+  order: 9
+---
+
+Executes an ad-hoc SQL query against the configured target and prints the result.
+
+## Synopsis
+
+```
+chkit query "<sql>" [flags]
+```
+
+The SQL must be a single positional argument. Wrap it in quotes if it contains spaces.
+
+## Flags
+
+No command-specific flags. See [global flags](/cli/overview/#global-flags).
+
+When the [ObsessionDB plugin](/plugins/obsessiondb/) is loaded, `chkit query`
+also accepts `--service <name>` to route the query to a specific service for
+this invocation (see [Per-command service override](/plugins/obsessiondb/#per-command-service-override)).
+
+## Behavior
+
+`chkit query` runs the SQL through whichever executor is active:
+
+- Without any plugin override, it uses the `clickhouse` connection from your config.
+- With the ObsessionDB plugin loaded, it routes the query to the selected service (or to the service named with `--service`).
+
+The command requires an executor — if no `clickhouse` config is present and no plugin supplies one, it exits with an error.
+
+## Examples
+
+```sh
+chkit query "SELECT count() FROM users"
+```
+
+```
+count()
+───────
+42
+
+(1 row)
+```
+
+Override the ObsessionDB service for a single query:
+
+```sh
+chkit query "SELECT count() FROM users" --service customer-b
+```
+
+Machine-readable JSON output:
+
+```sh
+chkit query "SELECT count() FROM users" --json
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Query executed successfully |
+| 1 | Missing SQL, no executor configured, or query failed |
+
+## JSON output
+
+```json
+{
+  "command": "query",
+  "schemaVersion": 1,
+  "rowCount": 1,
+  "rows": [
+    { "count()": "42" }
+  ]
+}
+```
+
+## Related commands
+
+- [`chkit status`](/cli/status/) — show migration state
+- [`chkit drift`](/cli/drift/) — compare snapshot to live ClickHouse

--- a/apps/docs/src/content/docs/plugins/obsessiondb.md
+++ b/apps/docs/src/content/docs/plugins/obsessiondb.md
@@ -43,7 +43,32 @@ export default defineConfig({
 })
 ```
 
-The plugin hooks into `generate`, `migrate`, `status`, `drift`, and `check`.
+The plugin hooks into `generate`, `migrate`, `status`, `drift`, `check`, and `query`.
+
+## Service selection
+
+Authenticate and pick the ObsessionDB service this project should route through:
+
+```bash
+chkit obsessiondb login
+chkit obsessiondb select-service
+```
+
+The selection is stored in `.chkit/obsessiondb.json` next to your config file and used as the default target for every command after that.
+
+### Per-command service override
+
+Once authenticated, any command that hits ClickHouse accepts `--service <name>` to target a different service for one invocation without changing the saved selection. The flag takes the service **name** as shown in `chkit obsessiondb select-service`.
+
+```bash
+# Run an ad-hoc query against a different service
+chkit query "SELECT count() FROM users" --service customer-b
+
+# Apply migrations against a one-off service
+chkit migrate --apply --service staging
+```
+
+`--service` is available on `generate`, `migrate`, `status`, `drift`, `check`, and `query`. The lookup fails fast with the list of available services if the name does not match.
 
 ## How it works
 

--- a/clickhouse.config.ts
+++ b/clickhouse.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@chkit/core'
+import { obsessiondb } from '@chkit/plugin-obsessiondb'
+
+export default defineConfig({
+  schema: './src/db/schema/**/*.ts',
+  outDir: './chkit',
+  migrationsDir: './chkit/migrations',
+  metaDir: './chkit/meta',
+  plugins: [
+    obsessiondb(),
+  ],
+  clickhouse: {
+    url: process.env.CLICKHOUSE_URL ?? 'http://localhost:8123',
+    username: process.env.CLICKHOUSE_USER ?? 'default',
+    password: process.env.CLICKHOUSE_PASSWORD ?? '',
+    database: process.env.CLICKHOUSE_DB ?? 'default',
+  },
+})

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import process from 'node:process'
+import type { ParsedFlags } from '@chkit/core'
 
 import { createCommandRegistry } from './command-registry.js'
-import { runResolvedCommand } from './command-dispatch.js'
+import { parseCommandArgs, runResolvedCommand } from './command-dispatch.js'
 import { generateCommand } from './commands/generate.js'
 import { migrateCommand } from './commands/migrate.js'
 import { statusCommand } from './commands/status.js'
@@ -124,15 +125,6 @@ async function main(): Promise<void> {
     internalPlugins: getInternalPlugins(),
   })
 
-  const initCtx = {
-    command: commandName,
-    configPath,
-    isInteractive: process.stdin.isTTY === true && process.stderr.isTTY === true,
-    jsonMode: argv.includes('--json'),
-  }
-  await pluginRuntime.runOnInit(initCtx)
-  _onComplete = (exitCode: number) => pluginRuntime.runOnComplete({ ...initCtx, exitCode })
-
   const registry = createCommandRegistry({
     coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, queryCommand, pluginCommand],
     globalFlags: GLOBAL_FLAGS,
@@ -141,6 +133,22 @@ async function main(): Promise<void> {
   })
 
   const resolved = registry.get(commandName)
+  let initFlags: ParsedFlags = {}
+  if (resolved && !resolved.isPlugin && commandName !== 'plugin' && !argv.includes('--help') && !argv.includes('-h')) {
+    const parsed = parseCommandArgs(commandName, argv.slice(1), registry.resolveFlags(commandName))
+    if (!parsed) return
+    initFlags = parsed.flags
+  }
+
+  const initCtx = {
+    command: commandName,
+    configPath,
+    isInteractive: process.stdin.isTTY === true && process.stderr.isTTY === true,
+    jsonMode: argv.includes('--json'),
+    flags: initFlags,
+  }
+  await pluginRuntime.runOnInit(initCtx)
+  _onComplete = (exitCode: number) => pluginRuntime.runOnComplete({ ...initCtx, exitCode })
   debug('cli', `command "${commandName}" resolved: ${resolved ? (resolved.isPlugin ? 'plugin' : 'core') : 'not found'}`)
 
   if (!resolved) {

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -9,6 +9,7 @@ import { statusCommand } from './commands/status.js'
 import { driftCommand } from './commands/drift.js'
 import { checkCommand } from './commands/check.js'
 import { pluginCommand } from './commands/plugin.js'
+import { queryCommand } from './commands/query.js'
 import { cmdInit } from './commands/init.js'
 import { loadConfig } from './config.js'
 import { GLOBAL_FLAGS } from './global-flags.js'
@@ -86,7 +87,7 @@ async function main(): Promise<void> {
       const { config, path: configPath } = await loadConfig(configPathArg)
       const pluginRuntime = await loadPluginRuntime({ config, configPath, cliVersion: CLI_VERSION })
       const registry = createCommandRegistry({
-        coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, pluginCommand],
+        coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, queryCommand, pluginCommand],
         globalFlags: GLOBAL_FLAGS,
         pluginExtensions: collectExtensions(pluginRuntime),
         pluginCommands: collectPluginCommands(pluginRuntime),
@@ -94,7 +95,7 @@ async function main(): Promise<void> {
       console.log(formatGlobalHelp(registry, CLI_VERSION))
     } catch {
       const registry = createCommandRegistry({
-        coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, pluginCommand],
+        coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, queryCommand, pluginCommand],
         globalFlags: GLOBAL_FLAGS,
         pluginExtensions: [],
         pluginCommands: [],
@@ -133,7 +134,7 @@ async function main(): Promise<void> {
   _onComplete = (exitCode: number) => pluginRuntime.runOnComplete({ ...initCtx, exitCode })
 
   const registry = createCommandRegistry({
-    coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, pluginCommand],
+    coreCommands: [generateCommand, migrateCommand, statusCommand, driftCommand, checkCommand, queryCommand, pluginCommand],
     globalFlags: GLOBAL_FLAGS,
     pluginExtensions: collectExtensions(pluginRuntime),
     pluginCommands: collectPluginCommands(pluginRuntime),

--- a/packages/cli/src/bin/command-dispatch.test.ts
+++ b/packages/cli/src/bin/command-dispatch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { FlagDef } from '@chkit/core'
+import { parseCommandArgs } from './command-dispatch.js'
+import { GLOBAL_FLAGS } from './global-flags.js'
+
+const SERVICE_FLAG: FlagDef = {
+	name: '--service',
+	type: 'string',
+	description: 'Override service',
+}
+
+describe('parseCommandArgs', () => {
+	test('treats query SQL starting with a line comment as positional SQL', () => {
+		const parsed = parseCommandArgs(
+			'query',
+			['--json', '--service', 'prod', '-- inspect\nSELECT 1'],
+			[...GLOBAL_FLAGS, SERVICE_FLAG],
+		)
+
+		expect(parsed?.flags['--json']).toBe(true)
+		expect(parsed?.flags['--service']).toBe('prod')
+		expect(parsed?.positionals).toEqual(['-- inspect\nSELECT 1'])
+	})
+
+	test('supports option terminator before query SQL', () => {
+		const parsed = parseCommandArgs(
+			'query',
+			['--service', 'prod', '--', '-- inspect\nSELECT 1'],
+			[...GLOBAL_FLAGS, SERVICE_FLAG],
+		)
+
+		expect(parsed?.flags['--service']).toBe('prod')
+		expect(parsed?.positionals).toEqual(['-- inspect\nSELECT 1'])
+	})
+
+	test('supports query flags after SQL', () => {
+		const parsed = parseCommandArgs(
+			'query',
+			['SELECT 1', '--json', '--service', 'prod'],
+			[...GLOBAL_FLAGS, SERVICE_FLAG],
+		)
+
+		expect(parsed?.flags['--json']).toBe(true)
+		expect(parsed?.flags['--service']).toBe('prod')
+		expect(parsed?.positionals).toEqual(['SELECT 1'])
+	})
+})

--- a/packages/cli/src/bin/command-dispatch.ts
+++ b/packages/cli/src/bin/command-dispatch.ts
@@ -1,4 +1,10 @@
-import { parseFlags, UnknownFlagError, MissingFlagValueError, type FlagDef, type ParsedFlags } from '@chkit/core'
+import {
+	type FlagDef,
+	MissingFlagValueError,
+	type ParsedFlags,
+	parseFlags,
+	UnknownFlagError,
+} from '@chkit/core'
 
 import { typedFlags } from '../plugins.js'
 import type { CommandRegistry, RegisteredCommand } from './command-registry.js'
@@ -10,240 +16,319 @@ import type { PluginRuntime } from './plugin-runtime.js'
 import { loadSchemaDefinitions } from './schema-loader.js'
 import { resolveTableScope, tableKeysFromDefinitions } from './table-scope.js'
 
-function extractPositionals(argv: string[], flagDefs: readonly FlagDef[]): string[] {
-  const byName = new Map<string, FlagDef>()
-  for (const def of flagDefs) byName.set(def.name, def)
+function extractPositionals(
+	argv: string[],
+	flagDefs: readonly FlagDef[],
+): string[] {
+	const byName = new Map<string, FlagDef>()
+	for (const def of flagDefs) byName.set(def.name, def)
 
-  const positionals: string[] = []
-  for (let i = 0; i < argv.length; i += 1) {
-    const token = argv[i]
-    if (token === undefined) continue
-    if (!token.startsWith('--')) {
-      positionals.push(token)
-      continue
-    }
-    const def = byName.get(token)
-    if (def && def.type !== 'boolean') {
-      // Consume the value following a string/string[] flag
-      i += 1
-    }
-  }
-  return positionals
+	const positionals: string[] = []
+	for (let i = 0; i < argv.length; i += 1) {
+		const token = argv[i]
+		if (token === undefined) continue
+		if (!token.startsWith('--')) {
+			positionals.push(token)
+			continue
+		}
+		const def = byName.get(token)
+		if (def && def.type !== 'boolean') {
+			// Consume the value following a string/string[] flag
+			i += 1
+		}
+	}
+	return positionals
+}
+
+function splitQueryArgs(
+	argv: string[],
+	flagDefs: readonly FlagDef[],
+): {
+	flagArgs: string[]
+	positionals: string[]
+} {
+	const byName = new Map<string, FlagDef>()
+	for (const def of flagDefs) byName.set(def.name, def)
+
+	const flagArgs: string[] = []
+	const positionals: string[] = []
+	for (let i = 0; i < argv.length; i += 1) {
+		const token = argv[i]
+		if (token === undefined) continue
+		if (token === '--') {
+			positionals.push(...argv.slice(i + 1))
+			break
+		}
+
+		const def = byName.get(token)
+		if (!def) {
+			positionals.push(token)
+			continue
+		}
+
+		flagArgs.push(token)
+		if (def.type !== 'boolean') {
+			const next = argv[i + 1]
+			if (next !== undefined) {
+				flagArgs.push(next)
+				i += 1
+			}
+		}
+	}
+
+	return { flagArgs, positionals }
+}
+
+export function parseCommandArgs(
+	commandName: string,
+	argv: string[],
+	flagDefs: readonly FlagDef[],
+): { flags: ParsedFlags; positionals: string[] } | null {
+	if (commandName === 'query') {
+		const { flagArgs, positionals } = splitQueryArgs(argv, flagDefs)
+		const flags = parseFlagsOrReport(flagArgs, flagDefs)
+		if (!flags) return null
+		return { flags, positionals }
+	}
+
+	const flags = parseFlagsOrReport(argv, flagDefs)
+	if (!flags) return null
+	return { flags, positionals: extractPositionals(argv, flagDefs) }
 }
 
 function stripGlobalFlags(argv: string[]): {
-  jsonMode: boolean
-  tableSelector: string | undefined
-  rest: string[]
+	jsonMode: boolean
+	tableSelector: string | undefined
+	rest: string[]
 } {
-  const rest: string[] = []
-  let jsonMode = false
-  let tableSelector: string | undefined
+	const rest: string[] = []
+	let jsonMode = false
+	let tableSelector: string | undefined
 
-  for (let i = 0; i < argv.length; i++) {
-    const token = argv[i] as string
-    if (token === '--json') {
-      jsonMode = true
-      continue
-    }
-    if (token === '--config' && i + 1 < argv.length) {
-      i++
-      continue
-    }
-    if (token === '--table' && i + 1 < argv.length) {
-      tableSelector = argv[i + 1]
-      i++
-      continue
-    }
-    rest.push(token)
-  }
+	for (let i = 0; i < argv.length; i++) {
+		const token = argv[i] as string
+		if (token === '--json') {
+			jsonMode = true
+			continue
+		}
+		if (token === '--config' && i + 1 < argv.length) {
+			i++
+			continue
+		}
+		if (token === '--table' && i + 1 < argv.length) {
+			tableSelector = argv[i + 1]
+			i++
+			continue
+		}
+		rest.push(token)
+	}
 
-  return { jsonMode, tableSelector, rest }
+	return { jsonMode, tableSelector, rest }
 }
 
-function parseFlagsOrReport(args: string[], defs: ReturnType<CommandRegistry['resolveFlags']>): ParsedFlags | null {
-  try {
-    return parseFlags(args, defs)
-  } catch (error) {
-    if (error instanceof UnknownFlagError || error instanceof MissingFlagValueError) {
-      console.error(error.message)
-      process.exitCode = 1
-      return null
-    }
-    throw error
-  }
+function parseFlagsOrReport(
+	args: string[],
+	defs: readonly FlagDef[],
+): ParsedFlags | null {
+	try {
+		return parseFlags(args, defs)
+	} catch (error) {
+		if (
+			error instanceof UnknownFlagError ||
+			error instanceof MissingFlagValueError
+		) {
+			console.error(error.message)
+			process.exitCode = 1
+			return null
+		}
+		throw error
+	}
 }
 
 async function resolvePluginTableScope(input: {
-  schemaGlobs: string | string[]
-  tableSelector: string | undefined
+	schemaGlobs: string | string[]
+	tableSelector: string | undefined
 }) {
-  try {
-    const definitions = await loadSchemaDefinitions(input.schemaGlobs)
-    return resolveTableScope(input.tableSelector, tableKeysFromDefinitions(definitions))
-  } catch {
-    return resolveTableScope(input.tableSelector, [])
-  }
+	try {
+		const definitions = await loadSchemaDefinitions(input.schemaGlobs)
+		return resolveTableScope(
+			input.tableSelector,
+			tableKeysFromDefinitions(definitions),
+		)
+	} catch {
+		return resolveTableScope(input.tableSelector, [])
+	}
 }
 
 async function runPluginCommand(input: {
-  argv: string[]
-  commandName: string
-  resolved: RegisteredCommand
-  registry: CommandRegistry
-  config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
-  configPath: string
-  pluginRuntime: PluginRuntime
-  onAmbiguousPluginSubcommand?: () => void
+	argv: string[]
+	commandName: string
+	resolved: RegisteredCommand
+	registry: CommandRegistry
+	config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
+	configPath: string
+	pluginRuntime: PluginRuntime
+	onAmbiguousPluginSubcommand?: () => void
 }): Promise<void> {
-  const argsAfterCommand = input.argv.slice(1)
-  let subcommandName: string | undefined
+	const argsAfterCommand = input.argv.slice(1)
+	let subcommandName: string | undefined
 
-  if (input.resolved.subcommands) {
-    const matchedSub = input.resolved.subcommands.find((s) => argsAfterCommand.includes(s.name))
-    if (matchedSub) {
-      subcommandName = matchedSub.name
-    } else if (input.resolved.subcommands.length === 1) {
-      subcommandName = input.resolved.subcommands[0]?.name
-    } else {
-      input.onAmbiguousPluginSubcommand?.()
-      return
-    }
-  }
+	if (input.resolved.subcommands) {
+		const matchedSub = input.resolved.subcommands.find((s) =>
+			argsAfterCommand.includes(s.name),
+		)
+		if (matchedSub) {
+			subcommandName = matchedSub.name
+		} else if (input.resolved.subcommands.length === 1) {
+			subcommandName = input.resolved.subcommands[0]?.name
+		} else {
+			input.onAmbiguousPluginSubcommand?.()
+			return
+		}
+	}
 
-  const allPluginFlags = input.registry.resolveFlags(input.commandName, subcommandName)
-  const flags = parseFlagsOrReport(argsAfterCommand, allPluginFlags)
-  if (!flags) return
+	const allPluginFlags = input.registry.resolveFlags(
+		input.commandName,
+		subcommandName,
+	)
+	const flags = parseFlagsOrReport(argsAfterCommand, allPluginFlags)
+	if (!flags) return
 
-  const gf = typedFlags(flags, GLOBAL_FLAGS)
-  const jsonMode = gf['--json'] === true
-  const tableScope = await resolvePluginTableScope({
-    schemaGlobs: input.config.schema,
-    tableSelector: gf['--table'],
-  })
+	const gf = typedFlags(flags, GLOBAL_FLAGS)
+	const jsonMode = gf['--json'] === true
+	const tableScope = await resolvePluginTableScope({
+		schemaGlobs: input.config.schema,
+		tableSelector: gf['--table'],
+	})
 
-  try {
-    await input.pluginRuntime.runOnConfigLoaded({
-      command: input.commandName,
-      config: input.config,
-      configPath: input.configPath,
-      tableScope,
-      flags,
-    })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (jsonMode) {
-      console.log(JSON.stringify({ ok: false, error: message }))
-    } else {
-      console.error(message)
-    }
-    process.exitCode = 2
-    return
-  }
+	try {
+		await input.pluginRuntime.runOnConfigLoaded({
+			command: input.commandName,
+			config: input.config,
+			configPath: input.configPath,
+			tableScope,
+			flags,
+		})
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		if (jsonMode) {
+			console.log(JSON.stringify({ ok: false, error: message }))
+		} else {
+			console.error(message)
+		}
+		process.exitCode = 2
+		return
+	}
 
-  const pluginName = input.resolved.pluginName ?? input.commandName
-  const pluginCommandName = subcommandName ?? input.commandName
+	const pluginName = input.resolved.pluginName ?? input.commandName
+	const pluginCommandName = subcommandName ?? input.commandName
 
-  const exitCode = await input.pluginRuntime.runPluginCommand(pluginName, pluginCommandName, {
-    config: input.config,
-    configPath: input.configPath,
-    jsonMode,
-    tableScope,
-    args: [],
-    flags,
-    print(value) {
-      printOutput(value, jsonMode)
-    },
-  })
+	const exitCode = await input.pluginRuntime.runPluginCommand(
+		pluginName,
+		pluginCommandName,
+		{
+			config: input.config,
+			configPath: input.configPath,
+			jsonMode,
+			tableScope,
+			args: [],
+			flags,
+			print(value) {
+				printOutput(value, jsonMode)
+			},
+		},
+	)
 
-  if (exitCode !== 0) process.exitCode = exitCode
+	if (exitCode !== 0) process.exitCode = exitCode
 }
 
 async function runCoreOrBuiltinCommand(input: {
-  argv: string[]
-  commandName: string
-  resolved: RegisteredCommand
-  registry: CommandRegistry
-  config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
-  configPath: string
-  pluginRuntime: PluginRuntime
+	argv: string[]
+	commandName: string
+	resolved: RegisteredCommand
+	registry: CommandRegistry
+	config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
+	configPath: string
+	pluginRuntime: PluginRuntime
 }): Promise<void> {
-  if (input.commandName === 'plugin') {
-    const { jsonMode, tableSelector } = stripGlobalFlags(input.argv.slice(1))
-    const flags: ParsedFlags = {}
-    if (jsonMode) flags['--json'] = true
-    if (tableSelector) flags['--table'] = tableSelector
+	if (input.commandName === 'plugin') {
+		const { jsonMode, tableSelector } = stripGlobalFlags(input.argv.slice(1))
+		const flags: ParsedFlags = {}
+		if (jsonMode) flags['--json'] = true
+		if (tableSelector) flags['--table'] = tableSelector
 
-    const dirs = resolveDirs(input.config)
-    if (!input.resolved.run) throw new Error(`Command '${input.commandName}' has no run handler`)
-    const ctx = await input.pluginRuntime.resolveContext({
-      config: input.config,
-      configPath: input.configPath,
-      command: input.commandName,
-      flags,
-    })
-    try {
-      await input.resolved.run({
-        command: input.commandName,
-        flags,
-        positionals: [],
-        config: input.config,
-        configPath: input.configPath,
-        dirs,
-        pluginRuntime: input.pluginRuntime,
-        ctx,
-      })
-    } finally {
-      await input.pluginRuntime.disposeContext(ctx)
-    }
-    return
-  }
+		const dirs = resolveDirs(input.config)
+		if (!input.resolved.run)
+			throw new Error(`Command '${input.commandName}' has no run handler`)
+		const ctx = await input.pluginRuntime.resolveContext({
+			config: input.config,
+			configPath: input.configPath,
+			command: input.commandName,
+			flags,
+		})
+		try {
+			await input.resolved.run({
+				command: input.commandName,
+				flags,
+				positionals: [],
+				config: input.config,
+				configPath: input.configPath,
+				dirs,
+				pluginRuntime: input.pluginRuntime,
+				ctx,
+			})
+		} finally {
+			await input.pluginRuntime.disposeContext(ctx)
+		}
+		return
+	}
 
-  const allFlags = input.registry.resolveFlags(input.commandName)
-  const argsAfterCommand = input.argv.slice(1)
-  const flags = parseFlagsOrReport(argsAfterCommand, allFlags)
-  if (!flags) return
-  const positionals = extractPositionals(argsAfterCommand, allFlags)
+	const allFlags = input.registry.resolveFlags(input.commandName)
+	const argsAfterCommand = input.argv.slice(1)
+	const parsed = parseCommandArgs(input.commandName, argsAfterCommand, allFlags)
+	if (!parsed) return
+	const { flags, positionals } = parsed
 
-  const dirs = resolveDirs(input.config)
-  if (!input.resolved.run) throw new Error(`Command '${input.commandName}' has no run handler`)
-  const ctx = await input.pluginRuntime.resolveContext({
-    config: input.config,
-    configPath: input.configPath,
-    command: input.commandName,
-    flags,
-  })
-  try {
-    await input.resolved.run({
-      command: input.commandName,
-      flags,
-      positionals,
-      config: input.config,
-      configPath: input.configPath,
-      dirs,
-      pluginRuntime: input.pluginRuntime,
-      ctx,
-    })
-  } finally {
-    await input.pluginRuntime.disposeContext(ctx)
-  }
+	const dirs = resolveDirs(input.config)
+	if (!input.resolved.run)
+		throw new Error(`Command '${input.commandName}' has no run handler`)
+	const ctx = await input.pluginRuntime.resolveContext({
+		config: input.config,
+		configPath: input.configPath,
+		command: input.commandName,
+		flags,
+	})
+	try {
+		await input.resolved.run({
+			command: input.commandName,
+			flags,
+			positionals,
+			config: input.config,
+			configPath: input.configPath,
+			dirs,
+			pluginRuntime: input.pluginRuntime,
+			ctx,
+		})
+	} finally {
+		await input.pluginRuntime.disposeContext(ctx)
+	}
 }
 
 export async function runResolvedCommand(input: {
-  argv: string[]
-  commandName: string
-  resolved: RegisteredCommand
-  registry: CommandRegistry
-  config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
-  configPath: string
-  pluginRuntime: PluginRuntime
-  onAmbiguousPluginSubcommand?: () => void
+	argv: string[]
+	commandName: string
+	resolved: RegisteredCommand
+	registry: CommandRegistry
+	config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
+	configPath: string
+	pluginRuntime: PluginRuntime
+	onAmbiguousPluginSubcommand?: () => void
 }): Promise<void> {
-  if (input.resolved.isPlugin && !input.resolved.run) {
-    debug('dispatch', `routing to plugin command "${input.commandName}"`)
-    await runPluginCommand(input)
-    return
-  }
-  debug('dispatch', `routing to core command "${input.commandName}"`)
-  await runCoreOrBuiltinCommand(input)
+	if (input.resolved.isPlugin && !input.resolved.run) {
+		debug('dispatch', `routing to plugin command "${input.commandName}"`)
+		await runPluginCommand(input)
+		return
+	}
+	debug('dispatch', `routing to core command "${input.commandName}"`)
+	await runCoreOrBuiltinCommand(input)
 }

--- a/packages/cli/src/bin/command-dispatch.ts
+++ b/packages/cli/src/bin/command-dispatch.ts
@@ -1,4 +1,4 @@
-import { parseFlags, UnknownFlagError, MissingFlagValueError, type ParsedFlags } from '@chkit/core'
+import { parseFlags, UnknownFlagError, MissingFlagValueError, type FlagDef, type ParsedFlags } from '@chkit/core'
 
 import { typedFlags } from '../plugins.js'
 import type { CommandRegistry, RegisteredCommand } from './command-registry.js'
@@ -9,6 +9,27 @@ import { printOutput } from './json-output.js'
 import type { PluginRuntime } from './plugin-runtime.js'
 import { loadSchemaDefinitions } from './schema-loader.js'
 import { resolveTableScope, tableKeysFromDefinitions } from './table-scope.js'
+
+function extractPositionals(argv: string[], flagDefs: readonly FlagDef[]): string[] {
+  const byName = new Map<string, FlagDef>()
+  for (const def of flagDefs) byName.set(def.name, def)
+
+  const positionals: string[] = []
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (token === undefined) continue
+    if (!token.startsWith('--')) {
+      positionals.push(token)
+      continue
+    }
+    const def = byName.get(token)
+    if (def && def.type !== 'boolean') {
+      // Consume the value following a string/string[] flag
+      i += 1
+    }
+  }
+  return positionals
+}
 
 function stripGlobalFlags(argv: string[]): {
   jsonMode: boolean
@@ -165,6 +186,7 @@ async function runCoreOrBuiltinCommand(input: {
       await input.resolved.run({
         command: input.commandName,
         flags,
+        positionals: [],
         config: input.config,
         configPath: input.configPath,
         dirs,
@@ -178,8 +200,10 @@ async function runCoreOrBuiltinCommand(input: {
   }
 
   const allFlags = input.registry.resolveFlags(input.commandName)
-  const flags = parseFlagsOrReport(input.argv.slice(1), allFlags)
+  const argsAfterCommand = input.argv.slice(1)
+  const flags = parseFlagsOrReport(argsAfterCommand, allFlags)
   if (!flags) return
+  const positionals = extractPositionals(argsAfterCommand, allFlags)
 
   const dirs = resolveDirs(input.config)
   if (!input.resolved.run) throw new Error(`Command '${input.commandName}' has no run handler`)
@@ -193,6 +217,7 @@ async function runCoreOrBuiltinCommand(input: {
     await input.resolved.run({
       command: input.commandName,
       flags,
+      positionals,
       config: input.config,
       configPath: input.configPath,
       dirs,

--- a/packages/cli/src/bin/commands/query.test.ts
+++ b/packages/cli/src/bin/commands/query.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatQueryJson, formatRows } from './query.js'
+
+describe('query output formatting', () => {
+	test('shows at most 25 rows by default while reporting total rows', () => {
+		const rows = Array.from({ length: 27 }, (_, idx) => ({ value: idx + 1 }))
+
+		const output = formatRows(rows)
+
+		expect(output).toContain('25')
+		expect(output).not.toContain('26')
+		expect(output).not.toContain('more rows not shown')
+		expect(output).toContain('(27 rows, showing 25)')
+	})
+
+	test('does not add truncation note for short results', () => {
+		const output = formatRows([{ value: 1 }, { value: 2 }])
+
+		expect(output).toContain('1')
+		expect(output).toContain('2')
+		expect(output).not.toContain('more rows not shown')
+		expect(output).toContain('(2 rows)')
+	})
+
+	test('formats json mode as ClickHouse JSON shape', () => {
+		const output = formatQueryJson({
+			data: [{ database: 'default', name: 'users' }],
+			meta: [
+				{ name: 'database', type: 'String' },
+				{ name: 'name', type: 'String' },
+			],
+			rows: 1,
+			statistics: { elapsed: 0.1, rows_read: 1, bytes_read: 10 },
+			query_id: 'query-id',
+		})
+
+		expect(JSON.parse(output)).toEqual({
+			data: [{ database: 'default', name: 'users' }],
+			meta: [
+				{ name: 'database', type: 'String' },
+				{ name: 'name', type: 'String' },
+			],
+			rows: 1,
+			statistics: { elapsed: 0.1, rows_read: 1, bytes_read: 10 },
+			query_id: 'query-id',
+		})
+	})
+})

--- a/packages/cli/src/bin/commands/query.ts
+++ b/packages/cli/src/bin/commands/query.ts
@@ -1,0 +1,78 @@
+import type { CommandDef, CommandRunContext } from '../../plugins.js'
+import { emitJson } from '../json-output.js'
+
+export const queryCommand: CommandDef = {
+  name: 'query',
+  description: 'Run a SQL query against the configured target',
+  flags: [],
+  run: cmdQuery,
+}
+
+async function cmdQuery(runCtx: CommandRunContext): Promise<void> {
+  const { flags, positionals, ctx } = runCtx
+  const jsonMode = flags['--json'] === true
+
+  const sql = positionals[0]
+  if (!sql || sql.trim().length === 0) {
+    throw new Error('query requires a SQL string as the first positional argument (e.g. `chkit query "SELECT 1"`)')
+  }
+  if (positionals.length > 1) {
+    throw new Error('query accepts a single SQL string. Wrap it in quotes if it contains spaces.')
+  }
+
+  if (!ctx.hasExecutor) {
+    throw new Error('No target configured. Provide clickhouse settings in your config or install a plugin (e.g. obsessiondb) that supplies one.')
+  }
+
+  const rows = await ctx.executor.query<Record<string, unknown>>(sql)
+
+  if (jsonMode) {
+    emitJson('query', { rowCount: rows.length, rows })
+    return
+  }
+
+  printRows(rows)
+}
+
+function printRows(rows: Record<string, unknown>[]): void {
+  if (rows.length === 0) {
+    console.log('(no rows)')
+    return
+  }
+
+  const columns = Array.from(
+    rows.reduce<Set<string>>((acc, row) => {
+      for (const key of Object.keys(row)) acc.add(key)
+      return acc
+    }, new Set<string>())
+  )
+
+  const stringified = rows.map((row) =>
+    columns.map((col) => stringifyCell(row[col]))
+  )
+
+  const widths = columns.map((col, idx) => {
+    let width = col.length
+    for (const r of stringified) {
+      const cell = r[idx] ?? ''
+      if (cell.length > width) width = cell.length
+    }
+    return width
+  })
+
+  const header = columns.map((col, idx) => col.padEnd(widths[idx]!)).join(' │ ')
+  const separator = widths.map((w) => '─'.repeat(w)).join('─┼─')
+  console.log(header)
+  console.log(separator)
+  for (const r of stringified) {
+    console.log(r.map((cell, idx) => cell.padEnd(widths[idx]!)).join(' │ '))
+  }
+  console.log(`\n(${rows.length} row${rows.length === 1 ? '' : 's'})`)
+}
+
+function stringifyCell(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
+  return JSON.stringify(value)
+}

--- a/packages/cli/src/bin/commands/query.ts
+++ b/packages/cli/src/bin/commands/query.ts
@@ -1,78 +1,150 @@
+import type { ClickHouseJsonQueryResult } from '@chkit/clickhouse'
 import type { CommandDef, CommandRunContext } from '../../plugins.js'
-import { emitJson } from '../json-output.js'
+
+const DEFAULT_SHOWN_ROW_LIMIT = 25
 
 export const queryCommand: CommandDef = {
-  name: 'query',
-  description: 'Run a SQL query against the configured target',
-  flags: [],
-  run: cmdQuery,
+	name: 'query',
+	description: 'Run a SQL query against the configured target',
+	flags: [],
+	run: cmdQuery,
 }
 
 async function cmdQuery(runCtx: CommandRunContext): Promise<void> {
-  const { flags, positionals, ctx } = runCtx
-  const jsonMode = flags['--json'] === true
+	const { flags, positionals, ctx } = runCtx
+	const jsonMode = flags['--json'] === true
 
-  const sql = positionals[0]
-  if (!sql || sql.trim().length === 0) {
-    throw new Error('query requires a SQL string as the first positional argument (e.g. `chkit query "SELECT 1"`)')
-  }
-  if (positionals.length > 1) {
-    throw new Error('query accepts a single SQL string. Wrap it in quotes if it contains spaces.')
-  }
+	const sql = positionals[0]
+	if (!sql || sql.trim().length === 0) {
+		throw new Error(
+			'query requires a SQL string as the first positional argument (e.g. `chkit query "SELECT 1"`)',
+		)
+	}
+	if (positionals.length > 1) {
+		throw new Error(
+			'query accepts a single SQL string. Wrap it in quotes if it contains spaces.',
+		)
+	}
 
-  if (!ctx.hasExecutor) {
-    throw new Error('No target configured. Provide clickhouse settings in your config or install a plugin (e.g. obsessiondb) that supplies one.')
-  }
+	if (!ctx.hasExecutor) {
+		throw new Error(
+			'No target configured. Provide clickhouse settings in your config or install a plugin (e.g. obsessiondb) that supplies one.',
+		)
+	}
 
-  const rows = await ctx.executor.query<Record<string, unknown>>(sql)
+	if (jsonMode) {
+		const payload = ctx.executor.queryJson
+			? await ctx.executor.queryJson(sql)
+			: rowsToJsonResult(await ctx.executor.query<Record<string, unknown>>(sql))
+		printQueryJson(payload)
+		return
+	}
 
-  if (jsonMode) {
-    emitJson('query', { rowCount: rows.length, rows })
-    return
-  }
+	const rows = await ctx.executor.query<Record<string, unknown>>(sql)
+	printRows(rows)
+}
 
-  printRows(rows)
+function printQueryJson(payload: ClickHouseJsonQueryResult): void {
+	console.log(formatQueryJson(payload))
 }
 
 function printRows(rows: Record<string, unknown>[]): void {
-  if (rows.length === 0) {
-    console.log('(no rows)')
-    return
-  }
+	console.log(formatRows(rows))
+}
 
-  const columns = Array.from(
-    rows.reduce<Set<string>>((acc, row) => {
-      for (const key of Object.keys(row)) acc.add(key)
-      return acc
-    }, new Set<string>())
-  )
+export function formatQueryJson(payload: ClickHouseJsonQueryResult): string {
+	return JSON.stringify(payload, null, 2)
+}
 
-  const stringified = rows.map((row) =>
-    columns.map((col) => stringifyCell(row[col]))
-  )
+function rowsToJsonResult(
+	rows: Record<string, unknown>[],
+): ClickHouseJsonQueryResult {
+	const columns = Array.from(
+		rows.reduce<Set<string>>((acc, row) => {
+			for (const key of Object.keys(row)) acc.add(key)
+			return acc
+		}, new Set<string>()),
+	)
+	return {
+		data: rows,
+		meta: columns.map((name) => ({
+			name,
+			type: inferClickHouseType(rows, name),
+		})),
+		rows: rows.length,
+	}
+}
 
-  const widths = columns.map((col, idx) => {
-    let width = col.length
-    for (const r of stringified) {
-      const cell = r[idx] ?? ''
-      if (cell.length > width) width = cell.length
-    }
-    return width
-  })
+function inferClickHouseType(
+	rows: Record<string, unknown>[],
+	name: string,
+): string {
+	for (const row of rows) {
+		const value = row[name]
+		if (value === null || value === undefined) continue
+		if (typeof value === 'number')
+			return Number.isInteger(value) ? 'Int64' : 'Float64'
+		if (typeof value === 'boolean') return 'Bool'
+		return 'String'
+	}
+	return 'String'
+}
 
-  const header = columns.map((col, idx) => col.padEnd(widths[idx]!)).join(' │ ')
-  const separator = widths.map((w) => '─'.repeat(w)).join('─┼─')
-  console.log(header)
-  console.log(separator)
-  for (const r of stringified) {
-    console.log(r.map((cell, idx) => cell.padEnd(widths[idx]!)).join(' │ '))
-  }
-  console.log(`\n(${rows.length} row${rows.length === 1 ? '' : 's'})`)
+export function formatRows(
+	rows: Record<string, unknown>[],
+	options: { limit?: number } = {},
+): string {
+	const limit = options.limit ?? DEFAULT_SHOWN_ROW_LIMIT
+	if (rows.length === 0) {
+		return '(no rows)'
+	}
+
+	const shownRows = limit >= 0 ? rows.slice(0, limit) : rows
+	const columns = Array.from(
+		rows.reduce<Set<string>>((acc, row) => {
+			for (const key of Object.keys(row)) acc.add(key)
+			return acc
+		}, new Set<string>()),
+	)
+
+	const stringified = shownRows.map((row) =>
+		columns.map((col) => stringifyCell(row[col])),
+	)
+
+	const widths = columns.map((col, idx) => {
+		let width = col.length
+		for (const r of stringified) {
+			const cell = r[idx] ?? ''
+			if (cell.length > width) width = cell.length
+		}
+		return width
+	})
+
+	const lines: string[] = []
+	const header = columns
+		.map((col, idx) => col.padEnd(widths[idx] ?? 0))
+		.join(' │ ')
+	const separator = widths.map((w) => '─'.repeat(w)).join('─┼─')
+	lines.push(header)
+	lines.push(separator)
+	for (const r of stringified) {
+		lines.push(r.map((cell, idx) => cell.padEnd(widths[idx] ?? 0)).join(' │ '))
+	}
+	lines.push('')
+	lines.push(
+		`(${rows.length} row${rows.length === 1 ? '' : 's'}${shownRows.length < rows.length ? `, showing ${shownRows.length}` : ''})`,
+	)
+	return lines.join('\n')
 }
 
 function stringifyCell(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value)
-  return JSON.stringify(value)
+	if (value === null || value === undefined) return ''
+	if (typeof value === 'string') return value
+	if (
+		typeof value === 'number' ||
+		typeof value === 'boolean' ||
+		typeof value === 'bigint'
+	)
+		return String(value)
+	return JSON.stringify(value)
 }

--- a/packages/cli/src/bin/json-output.ts
+++ b/packages/cli/src/bin/json-output.ts
@@ -5,6 +5,7 @@ type Command =
   | 'drift'
   | 'check'
   | 'plugin'
+  | 'query'
 
 const JSON_CONTRACT_VERSION = 1
 

--- a/packages/cli/src/bin/plugin-runtime.ts
+++ b/packages/cli/src/bin/plugin-runtime.ts
@@ -1,590 +1,842 @@
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
-
 import {
-  canonicalizeDefinitions,
-  type ChxLegacyPluginRegistration,
-  type ChxPluginRegistration,
-  type MigrationPlan,
-  type ResolvedChxConfig,
-  type SchemaDefinition,
+	type ClickHouseExecutor,
+	createClickHouseExecutor,
+} from '@chkit/clickhouse'
+import {
+	type ChxLegacyPluginRegistration,
+	type ChxPluginRegistration,
+	canonicalizeDefinitions,
+	type MigrationPlan,
+	type ResolvedChxConfig,
+	type SchemaDefinition,
 } from '@chkit/core'
-import { createClickHouseExecutor, type ClickHouseExecutor } from '@chkit/clickhouse'
 
 import type {
-  ChxGetContextInput,
-  ChxOnCheckContext,
-  ChxOnCheckResult,
-  ChxOnAfterApplyContext,
-  ChxOnBeforeApplyContext,
-  ChxOnBeforePluginCommandContext,
-  ChxOnBeforePluginCommandResult,
-  ChxOnCompleteContext,
-  ChxOnConfigLoadedContext,
-  ChxOnInitContext,
-  ChxOnPlanCreatedContext,
-  ChxOnSchemaLoadedContext,
-  ChxPlugin,
-  ChxPluginCommand,
-  ChxPluginCommandContext,
-  PluginContext,
+	ChxGetContextInput,
+	ChxOnAfterApplyContext,
+	ChxOnBeforeApplyContext,
+	ChxOnBeforePluginCommandContext,
+	ChxOnBeforePluginCommandResult,
+	ChxOnCheckContext,
+	ChxOnCheckResult,
+	ChxOnCompleteContext,
+	ChxOnConfigLoadedContext,
+	ChxOnInitContext,
+	ChxOnPlanCreatedContext,
+	ChxOnSchemaLoadedContext,
+	ChxPlugin,
+	ChxPluginCommand,
+	ChxPluginCommandContext,
+	PluginContext,
 } from '../plugins.js'
 import { isInlinePluginRegistration } from '../plugins.js'
-import type { TableScope } from './table-scope.js'
 import { debug, isDebugEnabled } from './debug.js'
+import type { TableScope } from './table-scope.js'
 
 interface LoadedPlugin {
-  options: Record<string, unknown>
-  plugin: ChxPlugin
+	options: Record<string, unknown>
+	plugin: ChxPlugin
 }
 
 const UNFILTERED_TABLE_SCOPE: TableScope = {
-  enabled: false,
-  matchedTables: [],
-  matchCount: 0,
+	enabled: false,
+	matchedTables: [],
+	matchCount: 0,
 }
 
 export interface PluginRuntime {
-  plugins: ReadonlyArray<LoadedPlugin>
-  getCommand(pluginName: string, commandName: string): { command: ChxPluginCommand; plugin: LoadedPlugin } | null
-  resolveContext(input: Omit<ChxGetContextInput, 'defaults'>): Promise<PluginContext>
-  disposeContext(ctx: PluginContext): Promise<void>
-  runOnInit(context: Omit<ChxOnInitContext, 'options'>): Promise<void>
-  runOnComplete(context: Omit<ChxOnCompleteContext, 'options' | 'exitCode'> & { exitCode?: number }): Promise<void>
-  runOnConfigLoaded(
-    context: Omit<ChxOnConfigLoadedContext, 'options' | 'tableScope'> & { tableScope?: TableScope }
-  ): Promise<void>
-  runOnSchemaLoaded(context: ChxOnSchemaLoadedContext): Promise<SchemaDefinition[]>
-  runOnPlanCreated(
-    context: Omit<ChxOnPlanCreatedContext, 'plan' | 'tableScope'> & { tableScope?: TableScope },
-    plan: MigrationPlan
-  ): Promise<MigrationPlan>
-  runOnBeforeApply(context: ChxOnBeforeApplyContext): Promise<string[]>
-  runOnAfterApply(context: ChxOnAfterApplyContext): Promise<void>
-  runOnCheck(
-    context: Omit<ChxOnCheckContext, 'options' | 'tableScope'> & { tableScope?: TableScope }
-  ): Promise<ChxOnCheckResult[]>
-  runOnCheckReport(results: ChxOnCheckResult[], print: (line: string) => void): Promise<void>
-  runOnBeforePluginCommand(
-    pluginName: string,
-    commandName: string,
-    context: Omit<ChxOnBeforePluginCommandContext, 'targetPlugin' | 'command' | 'options'>
-  ): Promise<ChxOnBeforePluginCommandResult>
-  runPluginCommand(
-    pluginName: string,
-    commandName: string,
-    context: Omit<ChxPluginCommandContext, 'pluginName' | 'options' | 'tableScope'> & {
-      tableScope?: TableScope
-    }
-  ): Promise<number>
+	plugins: ReadonlyArray<LoadedPlugin>
+	getCommand(
+		pluginName: string,
+		commandName: string,
+	): { command: ChxPluginCommand; plugin: LoadedPlugin } | null
+	resolveContext(
+		input: Omit<ChxGetContextInput, 'defaults'>,
+	): Promise<PluginContext>
+	disposeContext(ctx: PluginContext): Promise<void>
+	runOnInit(context: Omit<ChxOnInitContext, 'options'>): Promise<void>
+	runOnComplete(
+		context: Omit<ChxOnCompleteContext, 'options' | 'exitCode'> & {
+			exitCode?: number
+		},
+	): Promise<void>
+	runOnConfigLoaded(
+		context: Omit<ChxOnConfigLoadedContext, 'options' | 'tableScope'> & {
+			tableScope?: TableScope
+		},
+	): Promise<void>
+	runOnSchemaLoaded(
+		context: ChxOnSchemaLoadedContext,
+	): Promise<SchemaDefinition[]>
+	runOnPlanCreated(
+		context: Omit<ChxOnPlanCreatedContext, 'plan' | 'tableScope'> & {
+			tableScope?: TableScope
+		},
+		plan: MigrationPlan,
+	): Promise<MigrationPlan>
+	runOnBeforeApply(context: ChxOnBeforeApplyContext): Promise<string[]>
+	runOnAfterApply(context: ChxOnAfterApplyContext): Promise<void>
+	runOnCheck(
+		context: Omit<ChxOnCheckContext, 'options' | 'tableScope'> & {
+			tableScope?: TableScope
+		},
+	): Promise<ChxOnCheckResult[]>
+	runOnCheckReport(
+		results: ChxOnCheckResult[],
+		print: (line: string) => void,
+	): Promise<void>
+	runOnBeforePluginCommand(
+		pluginName: string,
+		commandName: string,
+		context: Omit<
+			ChxOnBeforePluginCommandContext,
+			'targetPlugin' | 'command' | 'options'
+		>,
+	): Promise<ChxOnBeforePluginCommandResult>
+	runPluginCommand(
+		pluginName: string,
+		commandName: string,
+		context: Omit<
+			ChxPluginCommandContext,
+			'pluginName' | 'options' | 'tableScope'
+		> & {
+			tableScope?: TableScope
+		},
+	): Promise<number>
 }
 
 function parseCliMajor(version: string): number {
-  const major = Number(version.split('.')[0] ?? Number.NaN)
-  if (!Number.isInteger(major) || major < 0) {
-    throw new Error(`Invalid CLI version "${version}" while loading plugins.`)
-  }
-  return major
+	const major = Number(version.split('.')[0] ?? Number.NaN)
+	if (!Number.isInteger(major) || major < 0) {
+		throw new Error(`Invalid CLI version "${version}" while loading plugins.`)
+	}
+	return major
 }
 
-function normalizePluginRegistration(
-  entry: ChxPluginRegistration
-): {
-  kind: 'legacy' | 'inline'
-  resolvePath: string
-  inlinePlugin?: ChxPlugin
-  nameHint?: string
-  enabled: boolean
-  options: Record<string, unknown>
+function normalizePluginRegistration(entry: ChxPluginRegistration): {
+	kind: 'legacy' | 'inline'
+	resolvePath: string
+	inlinePlugin?: ChxPlugin
+	nameHint?: string
+	enabled: boolean
+	options: Record<string, unknown>
 } {
-  if (typeof entry === 'string') {
-    return {
-      kind: 'legacy',
-      resolvePath: entry,
-      enabled: true,
-      options: {},
-    }
-  }
+	if (typeof entry === 'string') {
+		return {
+			kind: 'legacy',
+			resolvePath: entry,
+			enabled: true,
+			options: {},
+		}
+	}
 
-  if (isInlinePluginRegistration(entry)) {
-    return {
-      kind: 'inline',
-      resolvePath: '',
-      inlinePlugin: entry.plugin,
-      nameHint: entry.name,
-      enabled: entry.enabled !== false,
-      options: entry.options ?? {},
-    }
-  }
+	if (isInlinePluginRegistration(entry)) {
+		return {
+			kind: 'inline',
+			resolvePath: '',
+			inlinePlugin: entry.plugin,
+			nameHint: entry.name,
+			enabled: entry.enabled !== false,
+			options: entry.options ?? {},
+		}
+	}
 
-  const legacy = entry as ChxLegacyPluginRegistration
-  return {
-    kind: 'legacy',
-    resolvePath: legacy.resolve,
-    nameHint: legacy.name,
-    enabled: legacy.enabled !== false,
-    options: legacy.options ?? {},
-  }
+	const legacy = entry as ChxLegacyPluginRegistration
+	return {
+		kind: 'legacy',
+		resolvePath: legacy.resolve,
+		nameHint: legacy.name,
+		enabled: legacy.enabled !== false,
+		options: legacy.options ?? {},
+	}
 }
 
-function wrapExecutorWithDebug(executor: ClickHouseExecutor): ClickHouseExecutor {
-  if (!isDebugEnabled()) return executor
+function wrapExecutorWithDebug(
+	executor: ClickHouseExecutor,
+): ClickHouseExecutor {
+	if (!isDebugEnabled()) return executor
+	const queryJson = executor.queryJson?.bind(executor)
 
-  return {
-    async command(sql: string): Promise<void> {
-      debug('clickhouse', `command: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`)
-      const start = performance.now()
-      try {
-        await executor.command(sql)
-        debug('clickhouse', `command OK (${Math.round(performance.now() - start)}ms)`)
-      } catch (error) {
-        debug('clickhouse', `command FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async query<T>(sql: string): Promise<T[]> {
-      debug('clickhouse', `query: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`)
-      const start = performance.now()
-      try {
-        const rows = await executor.query<T>(sql)
-        debug('clickhouse', `query OK — ${rows.length} rows (${Math.round(performance.now() - start)}ms)`)
-        return rows
-      } catch (error) {
-        debug('clickhouse', `query FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async insert<T extends Record<string, unknown>>(params: { table: string; values: T[]; compressed?: boolean }): Promise<void> {
-      debug('clickhouse', `insert into ${params.table} — ${params.values.length} rows`)
-      const start = performance.now()
-      try {
-        await executor.insert(params)
-        debug('clickhouse', `insert OK (${Math.round(performance.now() - start)}ms)`)
-      } catch (error) {
-        debug('clickhouse', `insert FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async submit(sql: string, queryId?: string): Promise<string> {
-      debug('clickhouse', `submit${queryId ? ` (id: ${queryId})` : ''}: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`)
-      const start = performance.now()
-      try {
-        const id = await executor.submit(sql, queryId)
-        debug('clickhouse', `submit OK — id: ${id} (${Math.round(performance.now() - start)}ms)`)
-        return id
-      } catch (error) {
-        debug('clickhouse', `submit FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async queryStatus(queryId: string, options?: { afterTime?: string }) {
-      debug('clickhouse', `queryStatus for ${queryId}`)
-      const start = performance.now()
-      try {
-        const status = await executor.queryStatus(queryId, options)
-        debug('clickhouse', `queryStatus: ${status.status} (${Math.round(performance.now() - start)}ms)`)
-        return status
-      } catch (error) {
-        debug('clickhouse', `queryStatus FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async listSchemaObjects() {
-      debug('clickhouse', 'listSchemaObjects')
-      const start = performance.now()
-      try {
-        const objects = await executor.listSchemaObjects()
-        debug('clickhouse', `listSchemaObjects OK — ${objects.length} objects (${Math.round(performance.now() - start)}ms)`)
-        return objects
-      } catch (error) {
-        debug('clickhouse', `listSchemaObjects FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async listTableDetails(databases: string[]) {
-      debug('clickhouse', `listTableDetails for databases: [${databases.join(', ')}]`)
-      const start = performance.now()
-      try {
-        const tables = await executor.listTableDetails(databases)
-        debug('clickhouse', `listTableDetails OK — ${tables.length} tables (${Math.round(performance.now() - start)}ms)`)
-        return tables
-      } catch (error) {
-        debug('clickhouse', `listTableDetails FAILED (${Math.round(performance.now() - start)}ms)`, error instanceof Error ? error.message : error)
-        throw error
-      }
-    },
-    async close(): Promise<void> {
-      debug('clickhouse', 'closing connections')
-      await executor.close()
-    },
-  }
+	return {
+		async command(sql: string): Promise<void> {
+			debug(
+				'clickhouse',
+				`command: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`,
+			)
+			const start = performance.now()
+			try {
+				await executor.command(sql)
+				debug(
+					'clickhouse',
+					`command OK (${Math.round(performance.now() - start)}ms)`,
+				)
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`command FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		async query<T>(sql: string): Promise<T[]> {
+			debug(
+				'clickhouse',
+				`query: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`,
+			)
+			const start = performance.now()
+			try {
+				const rows = await executor.query<T>(sql)
+				debug(
+					'clickhouse',
+					`query OK — ${rows.length} rows (${Math.round(performance.now() - start)}ms)`,
+				)
+				return rows
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`query FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		...(queryJson
+			? {
+					async queryJson<T extends Record<string, unknown>>(sql: string) {
+						debug(
+							'clickhouse',
+							`queryJson: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`,
+						)
+						const start = performance.now()
+						try {
+							const payload = await queryJson<T>(sql)
+							debug(
+								'clickhouse',
+								`queryJson OK — ${payload.rows} rows (${Math.round(performance.now() - start)}ms)`,
+							)
+							return payload
+						} catch (error) {
+							debug(
+								'clickhouse',
+								`queryJson FAILED (${Math.round(performance.now() - start)}ms)`,
+								error instanceof Error ? error.message : error,
+							)
+							throw error
+						}
+					},
+				}
+			: {}),
+		async insert<T extends Record<string, unknown>>(params: {
+			table: string
+			values: T[]
+			compressed?: boolean
+		}): Promise<void> {
+			debug(
+				'clickhouse',
+				`insert into ${params.table} — ${params.values.length} rows`,
+			)
+			const start = performance.now()
+			try {
+				await executor.insert(params)
+				debug(
+					'clickhouse',
+					`insert OK (${Math.round(performance.now() - start)}ms)`,
+				)
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`insert FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		async submit(sql: string, queryId?: string): Promise<string> {
+			debug(
+				'clickhouse',
+				`submit${queryId ? ` (id: ${queryId})` : ''}: ${sql.slice(0, 200)}${sql.length > 200 ? '...' : ''}`,
+			)
+			const start = performance.now()
+			try {
+				const id = await executor.submit(sql, queryId)
+				debug(
+					'clickhouse',
+					`submit OK — id: ${id} (${Math.round(performance.now() - start)}ms)`,
+				)
+				return id
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`submit FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		async queryStatus(queryId: string, options?: { afterTime?: string }) {
+			debug('clickhouse', `queryStatus for ${queryId}`)
+			const start = performance.now()
+			try {
+				const status = await executor.queryStatus(queryId, options)
+				debug(
+					'clickhouse',
+					`queryStatus: ${status.status} (${Math.round(performance.now() - start)}ms)`,
+				)
+				return status
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`queryStatus FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		async listSchemaObjects() {
+			debug('clickhouse', 'listSchemaObjects')
+			const start = performance.now()
+			try {
+				const objects = await executor.listSchemaObjects()
+				debug(
+					'clickhouse',
+					`listSchemaObjects OK — ${objects.length} objects (${Math.round(performance.now() - start)}ms)`,
+				)
+				return objects
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`listSchemaObjects FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		async listTableDetails(databases: string[]) {
+			debug(
+				'clickhouse',
+				`listTableDetails for databases: [${databases.join(', ')}]`,
+			)
+			const start = performance.now()
+			try {
+				const tables = await executor.listTableDetails(databases)
+				debug(
+					'clickhouse',
+					`listTableDetails OK — ${tables.length} tables (${Math.round(performance.now() - start)}ms)`,
+				)
+				return tables
+			} catch (error) {
+				debug(
+					'clickhouse',
+					`listTableDetails FAILED (${Math.round(performance.now() - start)}ms)`,
+					error instanceof Error ? error.message : error,
+				)
+				throw error
+			}
+		},
+		async close(): Promise<void> {
+			debug('clickhouse', 'closing connections')
+			await executor.close()
+		},
+	}
 }
 
-function formatPluginError(pluginName: string, hook: string, error: unknown): Error {
-  const message = error instanceof Error ? error.message : String(error)
-  return new Error(`Plugin "${pluginName}" failed in ${hook}: ${message}`)
+function formatPluginError(
+	pluginName: string,
+	hook: string,
+	error: unknown,
+): Error {
+	const message = error instanceof Error ? error.message : String(error)
+	return new Error(`Plugin "${pluginName}" failed in ${hook}: ${message}`)
 }
 
-function validatePlugin(cliVersion: string, plugin: ChxPlugin, sourcePath: string): void {
-  const name = plugin.manifest.name
-  if (!name || name.trim().length === 0) {
-    throw new Error(`Plugin at ${sourcePath} has an empty manifest.name.`)
-  }
+function validatePlugin(
+	cliVersion: string,
+	plugin: ChxPlugin,
+	sourcePath: string,
+): void {
+	const name = plugin.manifest.name
+	if (!name || name.trim().length === 0) {
+		throw new Error(`Plugin at ${sourcePath} has an empty manifest.name.`)
+	}
 
-  if (plugin.manifest.apiVersion !== 1) {
-    throw new Error(
-      `Plugin "${name}" requires apiVersion=${String(plugin.manifest.apiVersion)} but CLI supports apiVersion=1.`
-    )
-  }
+	if (plugin.manifest.apiVersion !== 1) {
+		throw new Error(
+			`Plugin "${name}" requires apiVersion=${String(plugin.manifest.apiVersion)} but CLI supports apiVersion=1.`,
+		)
+	}
 
-  const compatibility = plugin.manifest.compatibility?.cli
-  if (!compatibility) return
+	const compatibility = plugin.manifest.compatibility?.cli
+	if (!compatibility) return
 
-  const cliMajor = parseCliMajor(cliVersion)
-  if (compatibility.minMajor !== undefined && cliMajor < compatibility.minMajor) {
-    throw new Error(
-      `Plugin "${name}" is incompatible with CLI ${cliVersion}. Requires cli major >= ${compatibility.minMajor}.`
-    )
-  }
-  if (compatibility.maxMajor !== undefined && cliMajor > compatibility.maxMajor) {
-    throw new Error(
-      `Plugin "${name}" is incompatible with CLI ${cliVersion}. Requires cli major <= ${compatibility.maxMajor}.`
-    )
-  }
+	const cliMajor = parseCliMajor(cliVersion)
+	if (
+		compatibility.minMajor !== undefined &&
+		cliMajor < compatibility.minMajor
+	) {
+		throw new Error(
+			`Plugin "${name}" is incompatible with CLI ${cliVersion}. Requires cli major >= ${compatibility.minMajor}.`,
+		)
+	}
+	if (
+		compatibility.maxMajor !== undefined &&
+		cliMajor > compatibility.maxMajor
+	) {
+		throw new Error(
+			`Plugin "${name}" is incompatible with CLI ${cliVersion}. Requires cli major <= ${compatibility.maxMajor}.`,
+		)
+	}
 }
 
 async function importPluginModule(absolutePath: string): Promise<ChxPlugin> {
-  const mod = (await import(pathToFileURL(absolutePath).href)) as { default?: unknown; plugin?: unknown }
-  const candidate = (mod.default ?? mod.plugin) as ChxPlugin | undefined
-  if (!candidate || typeof candidate !== 'object') {
-    throw new Error(`Plugin module ${absolutePath} must export default definePlugin(...)`)
-  }
-  if (!candidate.manifest || typeof candidate.manifest !== 'object') {
-    throw new Error(`Plugin module ${absolutePath} is missing manifest.`)
-  }
-  return candidate
+	const mod = (await import(pathToFileURL(absolutePath).href)) as {
+		default?: unknown
+		plugin?: unknown
+	}
+	const candidate = (mod.default ?? mod.plugin) as ChxPlugin | undefined
+	if (!candidate || typeof candidate !== 'object') {
+		throw new Error(
+			`Plugin module ${absolutePath} must export default definePlugin(...)`,
+		)
+	}
+	if (!candidate.manifest || typeof candidate.manifest !== 'object') {
+		throw new Error(`Plugin module ${absolutePath} is missing manifest.`)
+	}
+	return candidate
 }
 
 export async function loadPluginRuntime(input: {
-  config: ResolvedChxConfig
-  configPath: string
-  cliVersion: string
-  internalPlugins?: ChxPlugin[]
+	config: ResolvedChxConfig
+	configPath: string
+	cliVersion: string
+	internalPlugins?: ChxPlugin[]
 }): Promise<PluginRuntime> {
-  const registrations = input.config.plugins ?? []
-  const loaded: LoadedPlugin[] = []
-  const byName = new Map<string, LoadedPlugin>()
-  const configDir = resolve(input.configPath, '..')
+	const registrations = input.config.plugins ?? []
+	const loaded: LoadedPlugin[] = []
+	const byName = new Map<string, LoadedPlugin>()
+	const configDir = resolve(input.configPath, '..')
 
-  for (const registration of registrations) {
-    const normalized = normalizePluginRegistration(registration)
-    if (!normalized.enabled) continue
+	for (const registration of registrations) {
+		const normalized = normalizePluginRegistration(registration)
+		if (!normalized.enabled) continue
 
-    const plugin =
-      normalized.kind === 'inline'
-        ? normalized.inlinePlugin
-        : await importPluginModule(resolve(configDir, normalized.resolvePath))
-    if (!plugin) continue
+		const plugin =
+			normalized.kind === 'inline'
+				? normalized.inlinePlugin
+				: await importPluginModule(resolve(configDir, normalized.resolvePath))
+		if (!plugin) continue
 
-    const sourceLabel =
-      normalized.kind === 'inline'
-        ? `inline registration${normalized.nameHint ? ` (${normalized.nameHint})` : ''}`
-        : resolve(configDir, normalized.resolvePath)
-    validatePlugin(input.cliVersion, plugin, sourceLabel)
+		const sourceLabel =
+			normalized.kind === 'inline'
+				? `inline registration${normalized.nameHint ? ` (${normalized.nameHint})` : ''}`
+				: resolve(configDir, normalized.resolvePath)
+		validatePlugin(input.cliVersion, plugin, sourceLabel)
 
-    if (normalized.nameHint && normalized.nameHint !== plugin.manifest.name) {
-      throw new Error(
-        `Plugin name mismatch for ${sourceLabel}: configured "${normalized.nameHint}" but manifest is "${plugin.manifest.name}".`
-      )
-    }
-    if (byName.has(plugin.manifest.name)) {
-      throw new Error(`Duplicate plugin name "${plugin.manifest.name}" in config.plugins.`)
-    }
+		if (normalized.nameHint && normalized.nameHint !== plugin.manifest.name) {
+			throw new Error(
+				`Plugin name mismatch for ${sourceLabel}: configured "${normalized.nameHint}" but manifest is "${plugin.manifest.name}".`,
+			)
+		}
+		if (byName.has(plugin.manifest.name)) {
+			throw new Error(
+				`Duplicate plugin name "${plugin.manifest.name}" in config.plugins.`,
+			)
+		}
 
-    debug('plugin', `loaded "${plugin.manifest.name}" v${plugin.manifest.version ?? '?'}`, {
-      hooks: Object.keys(plugin.hooks ?? {}),
-      commands: (plugin.commands ?? []).map((c) => c.name),
-    })
+		debug(
+			'plugin',
+			`loaded "${plugin.manifest.name}" v${plugin.manifest.version ?? '?'}`,
+			{
+				hooks: Object.keys(plugin.hooks ?? {}),
+				commands: (plugin.commands ?? []).map((c) => c.name),
+			},
+		)
 
-    const item: LoadedPlugin = {
-      plugin,
-      options: normalized.options,
-    }
-    loaded.push(item)
-    byName.set(plugin.manifest.name, item)
-  }
+		const item: LoadedPlugin = {
+			plugin,
+			options: normalized.options,
+		}
+		loaded.push(item)
+		byName.set(plugin.manifest.name, item)
+	}
 
-  for (const plugin of input.internalPlugins ?? []) {
-    if (byName.has(plugin.manifest.name)) continue
-    const item: LoadedPlugin = { plugin, options: {} }
-    loaded.push(item)
-    byName.set(plugin.manifest.name, item)
-  }
+	for (const plugin of input.internalPlugins ?? []) {
+		if (byName.has(plugin.manifest.name)) continue
+		const item: LoadedPlugin = { plugin, options: {} }
+		loaded.push(item)
+		byName.set(plugin.manifest.name, item)
+	}
 
-  async function runBeforePluginCommandHooks(
-    pluginName: string,
-    commandName: string,
-    context: Omit<ChxOnBeforePluginCommandContext, 'targetPlugin' | 'command' | 'options'>
-  ): Promise<ChxOnBeforePluginCommandResult> {
-    for (const item of loaded) {
-      if (item.plugin.manifest.name === pluginName) continue
-      const hook = item.plugin.hooks?.onBeforePluginCommand
-      if (!hook) continue
-      debug('hook', `onBeforePluginCommand → ${item.plugin.manifest.name} (target: ${pluginName}:${commandName})`)
-      try {
-        const result = await hook({
-          ...context,
-          targetPlugin: pluginName,
-          command: commandName,
-          options: item.options,
-        })
-        if (result.handled) {
-          debug('hook', `onBeforePluginCommand ← ${item.plugin.manifest.name} handled command (exitCode: ${result.exitCode})`)
-          return result
-        }
-      } catch (error) {
-        throw formatPluginError(item.plugin.manifest.name, 'onBeforePluginCommand', error)
-      }
-    }
-    return { handled: false }
-  }
+	async function runBeforePluginCommandHooks(
+		pluginName: string,
+		commandName: string,
+		context: Omit<
+			ChxOnBeforePluginCommandContext,
+			'targetPlugin' | 'command' | 'options'
+		>,
+	): Promise<ChxOnBeforePluginCommandResult> {
+		for (const item of loaded) {
+			if (item.plugin.manifest.name === pluginName) continue
+			const hook = item.plugin.hooks?.onBeforePluginCommand
+			if (!hook) continue
+			debug(
+				'hook',
+				`onBeforePluginCommand → ${item.plugin.manifest.name} (target: ${pluginName}:${commandName})`,
+			)
+			try {
+				const result = await hook({
+					...context,
+					targetPlugin: pluginName,
+					command: commandName,
+					options: item.options,
+				})
+				if (result.handled) {
+					debug(
+						'hook',
+						`onBeforePluginCommand ← ${item.plugin.manifest.name} handled command (exitCode: ${result.exitCode})`,
+					)
+					return result
+				}
+			} catch (error) {
+				throw formatPluginError(
+					item.plugin.manifest.name,
+					'onBeforePluginCommand',
+					error,
+				)
+			}
+		}
+		return { handled: false }
+	}
 
-  const NULL_EXECUTOR: ClickHouseExecutor = (() => {
-    const err = () => {
-      throw new Error('No ClickHouse connection configured and no plugin provided an executor')
-    }
-    return {
-      command: err,
-      query: err,
-      insert: err,
-      submit: err,
-      queryStatus: err,
-      listSchemaObjects: err,
-      listTableDetails: err,
-      close: () => Promise.resolve(),
-    }
-  })()
+	const NULL_EXECUTOR: ClickHouseExecutor = (() => {
+		const err = () => {
+			throw new Error(
+				'No ClickHouse connection configured and no plugin provided an executor',
+			)
+		}
+		return {
+			command: err,
+			query: err,
+			insert: err,
+			submit: err,
+			queryStatus: err,
+			listSchemaObjects: err,
+			listTableDetails: err,
+			close: () => Promise.resolve(),
+		}
+	})()
 
-  return {
-    plugins: loaded,
-    async resolveContext(input) {
-      const hasClickhouseConfig = !!input.config.clickhouse
-      debug('context', `resolving executor — clickhouse config: ${hasClickhouseConfig ? 'yes' : 'no'}`)
-      const rawExecutor = hasClickhouseConfig
-        ? createClickHouseExecutor(input.config.clickhouse!)
-        : NULL_EXECUTOR
-      const defaults: PluginContext = {
-        executor: wrapExecutorWithDebug(rawExecutor),
-        hasExecutor: hasClickhouseConfig,
-      }
-      let ctx = defaults
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.getContext
-        if (!hook) continue
-        try {
-          const result = await hook({ ...input, defaults })
-          if (result && typeof result === 'object' && 'executor' in result && result.executor) {
-            debug('context', `plugin "${item.plugin.manifest.name}" provided executor override`)
-            // Plugin returned an executor override — close the default one
-            if (ctx.executor !== defaults.executor) {
-              // A previous plugin already overrode — close that one
-              await ctx.executor.close()
-            } else if (ctx === defaults && defaults.executor !== NULL_EXECUTOR) {
-              // First override — close the default executor
-              await defaults.executor.close()
-            }
-            ctx = { ...ctx, ...result, hasExecutor: true }
-          }
-        } catch (error) {
-          await ctx.executor.close()
-          throw formatPluginError(item.plugin.manifest.name, 'getContext', error)
-        }
-      }
-      return ctx
-    },
-    async disposeContext(ctx) {
-      await ctx.executor.close()
-    },
-    getCommand(pluginName, commandName) {
-      const item = byName.get(pluginName)
-      if (!item) return null
-      const command = (item.plugin.commands ?? []).find((entry) => entry.name === commandName)
-      if (!command) return null
-      return { plugin: item, command }
-    },
-    async runOnInit(context) {
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onInit
-        if (!hook) continue
-        debug('hook', `onInit → ${item.plugin.manifest.name}`)
-        try {
-          await hook({ ...context, options: item.options })
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onInit', error)
-        }
-      }
-    },
-    async runOnComplete(context) {
-      const exitCode = context.exitCode ?? 0
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onComplete
-        if (!hook) continue
-        debug('hook', `onComplete → ${item.plugin.manifest.name} (exitCode: ${exitCode})`)
-        try {
-          await hook({ ...context, exitCode, options: item.options })
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onComplete', error)
-        }
-      }
-    },
-    async runOnConfigLoaded(context) {
-      const tableScope = context.tableScope ?? UNFILTERED_TABLE_SCOPE
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onConfigLoaded
-        if (!hook) continue
-        debug('hook', `onConfigLoaded → ${item.plugin.manifest.name}`)
-        try {
-          await hook({ ...context, options: item.options, tableScope })
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onConfigLoaded', error)
-        }
-      }
-    },
-    async runOnSchemaLoaded(context) {
-      let definitions = context.definitions
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onSchemaLoaded
-        if (!hook) continue
-        debug('hook', `onSchemaLoaded → ${item.plugin.manifest.name} (${definitions.length} definitions)`)
-        try {
-          const next = await hook({ ...context, definitions })
-          if (Array.isArray(next)) {
-            debug('hook', `onSchemaLoaded ← ${item.plugin.manifest.name} returned ${next.length} definitions`)
-            definitions = canonicalizeDefinitions(next)
-          }
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onSchemaLoaded', error)
-        }
-      }
-      return definitions
-    },
-    async runOnPlanCreated(context, initialPlan) {
-      const tableScope = context.tableScope ?? UNFILTERED_TABLE_SCOPE
-      let plan = initialPlan
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onPlanCreated
-        if (!hook) continue
-        debug('hook', `onPlanCreated → ${item.plugin.manifest.name} (${plan.operations.length} operations)`)
-        try {
-          const next = await hook({ ...context, tableScope, plan })
-          if (next) {
-            debug('hook', `onPlanCreated ← ${item.plugin.manifest.name} modified plan (${next.operations.length} operations)`)
-            plan = next
-          }
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onPlanCreated', error)
-        }
-      }
-      return plan
-    },
-    async runOnBeforeApply(context) {
-      let statements = context.statements
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onBeforeApply
-        if (!hook) continue
-        debug('hook', `onBeforeApply → ${item.plugin.manifest.name} (${context.migration}, ${statements.length} statements)`)
-        try {
-          const result = await hook({ ...context, statements })
-          if (result?.statements) {
-            debug('hook', `onBeforeApply ← ${item.plugin.manifest.name} modified statements (${result.statements.length})`)
-            statements = result.statements
-          }
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onBeforeApply', error)
-        }
-      }
-      return statements
-    },
-    async runOnAfterApply(context) {
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onAfterApply
-        if (!hook) continue
-        debug('hook', `onAfterApply → ${item.plugin.manifest.name} (${context.migration})`)
-        try {
-          await hook(context)
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onAfterApply', error)
-        }
-      }
-    },
-    async runOnCheck(context) {
-      const tableScope = context.tableScope ?? UNFILTERED_TABLE_SCOPE
-      const results: ChxOnCheckResult[] = []
-      for (const item of loaded) {
-        const hook = item.plugin.hooks?.onCheck
-        if (!hook) continue
-        debug('hook', `onCheck → ${item.plugin.manifest.name}`)
-        try {
-          const result = await hook({ ...context, options: item.options, tableScope })
-          if (!result) continue
-          debug('hook', `onCheck ← ${item.plugin.manifest.name}: ok=${result.ok}, findings=${result.findings.length}`)
-          results.push({
-            plugin: result.plugin || item.plugin.manifest.name,
-            evaluated: result.evaluated,
-            ok: result.ok,
-            findings: result.findings,
-            metadata: result.metadata,
-          })
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onCheck', error)
-        }
-      }
-      return results
-    },
-    async runOnCheckReport(results, print) {
-      for (const result of results) {
-        const item = byName.get(result.plugin)
-        if (!item) continue
-        const hook = item.plugin.hooks?.onCheckReport
-        if (!hook) continue
-        try {
-          await hook({ result, print })
-        } catch (error) {
-          throw formatPluginError(item.plugin.manifest.name, 'onCheckReport', error)
-        }
-      }
-    },
-    runOnBeforePluginCommand: runBeforePluginCommandHooks,
-    async runPluginCommand(pluginName, commandName, context) {
-      debug('command', `running plugin command "${pluginName}:${commandName}"`)
-      const item = byName.get(pluginName)
-      if (!item) return 1
-      const command = (item.plugin.commands ?? []).find((entry) => entry.name === commandName)
-      if (!command) return 1
+	return {
+		plugins: loaded,
+		async resolveContext(input) {
+			const hasClickhouseConfig = !!input.config.clickhouse
+			debug(
+				'context',
+				`resolving executor — clickhouse config: ${hasClickhouseConfig ? 'yes' : 'no'}`,
+			)
+			const rawExecutor = hasClickhouseConfig
+				? createClickHouseExecutor(input.config.clickhouse!)
+				: NULL_EXECUTOR
+			const defaults: PluginContext = {
+				executor: wrapExecutorWithDebug(rawExecutor),
+				hasExecutor: hasClickhouseConfig,
+			}
+			let ctx = defaults
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.getContext
+				if (!hook) continue
+				try {
+					const result = await hook({ ...input, defaults })
+					if (
+						result &&
+						typeof result === 'object' &&
+						'executor' in result &&
+						result.executor
+					) {
+						debug(
+							'context',
+							`plugin "${item.plugin.manifest.name}" provided executor override`,
+						)
+						// Plugin returned an executor override — close the default one
+						if (ctx.executor !== defaults.executor) {
+							// A previous plugin already overrode — close that one
+							await ctx.executor.close()
+						} else if (
+							ctx === defaults &&
+							defaults.executor !== NULL_EXECUTOR
+						) {
+							// First override — close the default executor
+							await defaults.executor.close()
+						}
+						ctx = { ...ctx, ...result, hasExecutor: true }
+					}
+				} catch (error) {
+					await ctx.executor.close()
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'getContext',
+						error,
+					)
+				}
+			}
+			return ctx
+		},
+		async disposeContext(ctx) {
+			await ctx.executor.close()
+		},
+		getCommand(pluginName, commandName) {
+			const item = byName.get(pluginName)
+			if (!item) return null
+			const command = (item.plugin.commands ?? []).find(
+				(entry) => entry.name === commandName,
+			)
+			if (!command) return null
+			return { plugin: item, command }
+		},
+		async runOnInit(context) {
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onInit
+				if (!hook) continue
+				debug('hook', `onInit → ${item.plugin.manifest.name}`)
+				try {
+					await hook({ ...context, options: item.options })
+				} catch (error) {
+					throw formatPluginError(item.plugin.manifest.name, 'onInit', error)
+				}
+			}
+		},
+		async runOnComplete(context) {
+			const exitCode = context.exitCode ?? 0
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onComplete
+				if (!hook) continue
+				debug(
+					'hook',
+					`onComplete → ${item.plugin.manifest.name} (exitCode: ${exitCode})`,
+				)
+				try {
+					await hook({ ...context, exitCode, options: item.options })
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onComplete',
+						error,
+					)
+				}
+			}
+		},
+		async runOnConfigLoaded(context) {
+			const tableScope = context.tableScope ?? UNFILTERED_TABLE_SCOPE
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onConfigLoaded
+				if (!hook) continue
+				debug('hook', `onConfigLoaded → ${item.plugin.manifest.name}`)
+				try {
+					await hook({ ...context, options: item.options, tableScope })
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onConfigLoaded',
+						error,
+					)
+				}
+			}
+		},
+		async runOnSchemaLoaded(context) {
+			let definitions = context.definitions
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onSchemaLoaded
+				if (!hook) continue
+				debug(
+					'hook',
+					`onSchemaLoaded → ${item.plugin.manifest.name} (${definitions.length} definitions)`,
+				)
+				try {
+					const next = await hook({ ...context, definitions })
+					if (Array.isArray(next)) {
+						debug(
+							'hook',
+							`onSchemaLoaded ← ${item.plugin.manifest.name} returned ${next.length} definitions`,
+						)
+						definitions = canonicalizeDefinitions(next)
+					}
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onSchemaLoaded',
+						error,
+					)
+				}
+			}
+			return definitions
+		},
+		async runOnPlanCreated(context, initialPlan) {
+			const tableScope = context.tableScope ?? UNFILTERED_TABLE_SCOPE
+			let plan = initialPlan
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onPlanCreated
+				if (!hook) continue
+				debug(
+					'hook',
+					`onPlanCreated → ${item.plugin.manifest.name} (${plan.operations.length} operations)`,
+				)
+				try {
+					const next = await hook({ ...context, tableScope, plan })
+					if (next) {
+						debug(
+							'hook',
+							`onPlanCreated ← ${item.plugin.manifest.name} modified plan (${next.operations.length} operations)`,
+						)
+						plan = next
+					}
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onPlanCreated',
+						error,
+					)
+				}
+			}
+			return plan
+		},
+		async runOnBeforeApply(context) {
+			let statements = context.statements
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onBeforeApply
+				if (!hook) continue
+				debug(
+					'hook',
+					`onBeforeApply → ${item.plugin.manifest.name} (${context.migration}, ${statements.length} statements)`,
+				)
+				try {
+					const result = await hook({ ...context, statements })
+					if (result?.statements) {
+						debug(
+							'hook',
+							`onBeforeApply ← ${item.plugin.manifest.name} modified statements (${result.statements.length})`,
+						)
+						statements = result.statements
+					}
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onBeforeApply',
+						error,
+					)
+				}
+			}
+			return statements
+		},
+		async runOnAfterApply(context) {
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onAfterApply
+				if (!hook) continue
+				debug(
+					'hook',
+					`onAfterApply → ${item.plugin.manifest.name} (${context.migration})`,
+				)
+				try {
+					await hook(context)
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onAfterApply',
+						error,
+					)
+				}
+			}
+		},
+		async runOnCheck(context) {
+			const tableScope = context.tableScope ?? UNFILTERED_TABLE_SCOPE
+			const results: ChxOnCheckResult[] = []
+			for (const item of loaded) {
+				const hook = item.plugin.hooks?.onCheck
+				if (!hook) continue
+				debug('hook', `onCheck → ${item.plugin.manifest.name}`)
+				try {
+					const result = await hook({
+						...context,
+						options: item.options,
+						tableScope,
+					})
+					if (!result) continue
+					debug(
+						'hook',
+						`onCheck ← ${item.plugin.manifest.name}: ok=${result.ok}, findings=${result.findings.length}`,
+					)
+					results.push({
+						plugin: result.plugin || item.plugin.manifest.name,
+						evaluated: result.evaluated,
+						ok: result.ok,
+						findings: result.findings,
+						metadata: result.metadata,
+					})
+				} catch (error) {
+					throw formatPluginError(item.plugin.manifest.name, 'onCheck', error)
+				}
+			}
+			return results
+		},
+		async runOnCheckReport(results, print) {
+			for (const result of results) {
+				const item = byName.get(result.plugin)
+				if (!item) continue
+				const hook = item.plugin.hooks?.onCheckReport
+				if (!hook) continue
+				try {
+					await hook({ result, print })
+				} catch (error) {
+					throw formatPluginError(
+						item.plugin.manifest.name,
+						'onCheckReport',
+						error,
+					)
+				}
+			}
+		},
+		runOnBeforePluginCommand: runBeforePluginCommandHooks,
+		async runPluginCommand(pluginName, commandName, context) {
+			debug('command', `running plugin command "${pluginName}:${commandName}"`)
+			const item = byName.get(pluginName)
+			if (!item) return 1
+			const command = (item.plugin.commands ?? []).find(
+				(entry) => entry.name === commandName,
+			)
+			if (!command) return 1
 
-      // Run onBeforePluginCommand hooks — if any returns handled, skip the command
-      const beforeResult = await runBeforePluginCommandHooks(pluginName, commandName, {
-        config: context.config,
-        configPath: context.configPath,
-        jsonMode: context.jsonMode,
-        args: context.args,
-        flags: context.flags,
-        tableScope: context.tableScope ?? UNFILTERED_TABLE_SCOPE,
-        print: context.print,
-      })
-      if (beforeResult.handled) return beforeResult.exitCode
+			// Run onBeforePluginCommand hooks — if any returns handled, skip the command
+			const beforeResult = await runBeforePluginCommandHooks(
+				pluginName,
+				commandName,
+				{
+					config: context.config,
+					configPath: context.configPath,
+					jsonMode: context.jsonMode,
+					args: context.args,
+					flags: context.flags,
+					tableScope: context.tableScope ?? UNFILTERED_TABLE_SCOPE,
+					print: context.print,
+				},
+			)
+			if (beforeResult.handled) return beforeResult.exitCode
 
-      try {
-        const code = await command.run({
-          ...context,
-          pluginName,
-          options: item.options,
-          tableScope: context.tableScope ?? UNFILTERED_TABLE_SCOPE,
-        })
-        return typeof code === 'number' ? code : 0
-      } catch (error) {
-        throw formatPluginError(item.plugin.manifest.name, `command:${commandName}`, error)
-      }
-    },
-  }
+			try {
+				const code = await command.run({
+					...context,
+					pluginName,
+					options: item.options,
+					tableScope: context.tableScope ?? UNFILTERED_TABLE_SCOPE,
+				})
+				return typeof code === 'number' ? code : 0
+			} catch (error) {
+				throw formatPluginError(
+					item.plugin.manifest.name,
+					`command:${commandName}`,
+					error,
+				)
+			}
+		},
+	}
 }

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -108,6 +108,7 @@ export interface ChxOnInitContext {
   configPath: string
   isInteractive: boolean
   jsonMode: boolean
+  flags: ParsedFlags
   options: Record<string, unknown>
 }
 

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -46,6 +46,7 @@ export interface CommandDef {
 export interface CommandRunContext {
   command: string
   flags: ParsedFlags
+  positionals: string[]
   config: ResolvedChxConfig
   configPath: string
   dirs: { outDir: string; migrationsDir: string; metaDir: string }

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -1,384 +1,435 @@
 import { createRequire } from 'node:module'
-import { createClient, type ClickHouseSettings } from '@clickhouse/client'
 import {
-  normalizeSQLFragment,
-  parseCodec,
-  type ChxConfig,
-  type ColumnDefinition,
-  type ProjectionDefinition,
-  type SkipIndexDefinition,
+	type ChxConfig,
+	type ColumnDefinition,
+	normalizeSQLFragment,
+	type ProjectionDefinition,
+	parseCodec,
+	type SkipIndexDefinition,
 } from '@chkit/core'
+import { type ClickHouseSettings, createClient } from '@clickhouse/client'
 import { getLogger } from '@logtape/logtape'
 import {
-  parseEngineFromCreateTableQuery,
-  parseOrderByFromCreateTableQuery,
-  parsePartitionByFromCreateTableQuery,
-  parsePrimaryKeyFromCreateTableQuery,
-  parseProjectionsFromCreateTableQuery,
-  parseSettingsFromCreateTableQuery,
-  parseTTLFromCreateTableQuery,
-  parseUniqueKeyFromCreateTableQuery,
+	parseEngineFromCreateTableQuery,
+	parseOrderByFromCreateTableQuery,
+	parsePartitionByFromCreateTableQuery,
+	parsePrimaryKeyFromCreateTableQuery,
+	parseProjectionsFromCreateTableQuery,
+	parseSettingsFromCreateTableQuery,
+	parseTTLFromCreateTableQuery,
+	parseUniqueKeyFromCreateTableQuery,
 } from './create-table-parser.js'
 
-const pkg = createRequire(import.meta.url)('../package.json') as { version: string }
+const pkg = createRequire(import.meta.url)('../package.json') as {
+	version: string
+}
 const CHKIT_APPLICATION_ID = `chkit/${pkg.version}`
 
 export interface QueryStatus {
-  status: 'running' | 'finished' | 'failed' | 'unknown'
-  readRows?: number
-  readBytes?: number
-  writtenRows?: number
-  writtenBytes?: number
-  elapsedMs?: number
-  durationMs?: number
-  error?: string
+	status: 'running' | 'finished' | 'failed' | 'unknown'
+	readRows?: number
+	readBytes?: number
+	writtenRows?: number
+	writtenBytes?: number
+	elapsedMs?: number
+	durationMs?: number
+	error?: string
 }
 
 export type { ClickHouseSettings }
 
 export interface ClickHouseInsertParams<T extends Record<string, unknown>> {
-  table: string
-  values: T[]
-  compressed?: boolean
+	table: string
+	values: T[]
+	compressed?: boolean
+}
+
+export interface ClickHouseJsonQueryResult<
+	T extends Record<string, unknown> = Record<string, unknown>,
+> {
+	data: T[]
+	meta: Array<{ name: string; type: string }>
+	rows: number
+	statistics?: {
+		elapsed?: number
+		rows_read?: number
+		bytes_read?: number
+	}
+	query_id?: string
 }
 
 export interface ClickHouseExecutor {
-  command(sql: string): Promise<void>
-  query<T>(sql: string, settings?: ClickHouseSettings): Promise<T[]>
-  insert<T extends Record<string, unknown>>(params: ClickHouseInsertParams<T>): Promise<void>
-  listSchemaObjects(): Promise<SchemaObjectRef[]>
-  listTableDetails(databases: string[]): Promise<IntrospectedTable[]>
+	command(sql: string): Promise<void>
+	query<T>(sql: string, settings?: ClickHouseSettings): Promise<T[]>
+	queryJson?<T extends Record<string, unknown>>(
+		sql: string,
+		settings?: ClickHouseSettings,
+	): Promise<ClickHouseJsonQueryResult<T>>
+	insert<T extends Record<string, unknown>>(
+		params: ClickHouseInsertParams<T>,
+	): Promise<void>
+	listSchemaObjects(): Promise<SchemaObjectRef[]>
+	listTableDetails(databases: string[]): Promise<IntrospectedTable[]>
 
-  /** Submit a query asynchronously. ClickHouse accepts the query and processes it server-side.
-   *  Returns immediately without waiting for completion.
-   *  @param sql - The SQL to execute
-   *  @param queryId - Optional deterministic query_id (useful for resumability). Auto-generated if omitted.
-   *  @returns The query_id assigned to this query. */
-  submit(sql: string, queryId?: string): Promise<string>
+	/** Submit a query asynchronously. ClickHouse accepts the query and processes it server-side.
+	 *  Returns immediately without waiting for completion.
+	 *  @param sql - The SQL to execute
+	 *  @param queryId - Optional deterministic query_id (useful for resumability). Auto-generated if omitted.
+	 *  @returns The query_id assigned to this query. */
+	submit(sql: string, queryId?: string): Promise<string>
 
-  /** Check the status of a previously submitted query.
-   *  Checks system.processes first (running?), then system.query_log (finished/failed?).
-   *  @param queryId - The query_id returned by submit()
-   *  @param options.afterTime - Only consider query_log entries for queries started at or after this ISO timestamp.
-   *    Useful when resubmitting with the same query_id to ignore stale entries from previous attempts. */
-  queryStatus(queryId: string, options?: { afterTime?: string }): Promise<QueryStatus>
+	/** Check the status of a previously submitted query.
+	 *  Checks system.processes first (running?), then system.query_log (finished/failed?).
+	 *  @param queryId - The query_id returned by submit()
+	 *  @param options.afterTime - Only consider query_log entries for queries started at or after this ISO timestamp.
+	 *    Useful when resubmitting with the same query_id to ignore stale entries from previous attempts. */
+	queryStatus(
+		queryId: string,
+		options?: { afterTime?: string },
+	): Promise<QueryStatus>
 
-  close(): Promise<void>
+	close(): Promise<void>
 }
 
 export interface SchemaObjectRef {
-  kind: 'table' | 'view' | 'materialized_view'
-  database: string
-  name: string
+	kind: 'table' | 'view' | 'materialized_view'
+	database: string
+	name: string
 }
 
 export interface SystemTableRow {
-  database: string
-  name: string
-  engine: string
-  create_table_query?: string
+	database: string
+	name: string
+	engine: string
+	create_table_query?: string
 }
 
 export interface SystemColumnRow {
-  database: string
-  table: string
-  name: string
-  type: string
-  default_kind?: string
-  default_expression?: string
-  comment?: string
-  position: number
-  compression_codec?: string
+	database: string
+	table: string
+	name: string
+	type: string
+	default_kind?: string
+	default_expression?: string
+	comment?: string
+	position: number
+	compression_codec?: string
 }
 
 export interface SystemSkippingIndexRow {
-  database: string
-  table: string
-  name: string
-  expr: string
-  type: string
-  granularity: number
+	database: string
+	table: string
+	name: string
+	expr: string
+	type: string
+	granularity: number
 }
 
 export interface IntrospectedTable {
-  database: string
-  name: string
-  engine?: string
-  primaryKey?: string
-  orderBy?: string
-  uniqueKey?: string
-  partitionBy?: string
-  columns: ColumnDefinition[]
-  settings: Record<string, string>
-  indexes: SkipIndexDefinition[]
-  projections: ProjectionDefinition[]
-  ttl?: string
+	database: string
+	name: string
+	engine?: string
+	primaryKey?: string
+	orderBy?: string
+	uniqueKey?: string
+	partitionBy?: string
+	columns: ColumnDefinition[]
+	settings: Record<string, string>
+	indexes: SkipIndexDefinition[]
+	projections: ProjectionDefinition[]
+	ttl?: string
 }
 
 type ClickHouseClient = ReturnType<typeof createClient>
 type ClickHouseConfig = NonNullable<ChxConfig['clickhouse']>
 type ClickHouseClientOptions = {
-  compression?: {
-    request?: boolean
-    response?: boolean
-  }
+	compression?: {
+		request?: boolean
+		response?: boolean
+	}
 }
 
 export {
-  parseEngineFromCreateTableQuery,
-  parseOrderByFromCreateTableQuery,
-  parsePartitionByFromCreateTableQuery,
-  parsePrimaryKeyFromCreateTableQuery,
-  parseProjectionsFromCreateTableQuery,
-  parseSettingsFromCreateTableQuery,
-  parseTTLFromCreateTableQuery,
-  parseUniqueKeyFromCreateTableQuery,
+	parseEngineFromCreateTableQuery,
+	parseOrderByFromCreateTableQuery,
+	parsePartitionByFromCreateTableQuery,
+	parsePrimaryKeyFromCreateTableQuery,
+	parseProjectionsFromCreateTableQuery,
+	parseSettingsFromCreateTableQuery,
+	parseTTLFromCreateTableQuery,
+	parseUniqueKeyFromCreateTableQuery,
 } from './create-table-parser.js'
 
-export function inferSchemaKindFromEngine(engine: string): SchemaObjectRef['kind'] | null {
-  if (engine === 'View') return 'view'
-  if (engine === 'MaterializedView') return 'materialized_view'
-  if (!engine || engine === 'Dictionary') return null
-  return 'table'
+export function inferSchemaKindFromEngine(
+	engine: string,
+): SchemaObjectRef['kind'] | null {
+	if (engine === 'View') return 'view'
+	if (engine === 'MaterializedView') return 'materialized_view'
+	if (!engine || engine === 'Dictionary') return null
+	return 'table'
 }
 
-
-export function normalizeColumnFromSystemRow(row: SystemColumnRow): ColumnDefinition {
-  const nullableMatch = row.type.match(/^Nullable\((.+)\)$/)
-  const type = nullableMatch?.[1] ? nullableMatch[1] : row.type
-  const nullable = Boolean(nullableMatch?.[1])
-  let defaultValue: ColumnDefinition['default'] | undefined
-  if (row.default_expression && row.default_kind === 'DEFAULT') {
-    defaultValue = normalizeSQLFragment(row.default_expression)
-  }
-  const codecSteps = parseCodec(row.compression_codec)
-  return {
-    name: row.name,
-    type,
-    nullable: nullable || undefined,
-    default: defaultValue,
-    comment: row.comment?.trim() || undefined,
-    codec: codecSteps,
-  }
+export function normalizeColumnFromSystemRow(
+	row: SystemColumnRow,
+): ColumnDefinition {
+	const nullableMatch = row.type.match(/^Nullable\((.+)\)$/)
+	const type = nullableMatch?.[1] ? nullableMatch[1] : row.type
+	const nullable = Boolean(nullableMatch?.[1])
+	let defaultValue: ColumnDefinition['default'] | undefined
+	if (row.default_expression && row.default_kind === 'DEFAULT') {
+		defaultValue = normalizeSQLFragment(row.default_expression)
+	}
+	const codecSteps = parseCodec(row.compression_codec)
+	return {
+		name: row.name,
+		type,
+		nullable: nullable || undefined,
+		default: defaultValue,
+		comment: row.comment?.trim() || undefined,
+		codec: codecSteps,
+	}
 }
 
 type ParsedIndexShape =
-  | { type: 'minmax' }
-  | { type: 'set'; maxRows: number }
-  | { type: 'bloom_filter'; falsePositiveRate?: number }
-  | { type: 'tokenbf_v1'; sizeBytes: number; hashFunctions: number; randomSeed: number }
-  | {
-      type: 'ngrambf_v1'
-      ngramSize: number
-      sizeBytes: number
-      hashFunctions: number
-      randomSeed: number
-    }
+	| { type: 'minmax' }
+	| { type: 'set'; maxRows: number }
+	| { type: 'bloom_filter'; falsePositiveRate?: number }
+	| {
+			type: 'tokenbf_v1'
+			sizeBytes: number
+			hashFunctions: number
+			randomSeed: number
+	  }
+	| {
+			type: 'ngrambf_v1'
+			ngramSize: number
+			sizeBytes: number
+			hashFunctions: number
+			randomSeed: number
+	  }
 
 function splitArgs(args: string | undefined): number[] {
-  if (args === undefined) return []
-  return args
-    .split(',')
-    .map((part) => Number(part.trim()))
-    .filter((value) => !Number.isNaN(value))
+	if (args === undefined) return []
+	return args
+		.split(',')
+		.map((part) => Number(part.trim()))
+		.filter((value) => !Number.isNaN(value))
 }
 
 function parseIndexType(value: string): ParsedIndexShape {
-  const match = value.match(/^(\w+)\((.+)\)$/)
-  const baseName = match?.[1] ?? value
-  const args = splitArgs(match?.[2])
+	const match = value.match(/^(\w+)\((.+)\)$/)
+	const baseName = match?.[1] ?? value
+	const args = splitArgs(match?.[2])
 
-  switch (baseName) {
-    case 'minmax':
-      return { type: 'minmax' }
-    case 'bloom_filter':
-      return args.length > 0
-        ? { type: 'bloom_filter', falsePositiveRate: args[0]! }
-        : { type: 'bloom_filter' }
-    case 'tokenbf_v1':
-      return {
-        type: 'tokenbf_v1',
-        sizeBytes: args[0] ?? 0,
-        hashFunctions: args[1] ?? 0,
-        randomSeed: args[2] ?? 0,
-      }
-    case 'ngrambf_v1':
-      return {
-        type: 'ngrambf_v1',
-        ngramSize: args[0] ?? 0,
-        sizeBytes: args[1] ?? 0,
-        hashFunctions: args[2] ?? 0,
-        randomSeed: args[3] ?? 0,
-      }
-    default:
-      return { type: 'set', maxRows: args[0] ?? 0 }
-  }
+	switch (baseName) {
+		case 'minmax':
+			return { type: 'minmax' }
+		case 'bloom_filter':
+			return args.length > 0
+				? { type: 'bloom_filter', falsePositiveRate: args[0]! }
+				: { type: 'bloom_filter' }
+		case 'tokenbf_v1':
+			return {
+				type: 'tokenbf_v1',
+				sizeBytes: args[0] ?? 0,
+				hashFunctions: args[1] ?? 0,
+				randomSeed: args[2] ?? 0,
+			}
+		case 'ngrambf_v1':
+			return {
+				type: 'ngrambf_v1',
+				ngramSize: args[0] ?? 0,
+				sizeBytes: args[1] ?? 0,
+				hashFunctions: args[2] ?? 0,
+				randomSeed: args[3] ?? 0,
+			}
+		default:
+			return { type: 'set', maxRows: args[0] ?? 0 }
+	}
 }
 
-export function normalizeIndexFromSystemRow(row: SystemSkippingIndexRow): SkipIndexDefinition {
-  const parsed = parseIndexType(row.type)
-  return {
-    name: row.name,
-    expression: normalizeSQLFragment(row.expr),
-    granularity: row.granularity,
-    ...parsed,
-  }
+export function normalizeIndexFromSystemRow(
+	row: SystemSkippingIndexRow,
+): SkipIndexDefinition {
+	const parsed = parseIndexType(row.type)
+	return {
+		name: row.name,
+		expression: normalizeSQLFragment(row.expr),
+		granularity: row.granularity,
+		...parsed,
+	}
 }
 
 export function buildIntrospectedTables(
-  tables: SystemTableRow[],
-  columns: SystemColumnRow[],
-  indexes: SystemSkippingIndexRow[],
+	tables: SystemTableRow[],
+	columns: SystemColumnRow[],
+	indexes: SystemSkippingIndexRow[],
 ): IntrospectedTable[] {
-  const tableRows = tables.filter((row) => inferSchemaKindFromEngine(row.engine) === 'table')
-  if (tableRows.length === 0) return []
+	const tableRows = tables.filter(
+		(row) => inferSchemaKindFromEngine(row.engine) === 'table',
+	)
+	if (tableRows.length === 0) return []
 
-  const columnsByTable = new Map<string, SystemColumnRow[]>()
-  for (const row of columns) {
-    const key = `${row.database}.${row.table}`
-    const rows = columnsByTable.get(key)
-    if (rows) rows.push(row)
-    else columnsByTable.set(key, [row])
-  }
+	const columnsByTable = new Map<string, SystemColumnRow[]>()
+	for (const row of columns) {
+		const key = `${row.database}.${row.table}`
+		const rows = columnsByTable.get(key)
+		if (rows) rows.push(row)
+		else columnsByTable.set(key, [row])
+	}
 
-  const indexesByTable = new Map<string, SystemSkippingIndexRow[]>()
-  for (const row of indexes) {
-    const key = `${row.database}.${row.table}`
-    const rows = indexesByTable.get(key)
-    if (rows) rows.push(row)
-    else indexesByTable.set(key, [row])
-  }
+	const indexesByTable = new Map<string, SystemSkippingIndexRow[]>()
+	for (const row of indexes) {
+		const key = `${row.database}.${row.table}`
+		const rows = indexesByTable.get(key)
+		if (rows) rows.push(row)
+		else indexesByTable.set(key, [row])
+	}
 
-  return tableRows
-    .map((row) => {
-      const key = `${row.database}.${row.name}`
-      const columnRows = (columnsByTable.get(key) ?? []).sort((a, b) => a.position - b.position)
-      const indexRows = indexesByTable.get(key) ?? []
-      return {
-        database: row.database,
-        name: row.name,
-        engine: parseEngineFromCreateTableQuery(row.create_table_query),
-        primaryKey: parsePrimaryKeyFromCreateTableQuery(row.create_table_query),
-        orderBy: parseOrderByFromCreateTableQuery(row.create_table_query),
-        uniqueKey: parseUniqueKeyFromCreateTableQuery(row.create_table_query),
-        partitionBy: parsePartitionByFromCreateTableQuery(row.create_table_query),
-        columns: columnRows.map(normalizeColumnFromSystemRow),
-        settings: parseSettingsFromCreateTableQuery(row.create_table_query),
-        indexes: indexRows.map(normalizeIndexFromSystemRow),
-        projections: parseProjectionsFromCreateTableQuery(row.create_table_query),
-        ttl: parseTTLFromCreateTableQuery(row.create_table_query),
-      }
-    })
-    .sort((a, b) => {
-      const dbOrder = a.database.localeCompare(b.database)
-      if (dbOrder !== 0) return dbOrder
-      return a.name.localeCompare(b.name)
-    })
+	return tableRows
+		.map((row) => {
+			const key = `${row.database}.${row.name}`
+			const columnRows = (columnsByTable.get(key) ?? []).sort(
+				(a, b) => a.position - b.position,
+			)
+			const indexRows = indexesByTable.get(key) ?? []
+			return {
+				database: row.database,
+				name: row.name,
+				engine: parseEngineFromCreateTableQuery(row.create_table_query),
+				primaryKey: parsePrimaryKeyFromCreateTableQuery(row.create_table_query),
+				orderBy: parseOrderByFromCreateTableQuery(row.create_table_query),
+				uniqueKey: parseUniqueKeyFromCreateTableQuery(row.create_table_query),
+				partitionBy: parsePartitionByFromCreateTableQuery(
+					row.create_table_query,
+				),
+				columns: columnRows.map(normalizeColumnFromSystemRow),
+				settings: parseSettingsFromCreateTableQuery(row.create_table_query),
+				indexes: indexRows.map(normalizeIndexFromSystemRow),
+				projections: parseProjectionsFromCreateTableQuery(
+					row.create_table_query,
+				),
+				ttl: parseTTLFromCreateTableQuery(row.create_table_query),
+			}
+		})
+		.sort((a, b) => {
+			const dbOrder = a.database.localeCompare(b.database)
+			if (dbOrder !== 0) return dbOrder
+			return a.name.localeCompare(b.name)
+		})
 }
 
 const NETWORK_ERROR_LABELS: Record<string, string> = {
-  ECONNREFUSED: 'connection refused',
-  ENOTFOUND: 'host not found',
-  ETIMEDOUT: 'connection timed out',
-  ECONNRESET: 'connection reset',
-  EHOSTUNREACH: 'host unreachable',
+	ECONNREFUSED: 'connection refused',
+	ENOTFOUND: 'host not found',
+	ETIMEDOUT: 'connection timed out',
+	ECONNRESET: 'connection reset',
+	EHOSTUNREACH: 'host unreachable',
 }
 
 function wrapConnectionError(error: unknown, url: string): never {
-  if (error instanceof Error && 'code' in error) {
-    const code = (error as NodeJS.ErrnoException).code ?? ''
-    const label = NETWORK_ERROR_LABELS[code]
-    if (label) {
-      const isLocalhostDefault = /^https?:\/\/(localhost|127\.0\.0\.1):8123\/?$/.test(url)
-      const envUnset = !process.env.CLICKHOUSE_URL
-      const hint = isLocalhostDefault && envUnset
-        ? '\n  Hint: CLICKHOUSE_URL is not set — chkit fell back to the default localhost endpoint. Set CLICKHOUSE_URL to point at your ClickHouse instance.'
-        : ''
-      throw new Error(`Could not connect to ClickHouse at ${url} (${label})${hint}`)
-    }
-  }
-  throw error
+	if (error instanceof Error && 'code' in error) {
+		const code = (error as NodeJS.ErrnoException).code ?? ''
+		const label = NETWORK_ERROR_LABELS[code]
+		if (label) {
+			const isLocalhostDefault =
+				/^https?:\/\/(localhost|127\.0\.0\.1):8123\/?$/.test(url)
+			const envUnset = !process.env.CLICKHOUSE_URL
+			const hint =
+				isLocalhostDefault && envUnset
+					? '\n  Hint: CLICKHOUSE_URL is not set — chkit fell back to the default localhost endpoint. Set CLICKHOUSE_URL to point at your ClickHouse instance.'
+					: ''
+			throw new Error(
+				`Could not connect to ClickHouse at ${url} (${label})${hint}`,
+			)
+		}
+	}
+	throw error
 }
 
 export function isUnknownDatabaseError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  if (!('code' in error)) return false
-  return String(error.code) === '81'
+	if (!(error instanceof Error)) return false
+	if (!('code' in error)) return false
+	return String(error.code) === '81'
 }
 
 export {
-  waitForDDLPropagation,
-  waitForTable,
-  waitForView,
-  waitForColumn,
-  waitForTableAbsent,
+	waitForColumn,
+	waitForDDLPropagation,
+	waitForTable,
+	waitForTableAbsent,
+	waitForView,
 } from './ddl-propagation.js'
 
-function parseSummaryFromHeaders(headers: Record<string, string | string[] | undefined>): {
-  read_rows: string
-  read_bytes: string
-  written_rows: string
-  written_bytes: string
-  result_rows: string
-  result_bytes: string
-  elapsed_ns: string
-} | undefined {
-  const raw = headers['x-clickhouse-summary']
-  if (!raw || typeof raw !== 'string') return undefined
-  try {
-    return JSON.parse(raw)
-  } catch {
-    return undefined
-  }
+function parseSummaryFromHeaders(
+	headers: Record<string, string | string[] | undefined>,
+):
+	| {
+			read_rows: string
+			read_bytes: string
+			written_rows: string
+			written_bytes: string
+			result_rows: string
+			result_bytes: string
+			elapsed_ns: string
+	  }
+	| undefined {
+	const raw = headers['x-clickhouse-summary']
+	if (!raw || typeof raw !== 'string') return undefined
+	try {
+		return JSON.parse(raw)
+	} catch {
+		return undefined
+	}
 }
 
 function logProfiling(
-  logger: ReturnType<typeof getLogger>,
-  query: string,
-  queryId: string,
-  summary?: {
-    read_rows: string
-    read_bytes: string
-    written_rows: string
-    written_bytes: string
-    result_rows?: string
-    result_bytes?: string
-    elapsed_ns: string
-  },
+	logger: ReturnType<typeof getLogger>,
+	query: string,
+	queryId: string,
+	summary?: {
+		read_rows: string
+		read_bytes: string
+		written_rows: string
+		written_bytes: string
+		result_rows?: string
+		result_bytes?: string
+		elapsed_ns: string
+	},
 ): void {
-  logger.trace('Query completed: {query}', {
-    query,
-    queryId,
-    readRows: Number(summary?.read_rows ?? 0),
-    readBytes: Number(summary?.read_bytes ?? 0),
-    writtenRows: Number(summary?.written_rows ?? 0),
-    writtenBytes: Number(summary?.written_bytes ?? 0),
-    elapsedMs: Number(summary?.elapsed_ns ?? 0) / 1_000_000,
-    resultRows: Number(summary?.result_rows ?? 0),
-    resultBytes: Number(summary?.result_bytes ?? 0),
-  })
+	logger.trace('Query completed: {query}', {
+		query,
+		queryId,
+		readRows: Number(summary?.read_rows ?? 0),
+		readBytes: Number(summary?.read_bytes ?? 0),
+		writtenRows: Number(summary?.written_rows ?? 0),
+		writtenBytes: Number(summary?.written_bytes ?? 0),
+		elapsedMs: Number(summary?.elapsed_ns ?? 0) / 1_000_000,
+		resultRows: Number(summary?.result_rows ?? 0),
+		resultBytes: Number(summary?.result_bytes ?? 0),
+	})
 }
 
 const DEFAULT_CLICKHOUSE_SETTINGS: ClickHouseSettings = {
-  wait_end_of_query: 1,
-  async_insert: 0,
-  send_progress_in_http_headers: 1,
+	wait_end_of_query: 1,
+	async_insert: 0,
+	send_progress_in_http_headers: 1,
 }
 
 export function createStatelessClickHouseClient(
-  config: ClickHouseConfig,
-  clickhouseSettings: ClickHouseSettings = DEFAULT_CLICKHOUSE_SETTINGS,
-  options: ClickHouseClientOptions = {},
+	config: ClickHouseConfig,
+	clickhouseSettings: ClickHouseSettings = DEFAULT_CLICKHOUSE_SETTINGS,
+	options: ClickHouseClientOptions = {},
 ): ClickHouseClient {
-  return createClient({
-    url: config.url,
-    username: config.username,
-    password: config.password,
-    database: config.database,
-    application: CHKIT_APPLICATION_ID,
-    clickhouse_settings: clickhouseSettings,
-    ...(options.compression ? { compression: options.compression } : {}),
-  })
+	return createClient({
+		url: config.url,
+		username: config.username,
+		password: config.password,
+		database: config.database,
+		application: CHKIT_APPLICATION_ID,
+		clickhouse_settings: clickhouseSettings,
+		...(options.compression ? { compression: options.compression } : {}),
+	})
 }
 
 /**
@@ -388,128 +439,184 @@ export function createStatelessClickHouseClient(
  * session, so callers must serialize all requests made through this client.
  */
 export function createSessionClickHouseClient(
-  config: ClickHouseConfig,
-  clickhouseSettings: ClickHouseSettings = DEFAULT_CLICKHOUSE_SETTINGS,
-  sessionId = crypto.randomUUID(),
-  options: ClickHouseClientOptions = {},
+	config: ClickHouseConfig,
+	clickhouseSettings: ClickHouseSettings = DEFAULT_CLICKHOUSE_SETTINGS,
+	sessionId = crypto.randomUUID(),
+	options: ClickHouseClientOptions = {},
 ): ClickHouseClient {
-  return createClient({
-    url: config.url,
-    username: config.username,
-    password: config.password,
-    database: config.database,
-    session_id: sessionId,
-    application: CHKIT_APPLICATION_ID,
-    clickhouse_settings: clickhouseSettings,
-    ...(options.compression ? { compression: options.compression } : {}),
-  })
+	return createClient({
+		url: config.url,
+		username: config.username,
+		password: config.password,
+		database: config.database,
+		session_id: sessionId,
+		application: CHKIT_APPLICATION_ID,
+		clickhouse_settings: clickhouseSettings,
+		...(options.compression ? { compression: options.compression } : {}),
+	})
 }
 
 export function createExecutorWithClient(
-  config: ClickHouseConfig,
-  client: ClickHouseClient,
-  options: { createCompressedClient?: () => ClickHouseClient } = {},
+	config: ClickHouseConfig,
+	client: ClickHouseClient,
+	options: { createCompressedClient?: () => ClickHouseClient } = {},
 ): ClickHouseExecutor {
-  const profiler = getLogger(['chkit', 'profiling'])
+	const profiler = getLogger(['chkit', 'profiling'])
 
-  const fireAndForgetClient = createStatelessClickHouseClient(config, { wait_end_of_query: 0 })
-  let compressedClient: ClickHouseClient | undefined
+	const fireAndForgetClient = createStatelessClickHouseClient(config, {
+		wait_end_of_query: 0,
+	})
+	let compressedClient: ClickHouseClient | undefined
 
-  return {
-    async command(sql: string): Promise<void> {
-      try {
-        const result = await client.command({ query: sql, http_headers: { 'X-DDL': '1' } })
-        logProfiling(profiler, sql, result.query_id, result.summary)
-      } catch (error) {
-        if (isUnknownDatabaseError(error)) {
-          const fallback = createClient({
-            url: config.url,
-            username: config.username,
-            password: config.password,
-            application: CHKIT_APPLICATION_ID,
-            clickhouse_settings: { wait_end_of_query: 1, async_insert: 0 },
-          })
-          try {
-            await fallback.command({ query: sql, http_headers: { 'X-DDL': '1' } })
-          } finally {
-            await fallback.close()
-          }
-          return
-        }
-        wrapConnectionError(error, config.url)
-      }
-    },
-    async query<T>(sql: string, settings?: ClickHouseSettings): Promise<T[]> {
-      try {
-        const result = await client.query({ query: sql, format: 'JSONEachRow', http_headers: { 'X-DDL': '1' }, ...(settings ? { clickhouse_settings: settings } : {}) })
-        const rows = await result.json<T>()
-        logProfiling(profiler, sql, result.query_id, parseSummaryFromHeaders(result.response_headers))
-        return rows
-      } catch (error) {
-        wrapConnectionError(error, config.url)
-      }
-    },
-    async insert<T extends Record<string, unknown>>(params: ClickHouseInsertParams<T>): Promise<void> {
-      try {
-        let insertClient = client
-        if (params.compressed === true) {
-          if (!compressedClient) {
-            compressedClient = options.createCompressedClient?.() ?? createStatelessClickHouseClient(
-              config,
-              DEFAULT_CLICKHOUSE_SETTINGS,
-              { compression: { request: true } },
-            )
-          }
-          insertClient = compressedClient
-        }
-        const result = await insertClient.insert({
-          table: params.table,
-          values: params.values,
-          format: 'JSONEachRow',
-        })
-        logProfiling(profiler, `INSERT INTO ${params.table}`, result.query_id, result.summary)
-      } catch (error) {
-        wrapConnectionError(error, config.url)
-      }
-    },
-    async submit(sql: string, queryId?: string): Promise<string> {
-      const id = queryId ?? crypto.randomUUID()
-      try {
-        await fireAndForgetClient.command({ query: sql, query_id: id })
-      } catch (error) {
-        wrapConnectionError(error, config.url)
-      }
-      return id
-    },
-    async queryStatus(queryId: string, options?: { afterTime?: string }): Promise<QueryStatus> {
-      try {
-        const running = await client.query({
-          query: `SELECT read_rows, read_bytes, written_rows, written_bytes, elapsed FROM clusterAllReplicas('cluster', system.processes) WHERE user = currentUser() AND query_id = {qid:String} SETTINGS skip_unavailable_shards = 1`,
-          query_params: { qid: queryId },
-          format: 'JSONEachRow',
-        })
-        const runningRows = await running.json<{
-          read_rows: string
-          read_bytes: string
-          written_rows: string
-          written_bytes: string
-          elapsed: string
-        }>()
-        if (runningRows.length > 0) {
-          const proc = runningRows[0]!
-          return {
-            status: 'running',
-            readRows: Number(proc.read_rows),
-            readBytes: Number(proc.read_bytes),
-            writtenRows: Number(proc.written_rows),
-            writtenBytes: Number(proc.written_bytes),
-            elapsedMs: Math.round(Number(proc.elapsed) * 1000),
-          }
-        }
+	return {
+		async command(sql: string): Promise<void> {
+			try {
+				const result = await client.command({
+					query: sql,
+					http_headers: { 'X-DDL': '1' },
+				})
+				logProfiling(profiler, sql, result.query_id, result.summary)
+			} catch (error) {
+				if (isUnknownDatabaseError(error)) {
+					const fallback = createClient({
+						url: config.url,
+						username: config.username,
+						password: config.password,
+						application: CHKIT_APPLICATION_ID,
+						clickhouse_settings: { wait_end_of_query: 1, async_insert: 0 },
+					})
+					try {
+						await fallback.command({
+							query: sql,
+							http_headers: { 'X-DDL': '1' },
+						})
+					} finally {
+						await fallback.close()
+					}
+					return
+				}
+				wrapConnectionError(error, config.url)
+			}
+		},
+		async query<T>(sql: string, settings?: ClickHouseSettings): Promise<T[]> {
+			try {
+				const result = await client.query({
+					query: sql,
+					format: 'JSONEachRow',
+					http_headers: { 'X-DDL': '1' },
+					...(settings ? { clickhouse_settings: settings } : {}),
+				})
+				const rows = await result.json<T>()
+				logProfiling(
+					profiler,
+					sql,
+					result.query_id,
+					parseSummaryFromHeaders(result.response_headers),
+				)
+				return rows
+			} catch (error) {
+				wrapConnectionError(error, config.url)
+			}
+		},
+		async queryJson<T extends Record<string, unknown>>(
+			sql: string,
+			settings?: ClickHouseSettings,
+		): Promise<ClickHouseJsonQueryResult<T>> {
+			try {
+				const result = await client.query({
+					query: sql,
+					format: 'JSON',
+					http_headers: { 'X-DDL': '1' },
+					...(settings ? { clickhouse_settings: settings } : {}),
+				})
+        const payload = (await result.json<T>()) as ClickHouseJsonQueryResult<T>
+				logProfiling(
+					profiler,
+					sql,
+					result.query_id,
+					parseSummaryFromHeaders(result.response_headers),
+				)
+				return {
+					...payload,
+					query_id: result.query_id,
+				}
+			} catch (error) {
+				wrapConnectionError(error, config.url)
+			}
+		},
+		async insert<T extends Record<string, unknown>>(
+			params: ClickHouseInsertParams<T>,
+		): Promise<void> {
+			try {
+				let insertClient = client
+				if (params.compressed === true) {
+					if (!compressedClient) {
+						compressedClient =
+							options.createCompressedClient?.() ??
+							createStatelessClickHouseClient(
+								config,
+								DEFAULT_CLICKHOUSE_SETTINGS,
+								{ compression: { request: true } },
+							)
+					}
+					insertClient = compressedClient
+				}
+				const result = await insertClient.insert({
+					table: params.table,
+					values: params.values,
+					format: 'JSONEachRow',
+				})
+				logProfiling(
+					profiler,
+					`INSERT INTO ${params.table}`,
+					result.query_id,
+					result.summary,
+				)
+			} catch (error) {
+				wrapConnectionError(error, config.url)
+			}
+		},
+		async submit(sql: string, queryId?: string): Promise<string> {
+			const id = queryId ?? crypto.randomUUID()
+			try {
+				await fireAndForgetClient.command({ query: sql, query_id: id })
+			} catch (error) {
+				wrapConnectionError(error, config.url)
+			}
+			return id
+		},
+		async queryStatus(
+			queryId: string,
+			options?: { afterTime?: string },
+		): Promise<QueryStatus> {
+			try {
+				const running = await client.query({
+					query: `SELECT read_rows, read_bytes, written_rows, written_bytes, elapsed FROM clusterAllReplicas('cluster', system.processes) WHERE user = currentUser() AND query_id = {qid:String} SETTINGS skip_unavailable_shards = 1`,
+					query_params: { qid: queryId },
+					format: 'JSONEachRow',
+				})
+				const runningRows = await running.json<{
+					read_rows: string
+					read_bytes: string
+					written_rows: string
+					written_bytes: string
+					elapsed: string
+				}>()
+				if (runningRows.length > 0) {
+					const proc = runningRows[0]!
+					return {
+						status: 'running',
+						readRows: Number(proc.read_rows),
+						readBytes: Number(proc.read_bytes),
+						writtenRows: Number(proc.written_rows),
+						writtenBytes: Number(proc.written_bytes),
+						elapsedMs: Math.round(Number(proc.elapsed) * 1000),
+					}
+				}
 
-        const afterTime = options?.afterTime ?? '1970-01-01T00:00:00Z'
-        const log = await client.query({
-          query: `SELECT type, written_rows, written_bytes, query_duration_ms, exception
+				const afterTime = options?.afterTime ?? '1970-01-01T00:00:00Z'
+				const log = await client.query({
+					query: `SELECT type, written_rows, written_bytes, query_duration_ms, exception
 FROM clusterAllReplicas('cluster', system.query_log)
 WHERE user = currentUser()
   AND query_id = {qid:String}
@@ -519,118 +626,132 @@ WHERE user = currentUser()
 ORDER BY event_time DESC
 LIMIT 1
 SETTINGS skip_unavailable_shards = 1`,
-          query_params: { qid: queryId, after: afterTime },
-          format: 'JSONEachRow',
-        })
-        const logRows = await log.json<{
-          type: string
-          written_rows: string
-          written_bytes: string
-          query_duration_ms: string
-          exception: string
-        }>()
+					query_params: { qid: queryId, after: afterTime },
+					format: 'JSONEachRow',
+				})
+				const logRows = await log.json<{
+					type: string
+					written_rows: string
+					written_bytes: string
+					query_duration_ms: string
+					exception: string
+				}>()
 
-        if (logRows.length === 0) {
-          return { status: 'unknown' }
-        }
+				if (logRows.length === 0) {
+					return { status: 'unknown' }
+				}
 
-        const row = logRows[0]!
-        if (row.type === 'QueryFinish') {
-          return {
-            status: 'finished',
-            writtenRows: Number(row.written_rows),
-            writtenBytes: Number(row.written_bytes),
-            durationMs: Number(row.query_duration_ms),
-          }
-        }
+				const row = logRows[0]!
+				if (row.type === 'QueryFinish') {
+					return {
+						status: 'finished',
+						writtenRows: Number(row.written_rows),
+						writtenBytes: Number(row.written_bytes),
+						durationMs: Number(row.query_duration_ms),
+					}
+				}
 
-        return {
-          status: 'failed',
-          durationMs: Number(row.query_duration_ms),
-          error: row.exception,
-        }
-      } catch (error) {
-        wrapConnectionError(error, config.url)
-      }
-    },
-    async close(): Promise<void> {
-      await Promise.all([client.close(), fireAndForgetClient.close(), compressedClient?.close()])
-    },
-    async listSchemaObjects(): Promise<SchemaObjectRef[]> {
-      const rows = await this.query<SystemTableRow>(
-        `SELECT database, name, engine
+				return {
+					status: 'failed',
+					durationMs: Number(row.query_duration_ms),
+					error: row.exception,
+				}
+			} catch (error) {
+				wrapConnectionError(error, config.url)
+			}
+		},
+		async close(): Promise<void> {
+			await Promise.all([
+				client.close(),
+				fireAndForgetClient.close(),
+				compressedClient?.close(),
+			])
+		},
+		async listSchemaObjects(): Promise<SchemaObjectRef[]> {
+			const rows = await this.query<SystemTableRow>(
+				`SELECT database, name, engine
 FROM system.tables
 WHERE is_temporary = 0
   AND database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
-  AND name NOT LIKE '_chkit_%'`
-      )
+  AND name NOT LIKE '_chkit_%'`,
+			)
 
-      const out: SchemaObjectRef[] = []
-      for (const row of rows) {
-        const kind = inferSchemaKindFromEngine(row.engine)
-        if (!kind) continue
-        out.push({
-          kind,
-          database: row.database,
-          name: row.name,
-        })
-      }
-      return out
-    },
-    async listTableDetails(databases: string[]): Promise<IntrospectedTable[]> {
-      if (databases.length === 0) return []
+			const out: SchemaObjectRef[] = []
+			for (const row of rows) {
+				const kind = inferSchemaKindFromEngine(row.engine)
+				if (!kind) continue
+				out.push({
+					kind,
+					database: row.database,
+					name: row.name,
+				})
+			}
+			return out
+		},
+		async listTableDetails(databases: string[]): Promise<IntrospectedTable[]> {
+			if (databases.length === 0) return []
 
-      const quotedDatabases = databases.map((dbName) => `'${dbName.replace(/'/g, "''")}'`).join(', ')
-      const tables = await this.query<SystemTableRow>(
-        `SELECT database, name, engine, create_table_query
+			const quotedDatabases = databases
+				.map((dbName) => `'${dbName.replace(/'/g, "''")}'`)
+				.join(', ')
+			const tables = await this.query<SystemTableRow>(
+				`SELECT database, name, engine, create_table_query
 FROM system.tables
 WHERE is_temporary = 0
-  AND database IN (${quotedDatabases})`
-      )
-      const columns = await this.query<SystemColumnRow>(
-        `SELECT database, table, name, type, default_kind, default_expression, comment, position, compression_codec
+  AND database IN (${quotedDatabases})`,
+			)
+			const columns = await this.query<SystemColumnRow>(
+				`SELECT database, table, name, type, default_kind, default_expression, comment, position, compression_codec
 FROM system.columns
-WHERE database IN (${quotedDatabases})`
-      )
-      const indexes = await this.query<SystemSkippingIndexRow>(
-        `SELECT database, table, name, expr, type, granularity
+WHERE database IN (${quotedDatabases})`,
+			)
+			const indexes = await this.query<SystemSkippingIndexRow>(
+				`SELECT database, table, name, expr, type, granularity
 FROM system.data_skipping_indices
-WHERE database IN (${quotedDatabases})`
-      )
+WHERE database IN (${quotedDatabases})`,
+			)
 
-      return buildIntrospectedTables(tables, columns, indexes)
-    },
-  }
+			return buildIntrospectedTables(tables, columns, indexes)
+		},
+	}
 }
 
-export function createClickHouseExecutor(config: ClickHouseConfig): ClickHouseExecutor {
-  // Default executor is session-bound so DDL-heavy workflows run through a
-  // single ClickHouse HTTP session. Do not issue concurrent queries through it.
-  const sessionId = crypto.randomUUID()
-  return createExecutorWithClient(
-    config,
-    createSessionClickHouseClient(config, DEFAULT_CLICKHOUSE_SETTINGS, sessionId),
-    {
-      createCompressedClient: () => createSessionClickHouseClient(
-        config,
-        DEFAULT_CLICKHOUSE_SETTINGS,
-        sessionId,
-        { compression: { request: true } },
-      ),
-    },
-  )
+export function createClickHouseExecutor(
+	config: ClickHouseConfig,
+): ClickHouseExecutor {
+	// Default executor is session-bound so DDL-heavy workflows run through a
+	// single ClickHouse HTTP session. Do not issue concurrent queries through it.
+	const sessionId = crypto.randomUUID()
+	return createExecutorWithClient(
+		config,
+		createSessionClickHouseClient(
+			config,
+			DEFAULT_CLICKHOUSE_SETTINGS,
+			sessionId,
+		),
+		{
+			createCompressedClient: () =>
+				createSessionClickHouseClient(
+					config,
+					DEFAULT_CLICKHOUSE_SETTINGS,
+					sessionId,
+					{ compression: { request: true } },
+				),
+		},
+	)
 }
 
-export function createStatelessClickHouseExecutor(config: ClickHouseConfig): ClickHouseExecutor {
-  return createExecutorWithClient(
-    config,
-    createStatelessClickHouseClient(config),
-    {
-      createCompressedClient: () => createStatelessClickHouseClient(
-        config,
-        DEFAULT_CLICKHOUSE_SETTINGS,
-        { compression: { request: true } },
-      ),
-    },
-  )
+export function createStatelessClickHouseExecutor(
+	config: ClickHouseConfig,
+): ClickHouseExecutor {
+	return createExecutorWithClient(
+		config,
+		createStatelessClickHouseClient(config),
+		{
+			createCompressedClient: () =>
+				createStatelessClickHouseClient(config, DEFAULT_CLICKHOUSE_SETTINGS, {
+					compression: { request: true },
+				}),
+		},
+	)
 }

--- a/packages/plugin-obsessiondb/src/contract/workbench.ts
+++ b/packages/plugin-obsessiondb/src/contract/workbench.ts
@@ -6,31 +6,32 @@ import { oc } from '@orpc/contract'
 import { z } from 'zod'
 
 const queryResultSchema = z.object({
-  data: z.array(z.record(z.unknown())),
-  meta: z.array(z.object({ name: z.string(), type: z.string() })),
-  rows: z.number().int(),
-  statistics: z
-    .object({
-      bytes_read: z.number().int().optional(),
-      rows_read: z.number().int().optional(),
-      elapsed: z.number().optional(),
-    })
-    .optional(),
-  message: z.string().optional(),
-  error: z.string().optional(),
+	data: z.array(z.record(z.unknown())),
+	meta: z.array(z.object({ name: z.string(), type: z.string() })),
+	rows: z.number().int(),
+	statistics: z
+		.object({
+			bytes_read: z.number().int().optional(),
+			rows_read: z.number().int().optional(),
+			elapsed: z.number().optional(),
+		})
+		.optional(),
+	query_id: z.string().optional(),
+	message: z.string().optional(),
+	error: z.string().optional(),
 })
 
 export const workbenchContract = {
-  query: {
-    execute: oc
-      .input(
-        z.object({
-          serviceId: z.string(),
-          query: z.string().min(1),
-          settings: z.record(z.union([z.string(), z.number()])).optional(),
-          database: z.string().optional(),
-        }),
-      )
-      .output(queryResultSchema),
-  },
+	query: {
+		execute: oc
+			.input(
+				z.object({
+					serviceId: z.string(),
+					query: z.string().min(1),
+					settings: z.record(z.union([z.string(), z.number()])).optional(),
+					database: z.string().optional(),
+				}),
+			)
+			.output(queryResultSchema),
+	},
 }

--- a/packages/plugin-obsessiondb/src/index.test.ts
+++ b/packages/plugin-obsessiondb/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, afterEach, mock } from 'bun:test'
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -6,416 +6,570 @@ import type { ResolvedChxConfig, SchemaDefinition } from '@chkit/core'
 
 import { saveCredentials } from './auth/credentials'
 import {
-  isObsessionDBHost,
-  obsessiondb,
-  resolveStripBehavior,
-  rewriteSharedEngines,
-  stripSharedPrefix,
+	isObsessionDBHost,
+	obsessiondb,
+	resolveStripBehavior,
+	rewriteSharedEngines,
+	stripSharedPrefix,
 } from './index'
 
 function makeConfig(url?: string): ResolvedChxConfig {
-  return {
-    schema: ['schema/**/*.ts'],
-    outDir: '.chkit',
-    migrationsDir: 'migrations',
-    metaDir: '.chkit/meta',
-    plugins: [],
-    check: { unusedTables: true, unusedColumns: true },
-    safety: { allowDestructive: false },
-    ...(url ? { clickhouse: { url, username: 'default', password: '', database: 'default', secure: false } } : {}),
-  }
+	return {
+		schema: ['schema/**/*.ts'],
+		outDir: '.chkit',
+		migrationsDir: 'migrations',
+		metaDir: '.chkit/meta',
+		plugins: [],
+		check: { unusedTables: true, unusedColumns: true },
+		safety: { allowDestructive: false },
+		...(url
+			? {
+					clickhouse: {
+						url,
+						username: 'default',
+						password: '',
+						database: 'default',
+						secure: false,
+					},
+				}
+			: {}),
+	}
 }
 
-function makeTable(name: string, engine: string, settings?: Record<string, string | number | boolean>): SchemaDefinition {
-  return {
-    kind: 'table',
-    database: 'default',
-    name,
-    columns: [{ name: 'id', type: 'UInt64' }],
-    engine,
-    primaryKey: ['id'],
-    orderBy: ['id'],
-    ...(settings ? { settings } : {}),
-  }
+function makeTable(
+	name: string,
+	engine: string,
+	settings?: Record<string, string | number | boolean>,
+): SchemaDefinition {
+	return {
+		kind: 'table',
+		database: 'default',
+		name,
+		columns: [{ name: 'id', type: 'UInt64' }],
+		engine,
+		primaryKey: ['id'],
+		orderBy: ['id'],
+		...(settings ? { settings } : {}),
+	}
 }
 
 function makeView(name: string): SchemaDefinition {
-  return {
-    kind: 'view',
-    database: 'default',
-    name,
-    as: 'SELECT 1',
-  }
+	return {
+		kind: 'view',
+		database: 'default',
+		name,
+		as: 'SELECT 1',
+	}
 }
 
 function makeMaterializedView(name: string): SchemaDefinition {
-  return {
-    kind: 'materialized_view',
-    database: 'default',
-    name,
-    to: { database: 'default', name: 'target' },
-    as: 'SELECT 1',
-  }
+	return {
+		kind: 'materialized_view',
+		database: 'default',
+		name,
+		to: { database: 'default', name: 'target' },
+		as: 'SELECT 1',
+	}
 }
 
 describe('isObsessionDBHost', () => {
-  test('matches obsessiondb.com subdomains', () => {
-    expect(isObsessionDBHost('https://my-cluster.obsessiondb.com:8443')).toBe(true)
-    expect(isObsessionDBHost('https://app.obsessiondb.com')).toBe(true)
-    expect(isObsessionDBHost('https://obsessiondb.com')).toBe(true)
-  })
+	test('matches obsessiondb.com subdomains', () => {
+		expect(isObsessionDBHost('https://my-cluster.obsessiondb.com:8443')).toBe(
+			true,
+		)
+		expect(isObsessionDBHost('https://app.obsessiondb.com')).toBe(true)
+		expect(isObsessionDBHost('https://obsessiondb.com')).toBe(true)
+	})
 
-  test('matches numia-dev.com hosts', () => {
-    expect(isObsessionDBHost('https://obsession.numia-dev.com:8443')).toBe(true)
-    expect(isObsessionDBHost('https://ch.obsession.numia-dev.com')).toBe(true)
-  })
+	test('matches numia-dev.com hosts', () => {
+		expect(isObsessionDBHost('https://obsession.numia-dev.com:8443')).toBe(true)
+		expect(isObsessionDBHost('https://ch.obsession.numia-dev.com')).toBe(true)
+	})
 
-  test('does not match regular ClickHouse hosts', () => {
-    expect(isObsessionDBHost('http://localhost:8123')).toBe(false)
-    expect(isObsessionDBHost('https://clickhouse.example.com:8443')).toBe(false)
-    expect(isObsessionDBHost('https://notobsessiondb.com')).toBe(false)
-  })
+	test('does not match regular ClickHouse hosts', () => {
+		expect(isObsessionDBHost('http://localhost:8123')).toBe(false)
+		expect(isObsessionDBHost('https://clickhouse.example.com:8443')).toBe(false)
+		expect(isObsessionDBHost('https://notobsessiondb.com')).toBe(false)
+	})
 
-  test('returns false for invalid URLs', () => {
-    expect(isObsessionDBHost('not-a-url')).toBe(false)
-    expect(isObsessionDBHost('')).toBe(false)
-  })
+	test('returns false for invalid URLs', () => {
+		expect(isObsessionDBHost('not-a-url')).toBe(false)
+		expect(isObsessionDBHost('')).toBe(false)
+	})
 })
 
 describe('stripSharedPrefix', () => {
-  test('strips Shared prefix from engine names', () => {
-    expect(stripSharedPrefix('SharedReplacingMergeTree(ingested_at)')).toBe('ReplacingMergeTree(ingested_at)')
-    expect(stripSharedPrefix('SharedMergeTree')).toBe('MergeTree')
-    expect(stripSharedPrefix('SharedAggregatingMergeTree')).toBe('AggregatingMergeTree')
-  })
+	test('strips Shared prefix from engine names', () => {
+		expect(stripSharedPrefix('SharedReplacingMergeTree(ingested_at)')).toBe(
+			'ReplacingMergeTree(ingested_at)',
+		)
+		expect(stripSharedPrefix('SharedMergeTree')).toBe('MergeTree')
+		expect(stripSharedPrefix('SharedAggregatingMergeTree')).toBe(
+			'AggregatingMergeTree',
+		)
+	})
 
-  test('leaves non-Shared engines unchanged', () => {
-    expect(stripSharedPrefix('MergeTree')).toBe('MergeTree')
-    expect(stripSharedPrefix('ReplacingMergeTree(ts)')).toBe('ReplacingMergeTree(ts)')
-    expect(stripSharedPrefix('Log')).toBe('Log')
-  })
+	test('leaves non-Shared engines unchanged', () => {
+		expect(stripSharedPrefix('MergeTree')).toBe('MergeTree')
+		expect(stripSharedPrefix('ReplacingMergeTree(ts)')).toBe(
+			'ReplacingMergeTree(ts)',
+		)
+		expect(stripSharedPrefix('Log')).toBe('Log')
+	})
 })
 
 describe('rewriteSharedEngines', () => {
-  test('rewrites Shared engines on tables', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'SharedReplacingMergeTree(ingested_at)'),
-      makeTable('users', 'SharedMergeTree'),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('rewrites Shared engines on tables', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'SharedReplacingMergeTree(ingested_at)'),
+			makeTable('users', 'SharedMergeTree'),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.count).toBe(2)
-    expect((result.definitions[0] as { engine: string }).engine).toBe('ReplacingMergeTree(ingested_at)')
-    expect((result.definitions[1] as { engine: string }).engine).toBe('MergeTree')
-  })
+		expect(result.count).toBe(2)
+		expect((result.definitions[0] as { engine: string }).engine).toBe(
+			'ReplacingMergeTree(ingested_at)',
+		)
+		expect((result.definitions[1] as { engine: string }).engine).toBe(
+			'MergeTree',
+		)
+	})
 
-  test('skips views and materialized views', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'SharedMergeTree'),
-      makeView('events_view'),
-      makeMaterializedView('events_mv'),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('skips views and materialized views', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'SharedMergeTree'),
+			makeView('events_view'),
+			makeMaterializedView('events_mv'),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.count).toBe(1)
-    expect(result.definitions).toHaveLength(3)
-    expect(result.definitions[1]).toEqual(makeView('events_view'))
-    expect(result.definitions[2]).toEqual(makeMaterializedView('events_mv'))
-  })
+		expect(result.count).toBe(1)
+		expect(result.definitions).toHaveLength(3)
+		expect(result.definitions[1]).toEqual(makeView('events_view'))
+		expect(result.definitions[2]).toEqual(makeMaterializedView('events_mv'))
+	})
 
-  test('skips tables without Shared prefix', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'MergeTree'),
-      makeTable('users', 'ReplacingMergeTree(ts)'),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('skips tables without Shared prefix', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'MergeTree'),
+			makeTable('users', 'ReplacingMergeTree(ts)'),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.count).toBe(0)
-    expect(result.definitions).toEqual(definitions)
-  })
+		expect(result.count).toBe(0)
+		expect(result.definitions).toEqual(definitions)
+	})
 
-  test('handles empty definitions', () => {
-    const result = rewriteSharedEngines([])
+	test('handles empty definitions', () => {
+		const result = rewriteSharedEngines([])
 
-    expect(result.count).toBe(0)
-    expect(result.definitions).toEqual([])
-  })
+		expect(result.count).toBe(0)
+		expect(result.definitions).toEqual([])
+	})
 
-  test('handles mix of Shared and non-Shared tables', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'SharedReplacingMergeTree(ts)'),
-      makeTable('users', 'MergeTree'),
-      makeTable('logs', 'SharedMergeTree'),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('handles mix of Shared and non-Shared tables', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'SharedReplacingMergeTree(ts)'),
+			makeTable('users', 'MergeTree'),
+			makeTable('logs', 'SharedMergeTree'),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.count).toBe(2)
-    expect((result.definitions[0] as { engine: string }).engine).toBe('ReplacingMergeTree(ts)')
-    expect((result.definitions[1] as { engine: string }).engine).toBe('MergeTree')
-    expect((result.definitions[2] as { engine: string }).engine).toBe('MergeTree')
-  })
+		expect(result.count).toBe(2)
+		expect((result.definitions[0] as { engine: string }).engine).toBe(
+			'ReplacingMergeTree(ts)',
+		)
+		expect((result.definitions[1] as { engine: string }).engine).toBe(
+			'MergeTree',
+		)
+		expect((result.definitions[2] as { engine: string }).engine).toBe(
+			'MergeTree',
+		)
+	})
 
-  test('strips storage_policy from table settings', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'MergeTree', { storage_policy: "'s3'", index_granularity: 8192 }),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('strips storage_policy from table settings', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'MergeTree', {
+				storage_policy: "'s3'",
+				index_granularity: 8192,
+			}),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.strippedSettings).toEqual(['storage_policy'])
-    const table = result.definitions[0] as { settings?: Record<string, string | number | boolean> }
-    expect(table.settings).toEqual({ index_granularity: 8192 })
-  })
+		expect(result.strippedSettings).toEqual(['storage_policy'])
+		const table = result.definitions[0] as {
+			settings?: Record<string, string | number | boolean>
+		}
+		expect(table.settings).toEqual({ index_granularity: 8192 })
+	})
 
-  test('removes settings entirely when storage_policy is the only setting', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'MergeTree', { storage_policy: "'s3'" }),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('removes settings entirely when storage_policy is the only setting', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'MergeTree', { storage_policy: "'s3'" }),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.strippedSettings).toEqual(['storage_policy'])
-    const table = result.definitions[0] as { settings?: Record<string, string | number | boolean> }
-    expect(table.settings).toBeUndefined()
-  })
+		expect(result.strippedSettings).toEqual(['storage_policy'])
+		const table = result.definitions[0] as {
+			settings?: Record<string, string | number | boolean>
+		}
+		expect(table.settings).toBeUndefined()
+	})
 
-  test('strips storage_policy and Shared engine together', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'SharedMergeTree', { storage_policy: "'s3'", index_granularity: 4096 }),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('strips storage_policy and Shared engine together', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'SharedMergeTree', {
+				storage_policy: "'s3'",
+				index_granularity: 4096,
+			}),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.count).toBe(1)
-    expect(result.strippedSettings).toEqual(['storage_policy'])
-    const table = result.definitions[0] as { engine: string; settings?: Record<string, string | number | boolean> }
-    expect(table.engine).toBe('MergeTree')
-    expect(table.settings).toEqual({ index_granularity: 4096 })
-  })
+		expect(result.count).toBe(1)
+		expect(result.strippedSettings).toEqual(['storage_policy'])
+		const table = result.definitions[0] as {
+			engine: string
+			settings?: Record<string, string | number | boolean>
+		}
+		expect(table.engine).toBe('MergeTree')
+		expect(table.settings).toEqual({ index_granularity: 4096 })
+	})
 
-  test('does not strip non-cloud settings', () => {
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'MergeTree', { index_granularity: 8192 }),
-    ]
-    const result = rewriteSharedEngines(definitions)
+	test('does not strip non-cloud settings', () => {
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'MergeTree', { index_granularity: 8192 }),
+		]
+		const result = rewriteSharedEngines(definitions)
 
-    expect(result.strippedSettings).toEqual([])
-    expect(result.definitions).toEqual(definitions)
-  })
+		expect(result.strippedSettings).toEqual([])
+		expect(result.definitions).toEqual(definitions)
+	})
 })
 
 describe('resolveStripBehavior', () => {
-  test('--force-shared-engines prevents stripping', () => {
-    const config = makeConfig('http://localhost:8123')
-    expect(resolveStripBehavior(config, { 'force-shared-engines': true })).toBe(false)
-  })
+	test('--force-shared-engines prevents stripping', () => {
+		const config = makeConfig('http://localhost:8123')
+		expect(resolveStripBehavior(config, { 'force-shared-engines': true })).toBe(
+			false,
+		)
+	})
 
-  test('--no-shared-engines forces stripping', () => {
-    const config = makeConfig('https://my-cluster.obsessiondb.com:8443')
-    expect(resolveStripBehavior(config, { 'no-shared-engines': true })).toBe(true)
-  })
+	test('--no-shared-engines forces stripping', () => {
+		const config = makeConfig('https://my-cluster.obsessiondb.com:8443')
+		expect(resolveStripBehavior(config, { 'no-shared-engines': true })).toBe(
+			true,
+		)
+	})
 
-  test('--force-shared-engines takes precedence over --no-shared-engines', () => {
-    const config = makeConfig('http://localhost:8123')
-    expect(resolveStripBehavior(config, { 'force-shared-engines': true, 'no-shared-engines': true })).toBe(false)
-  })
+	test('--force-shared-engines takes precedence over --no-shared-engines', () => {
+		const config = makeConfig('http://localhost:8123')
+		expect(
+			resolveStripBehavior(config, {
+				'force-shared-engines': true,
+				'no-shared-engines': true,
+			}),
+		).toBe(false)
+	})
 
-  test('auto-detects ObsessionDB host and keeps Shared engines', () => {
-    const config = makeConfig('https://my-cluster.obsessiondb.com:8443')
-    expect(resolveStripBehavior(config, {})).toBe(false)
-  })
+	test('auto-detects ObsessionDB host and keeps Shared engines', () => {
+		const config = makeConfig('https://my-cluster.obsessiondb.com:8443')
+		expect(resolveStripBehavior(config, {})).toBe(false)
+	})
 
-  test('auto-detects regular ClickHouse and strips Shared engines', () => {
-    const config = makeConfig('http://localhost:8123')
-    expect(resolveStripBehavior(config, {})).toBe(true)
-  })
+	test('auto-detects regular ClickHouse and strips Shared engines', () => {
+		const config = makeConfig('http://localhost:8123')
+		expect(resolveStripBehavior(config, {})).toBe(true)
+	})
 
-  test('strips when no clickhouse config is present', () => {
-    const config = makeConfig()
-    expect(resolveStripBehavior(config, {})).toBe(true)
-  })
+	test('strips when no clickhouse config is present', () => {
+		const config = makeConfig()
+		expect(resolveStripBehavior(config, {})).toBe(true)
+	})
 })
 
 describe('obsessiondb plugin', () => {
-  test('creates typed inline plugin registration', () => {
-    const registration = obsessiondb()
+	test('creates typed inline plugin registration', () => {
+		const registration = obsessiondb()
 
-    expect(registration.name).toBe('obsessiondb')
-    expect(registration.enabled).toBe(true)
-    expect(registration.plugin.manifest.name).toBe('obsessiondb')
-    expect(registration.plugin.manifest.apiVersion).toBe(1)
-  })
+		expect(registration.name).toBe('obsessiondb')
+		expect(registration.enabled).toBe(true)
+		expect(registration.plugin.manifest.name).toBe('obsessiondb')
+		expect(registration.plugin.manifest.apiVersion).toBe(1)
+	})
 
-  test('registers extendCommands for generate, migrate, status, drift, check', () => {
-    const registration = obsessiondb()
-    const ext = registration.plugin.extendCommands[0]
+	test('registers extendCommands for generate, migrate, status, drift, check', () => {
+		const registration = obsessiondb()
+		const ext = registration.plugin.extendCommands[0]
 
-    expect(ext?.command).toEqual(['generate', 'migrate', 'status', 'drift', 'check'])
-    expect(ext?.flags).toHaveLength(2)
-    expect(ext?.flags[0]?.name).toBe('--force-shared-engines')
-    expect(ext?.flags[1]?.name).toBe('--no-shared-engines')
-  })
+		expect(ext?.command).toEqual([
+			'generate',
+			'migrate',
+			'status',
+			'drift',
+			'check',
+		])
+		expect(ext?.flags).toHaveLength(2)
+		expect(ext?.flags[0]?.name).toBe('--force-shared-engines')
+		expect(ext?.flags[1]?.name).toBe('--no-shared-engines')
+	})
 
-  test('onSchemaLoaded strips Shared engines for regular ClickHouse', () => {
-    const registration = obsessiondb()
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'SharedReplacingMergeTree(ts)'),
-      makeTable('users', 'MergeTree'),
-      makeView('events_view'),
-    ]
+	test('onSchemaLoaded strips Shared engines for regular ClickHouse', () => {
+		const registration = obsessiondb()
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'SharedReplacingMergeTree(ts)'),
+			makeTable('users', 'MergeTree'),
+			makeView('events_view'),
+		]
 
-    const result = registration.plugin.hooks.onSchemaLoaded({
-      config: makeConfig('http://localhost:8123'),
-      flags: {},
-      definitions,
-    })
+		const result = registration.plugin.hooks.onSchemaLoaded({
+			config: makeConfig('http://localhost:8123'),
+			flags: {},
+			definitions,
+		})
 
-    expect(result).toBeDefined()
-    expect(result).toHaveLength(3)
-    expect((result?.[0] as { engine: string }).engine).toBe('ReplacingMergeTree(ts)')
-    expect((result?.[1] as { engine: string }).engine).toBe('MergeTree')
-    expect(result?.[2]).toEqual(makeView('events_view'))
-  })
+		expect(result).toBeDefined()
+		expect(result).toHaveLength(3)
+		expect((result?.[0] as { engine: string }).engine).toBe(
+			'ReplacingMergeTree(ts)',
+		)
+		expect((result?.[1] as { engine: string }).engine).toBe('MergeTree')
+		expect(result?.[2]).toEqual(makeView('events_view'))
+	})
 
-  test('onSchemaLoaded is a no-op for ObsessionDB hosts', () => {
-    const registration = obsessiondb()
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'SharedReplacingMergeTree(ts)'),
-    ]
+	test('onSchemaLoaded is a no-op for ObsessionDB hosts', () => {
+		const registration = obsessiondb()
+		const definitions: SchemaDefinition[] = [
+			makeTable('events', 'SharedReplacingMergeTree(ts)'),
+		]
 
-    const result = registration.plugin.hooks.onSchemaLoaded({
-      config: makeConfig('https://my-cluster.obsessiondb.com:8443'),
-      flags: {},
-      definitions,
-    })
+		const result = registration.plugin.hooks.onSchemaLoaded({
+			config: makeConfig('https://my-cluster.obsessiondb.com:8443'),
+			flags: {},
+			definitions,
+		})
 
-    expect(result).toBeUndefined()
-  })
+		expect(result).toBeUndefined()
+	})
 
-  test('onSchemaLoaded returns undefined when no Shared engines exist', () => {
-    const registration = obsessiondb()
-    const definitions: SchemaDefinition[] = [
-      makeTable('events', 'MergeTree'),
-    ]
+	test('onSchemaLoaded returns undefined when no Shared engines exist', () => {
+		const registration = obsessiondb()
+		const definitions: SchemaDefinition[] = [makeTable('events', 'MergeTree')]
 
-    const result = registration.plugin.hooks.onSchemaLoaded({
-      config: makeConfig('http://localhost:8123'),
-      flags: {},
-      definitions,
-    })
+		const result = registration.plugin.hooks.onSchemaLoaded({
+			config: makeConfig('http://localhost:8123'),
+			flags: {},
+			definitions,
+		})
 
-    expect(result).toBeDefined()
-    expect(result).toHaveLength(1)
-  })
+		expect(result).toBeDefined()
+		expect(result).toHaveLength(1)
+	})
+})
+
+describe('obsessiondb onInit', () => {
+	let tempDir: string
+	let originalXdg: string | undefined
+	const originalFetch = globalThis.fetch
+
+	afterEach(async () => {
+		globalThis.fetch = originalFetch
+		if (originalXdg !== undefined) {
+			process.env.XDG_CONFIG_HOME = originalXdg
+		} else {
+			delete process.env.XDG_CONFIG_HOME
+		}
+		if (tempDir) {
+			await rm(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	async function setupAuth() {
+		tempDir = await mkdtemp(join(tmpdir(), 'chkit-obd-'))
+		originalXdg = process.env.XDG_CONFIG_HOME
+		process.env.XDG_CONFIG_HOME = tempDir
+		await saveCredentials({
+			access_token: 'test-tok',
+			base_url: 'https://api.test.com',
+		})
+	}
+
+	test('prints the overridden service when --service is provided', async () => {
+		await setupAuth()
+
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						json: {
+							organizations: [
+								{
+									id: 'org-1',
+									name: 'Org',
+									slug: 'org',
+									services: [
+										{
+											id: 'svc-prod',
+											name: 'prod',
+											status: 'running',
+											tier: 1,
+											nodes: 1,
+											connectionUrl: null,
+											connectionUsername: null,
+											desiredStatus: 'running',
+											desiredTier: 1,
+											desiredNodes: 1,
+											createdAt: '2026-03-29T00:00:00Z',
+											managed: true,
+										},
+									],
+								},
+							],
+						},
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				),
+		) as typeof fetch
+
+		const log = spyOn(console, 'log').mockImplementation(() => {})
+		const plugin = obsessiondb().plugin
+		await plugin.hooks.onInit({
+			command: 'query',
+			configPath: '/fake/clickhouse.config.ts',
+			isInteractive: false,
+			jsonMode: false,
+			flags: { '--service': 'prod' },
+		})
+
+		expect(log.mock.calls.flat().join('\n')).toContain('using service "prod"')
+		log.mockRestore()
+	})
 })
 
 describe('onBeforePluginCommand — backfill interception', () => {
-  let tempDir: string
-  let originalXdg: string | undefined
-  const originalFetch = globalThis.fetch
+	let tempDir: string
+	let originalXdg: string | undefined
+	const originalFetch = globalThis.fetch
 
-  afterEach(async () => {
-    globalThis.fetch = originalFetch
-    if (originalXdg !== undefined) {
-      process.env.XDG_CONFIG_HOME = originalXdg
-    } else {
-      delete process.env.XDG_CONFIG_HOME
-    }
-    if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true })
-    }
-  })
+	afterEach(async () => {
+		globalThis.fetch = originalFetch
+		if (originalXdg !== undefined) {
+			process.env.XDG_CONFIG_HOME = originalXdg
+		} else {
+			delete process.env.XDG_CONFIG_HOME
+		}
+		if (tempDir) {
+			await rm(tempDir, { recursive: true, force: true })
+		}
+	})
 
-  function makeHookContext(overrides: Record<string, unknown> = {}) {
-    const printed: unknown[] = []
-    return {
-      context: {
-        targetPlugin: 'backfill',
-        command: 'status',
-        config: {},
-        configPath: '/fake/clickhouse.config.ts',
-        jsonMode: false,
-        args: [],
-        flags: { '--job-id': 'job-123' },
-        options: {},
-        print: (v: unknown) => printed.push(v),
-        ...overrides,
-      },
-      printed,
-    }
-  }
+	function makeHookContext(overrides: Record<string, unknown> = {}) {
+		const printed: unknown[] = []
+		return {
+			context: {
+				targetPlugin: 'backfill',
+				command: 'status',
+				config: {},
+				configPath: '/fake/clickhouse.config.ts',
+				jsonMode: false,
+				args: [],
+				flags: { '--job-id': 'job-123' },
+				options: {},
+				print: (v: unknown) => printed.push(v),
+				...overrides,
+			},
+			printed,
+		}
+	}
 
-  async function setupAuth() {
-    tempDir = await mkdtemp(join(tmpdir(), 'chkit-obd-'))
-    originalXdg = process.env.XDG_CONFIG_HOME
-    process.env.XDG_CONFIG_HOME = tempDir
-    await saveCredentials({ access_token: 'test-tok', base_url: 'https://api.test.com' })
-  }
+	async function setupAuth() {
+		tempDir = await mkdtemp(join(tmpdir(), 'chkit-obd-'))
+		originalXdg = process.env.XDG_CONFIG_HOME
+		process.env.XDG_CONFIG_HOME = tempDir
+		await saveCredentials({
+			access_token: 'test-tok',
+			base_url: 'https://api.test.com',
+		})
+	}
 
-  test('intercepts backfill commands when authenticated', async () => {
-    await setupAuth()
+	test('intercepts backfill commands when authenticated', async () => {
+		await setupAuth()
 
-    const jobDetail = {
-      id: 'job-123',
-      serviceId: 'svc-1',
-      type: 'backfill',
-      target: 'my_table',
-      status: 'running',
-      concurrency: 4,
-      totalTasks: 10,
-      completedTasks: 3,
-      failedTasks: 0,
-      createdAt: '2026-03-29T00:00:00Z',
-      updatedAt: '2026-03-29T01:00:00Z',
-      workflowId: null,
-      metadata: null,
-      tasks: [],
-    }
+		const jobDetail = {
+			id: 'job-123',
+			serviceId: 'svc-1',
+			type: 'backfill',
+			target: 'my_table',
+			status: 'running',
+			concurrency: 4,
+			totalTasks: 10,
+			completedTasks: 3,
+			failedTasks: 0,
+			createdAt: '2026-03-29T00:00:00Z',
+			updatedAt: '2026-03-29T01:00:00Z',
+			workflowId: null,
+			metadata: null,
+			tasks: [],
+		}
 
-    globalThis.fetch = mock(async () =>
-      new Response(JSON.stringify({ json: jobDetail }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-    ) as typeof fetch
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ json: jobDetail }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}),
+		) as typeof fetch
 
-    const { context, printed } = makeHookContext()
-    const plugin = obsessiondb().plugin
-    const result = await plugin.hooks.onBeforePluginCommand(context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0])
+		const { context, printed } = makeHookContext()
+		const plugin = obsessiondb().plugin
+		const result = await plugin.hooks.onBeforePluginCommand(
+			context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0],
+		)
 
-    expect(result.handled).toBe(true)
-    expect(result.exitCode).toBe(0)
-    expect((printed[0] as Record<string, unknown>).id).toBe('job-123')
-  })
+		expect(result.handled).toBe(true)
+		expect(result.exitCode).toBe(0)
+		expect((printed[0] as Record<string, unknown>).id).toBe('job-123')
+	})
 
-  test('requires login when not authenticated', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'chkit-obd-'))
-    originalXdg = process.env.XDG_CONFIG_HOME
-    process.env.XDG_CONFIG_HOME = tempDir
+	test('requires login when not authenticated', async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'chkit-obd-'))
+		originalXdg = process.env.XDG_CONFIG_HOME
+		process.env.XDG_CONFIG_HOME = tempDir
 
-    const { context, printed } = makeHookContext({ command: 'status', flags: { '--job-id': 'job-1' } })
-    const plugin = obsessiondb().plugin
-    const result = await plugin.hooks.onBeforePluginCommand(context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0])
+		const { context, printed } = makeHookContext({
+			command: 'status',
+			flags: { '--job-id': 'job-1' },
+		})
+		const plugin = obsessiondb().plugin
+		const result = await plugin.hooks.onBeforePluginCommand(
+			context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0],
+		)
 
-    expect(result.handled).toBe(true)
-    expect(result.exitCode).toBe(1)
-    expect(printed[0]).toContain('chkit obsessiondb login')
-  })
+		expect(result.handled).toBe(true)
+		expect(result.exitCode).toBe(1)
+		expect(printed[0]).toContain('chkit obsessiondb login')
+	})
 
-  test('falls through with --local flag even when authenticated', async () => {
-    await setupAuth()
+	test('falls through with --local flag even when authenticated', async () => {
+		await setupAuth()
 
-    const { context } = makeHookContext({ flags: { '--local': true } })
-    const plugin = obsessiondb().plugin
-    const result = await plugin.hooks.onBeforePluginCommand(context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0])
+		const { context } = makeHookContext({ flags: { '--local': true } })
+		const plugin = obsessiondb().plugin
+		const result = await plugin.hooks.onBeforePluginCommand(
+			context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0],
+		)
 
-    expect(result.handled).toBe(false)
-  })
+		expect(result.handled).toBe(false)
+	})
 
-  test('falls through for non-backfill plugins', async () => {
-    await setupAuth()
+	test('falls through for non-backfill plugins', async () => {
+		await setupAuth()
 
-    const { context } = makeHookContext({ targetPlugin: 'codegen' })
-    const plugin = obsessiondb().plugin
-    const result = await plugin.hooks.onBeforePluginCommand(context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0])
+		const { context } = makeHookContext({ targetPlugin: 'codegen' })
+		const plugin = obsessiondb().plugin
+		const result = await plugin.hooks.onBeforePluginCommand(
+			context as Parameters<typeof plugin.hooks.onBeforePluginCommand>[0],
+		)
 
-    expect(result.handled).toBe(false)
-  })
+		expect(result.handled).toBe(false)
+	})
 })

--- a/packages/plugin-obsessiondb/src/index.ts
+++ b/packages/plugin-obsessiondb/src/index.ts
@@ -7,8 +7,10 @@ import type {
 import { AUTH_COMMANDS, loadCredentials, resolveBaseUrl } from './auth/index.js'
 import { BACKFILL_EXTEND_COMMANDS, handleBackfillCommand } from './backfill/index.js'
 import { createRemoteExecutor } from './query/remote-executor.js'
+import { listServices } from './service/api.js'
 import { SELECT_SERVICE_COMMAND } from './service/commands.js'
 import { loadSelectedService } from './service/storage.js'
+import type { SelectedService } from './service/types.js'
 
 export { loadCredentials, resolveBaseUrl, type Credentials } from './auth/index.js'
 export { createJobsClient, type JobsClient } from './backfill/index.js'
@@ -174,15 +176,43 @@ function createObsessionDBPlugin(_options: ObsessionDBPluginOptions): ObsessionD
           },
         ],
       },
+      {
+        command: ['generate', 'migrate', 'status', 'drift', 'check', 'query'],
+        flags: [
+          {
+            name: '--service',
+            type: 'string',
+            description: 'Override the selected ObsessionDB service by name for this command',
+          },
+        ],
+      },
       ...BACKFILL_EXTEND_COMMANDS,
     ],
     hooks: {
-      async getContext({ configPath }) {
+      async getContext({ configPath, flags }) {
         const creds = await loadCredentials()
         if (!creds) return
-        const service = await loadSelectedService(configPath)
-        if (!service) return
         const effectiveCreds = { ...creds, base_url: resolveBaseUrl(creds.base_url) }
+
+        const serviceOverride = flags['--service']
+        const overrideName = typeof serviceOverride === 'string' ? serviceOverride.trim() : ''
+
+        let service: SelectedService | null
+        if (overrideName.length > 0) {
+          const services = await listServices(effectiveCreds)
+          const match = services.find((s) => s.name === overrideName)
+          if (!match) {
+            const available = services.map((s) => s.name).join(', ') || '<none>'
+            throw new Error(
+              `obsessiondb: service "${overrideName}" not found. Available services: ${available}`,
+            )
+          }
+          service = { service_id: match.id, service_name: match.name }
+        } else {
+          service = await loadSelectedService(configPath)
+        }
+        if (!service) return
+
         return {
           executor: createRemoteExecutor({
             credentials: effectiveCreds,

--- a/packages/plugin-obsessiondb/src/index.ts
+++ b/packages/plugin-obsessiondb/src/index.ts
@@ -1,270 +1,317 @@
 import type {
-  ChxInlinePluginRegistration,
-  ResolvedChxConfig,
-  SchemaDefinition,
+	ChxInlinePluginRegistration,
+	ResolvedChxConfig,
+	SchemaDefinition,
 } from '@chkit/core'
 
 import { AUTH_COMMANDS, loadCredentials, resolveBaseUrl } from './auth/index.js'
-import { BACKFILL_EXTEND_COMMANDS, handleBackfillCommand } from './backfill/index.js'
+import {
+	BACKFILL_EXTEND_COMMANDS,
+	handleBackfillCommand,
+} from './backfill/index.js'
 import { createRemoteExecutor } from './query/remote-executor.js'
 import { listServices } from './service/api.js'
 import { SELECT_SERVICE_COMMAND } from './service/commands.js'
 import { loadSelectedService } from './service/storage.js'
 import type { SelectedService } from './service/types.js'
 
-export { loadCredentials, resolveBaseUrl, type Credentials } from './auth/index.js'
-export { createJobsClient, type JobsClient } from './backfill/index.js'
 export {
-  loadSelectedService,
-} from './service/storage.js'
+	type Credentials,
+	loadCredentials,
+	resolveBaseUrl,
+} from './auth/index.js'
+export { createJobsClient, type JobsClient } from './backfill/index.js'
+export { loadSelectedService } from './service/storage.js'
 export type { SelectedService } from './service/types.js'
 
 export type ObsessionDBPluginOptions = Record<string, never>
 
 interface PluginCommand {
-  name: string
-  description: string
-  flags?: ReadonlyArray<{ name: string; type: string; description: string }>
-  run: (context: Record<string, unknown>) => unknown
+	name: string
+	description: string
+	flags?: ReadonlyArray<{ name: string; type: string; description: string }>
+	run: (context: Record<string, unknown>) => unknown
 }
 
 interface BeforePluginCommandContext {
-  targetPlugin: string
-  command: string
-  config: Record<string, unknown>
-  configPath: string
-  jsonMode: boolean
-  args: string[]
-  flags: Record<string, string | string[] | boolean | undefined>
-  options: Record<string, unknown>
-  print: (value: unknown) => void
+	targetPlugin: string
+	command: string
+	config: Record<string, unknown>
+	configPath: string
+	jsonMode: boolean
+	args: string[]
+	flags: Record<string, string | string[] | boolean | undefined>
+	options: Record<string, unknown>
+	print: (value: unknown) => void
 }
 
 interface BeforePluginCommandResult {
-  handled: boolean
-  exitCode?: number
+	handled: boolean
+	exitCode?: number
 }
 
 interface GetContextInput {
-  config: ResolvedChxConfig
-  configPath: string
-  command: string
-  flags: Record<string, unknown>
-  defaults: Record<string, unknown>
+	config: ResolvedChxConfig
+	configPath: string
+	command: string
+	flags: Record<string, unknown>
+	defaults: Record<string, unknown>
 }
 
 interface ObsessionDBPlugin {
-  manifest: { name: 'obsessiondb'; apiVersion: 1 }
-  commands: PluginCommand[]
-  extendCommands: Array<{
-    command: string[]
-    flags: Array<{
-      name: string
-      type: 'boolean' | 'string'
-      description: string
-    }>
-  }>
-  hooks: {
-    getContext(input: GetContextInput): Promise<{ executor: unknown } | void>
-    onInit(context: { command: string; configPath: string; isInteractive: boolean; jsonMode: boolean }): Promise<void>
-    onSchemaLoaded(context: {
-      config: ResolvedChxConfig
-      flags: Record<string, string | string[] | boolean | undefined>
-      definitions: SchemaDefinition[]
-    }): SchemaDefinition[] | undefined
-    onBeforePluginCommand(context: BeforePluginCommandContext): Promise<BeforePluginCommandResult>
-  }
+	manifest: { name: 'obsessiondb'; apiVersion: 1 }
+	commands: PluginCommand[]
+	extendCommands: Array<{
+		command: string[]
+		flags: Array<{
+			name: string
+			type: 'boolean' | 'string'
+			description: string
+		}>
+	}>
+	hooks: {
+		getContext(
+			input: GetContextInput,
+		): Promise<{ executor: unknown } | undefined>
+		onInit(context: {
+			command: string
+			configPath: string
+			isInteractive: boolean
+			jsonMode: boolean
+			flags: Record<string, string | string[] | boolean | undefined>
+		}): Promise<void>
+		onSchemaLoaded(context: {
+			config: ResolvedChxConfig
+			flags: Record<string, string | string[] | boolean | undefined>
+			definitions: SchemaDefinition[]
+		}): SchemaDefinition[] | undefined
+		onBeforePluginCommand(
+			context: BeforePluginCommandContext,
+		): Promise<BeforePluginCommandResult>
+	}
 }
 
 type ObsessionDBRegistration = ChxInlinePluginRegistration<
-  ObsessionDBPlugin,
-  ObsessionDBPluginOptions
+	ObsessionDBPlugin,
+	ObsessionDBPluginOptions
 >
 
 export function isObsessionDBHost(url: string): boolean {
-  try {
-    const { hostname } = new URL(url)
-    return (
-      hostname === 'obsessiondb.com' ||
-      hostname.endsWith('.obsessiondb.com') ||
-      hostname === 'obsession.numia-dev.com' ||
-      hostname.endsWith('.obsession.numia-dev.com')
-    )
-  } catch {
-    return false
-  }
+	try {
+		const { hostname } = new URL(url)
+		return (
+			hostname === 'obsessiondb.com' ||
+			hostname.endsWith('.obsessiondb.com') ||
+			hostname === 'obsession.numia-dev.com' ||
+			hostname.endsWith('.obsession.numia-dev.com')
+		)
+	} catch {
+		return false
+	}
 }
 
 export function resolveStripBehavior(
-  config: ResolvedChxConfig,
-  flags: Record<string, string | string[] | boolean | undefined>,
+	config: ResolvedChxConfig,
+	flags: Record<string, string | string[] | boolean | undefined>,
 ): boolean {
-  if (flags['force-shared-engines']) return false
-  if (flags['no-shared-engines']) return true
-  // Auto-detect: if targeting ObsessionDB, keep Shared engines
-  const url = config.clickhouse?.url
-  if (url && isObsessionDBHost(url)) return false
-  return true
+	if (flags['force-shared-engines']) return false
+	if (flags['no-shared-engines']) return true
+	// Auto-detect: if targeting ObsessionDB, keep Shared engines
+	const url = config.clickhouse?.url
+	if (url && isObsessionDBHost(url)) return false
+	return true
 }
 
 export function stripSharedPrefix(engine: string): string {
-  return engine.replace(/^Shared/, '')
+	return engine.replace(/^Shared/, '')
 }
 
-function stripCloudSettings(settings: Record<string, string | number | boolean> | undefined): {
-  settings: Record<string, string | number | boolean> | undefined
-  stripped: string[]
+function stripCloudSettings(
+	settings: Record<string, string | number | boolean> | undefined,
+): {
+	settings: Record<string, string | number | boolean> | undefined
+	stripped: string[]
 } {
-  if (!settings) return { settings, stripped: [] }
-  const CLOUD_ONLY_SETTINGS = ['storage_policy']
-  const stripped: string[] = []
-  let result: Record<string, string | number | boolean> | undefined
-  for (const key of CLOUD_ONLY_SETTINGS) {
-    if (key in settings) {
-      if (!result) result = { ...settings }
-      delete result[key]
-      stripped.push(key)
-    }
-  }
-  if (!result) return { settings, stripped: [] }
-  return {
-    settings: Object.keys(result).length > 0 ? result : undefined,
-    stripped,
-  }
+	if (!settings) return { settings, stripped: [] }
+	const CLOUD_ONLY_SETTINGS = ['storage_policy']
+	const stripped: string[] = []
+	let result: Record<string, string | number | boolean> | undefined
+	for (const key of CLOUD_ONLY_SETTINGS) {
+		if (key in settings) {
+			if (!result) result = { ...settings }
+			delete result[key]
+			stripped.push(key)
+		}
+	}
+	if (!result) return { settings, stripped: [] }
+	return {
+		settings: Object.keys(result).length > 0 ? result : undefined,
+		stripped,
+	}
 }
 
 export function rewriteSharedEngines(definitions: SchemaDefinition[]): {
-  definitions: SchemaDefinition[]
-  count: number
-  strippedSettings: string[]
+	definitions: SchemaDefinition[]
+	count: number
+	strippedSettings: string[]
 } {
-  let count = 0
-  const allStrippedSettings: string[] = []
-  const rewritten = definitions.map((def) => {
-    if (def.kind !== 'table') return def
-    const hasSharedEngine = def.engine.startsWith('Shared')
-    const { settings, stripped } = stripCloudSettings(def.settings)
-    if (!hasSharedEngine && stripped.length === 0) return def
-    if (hasSharedEngine) count++
-    allStrippedSettings.push(...stripped)
-    return {
-      ...def,
-      engine: hasSharedEngine ? stripSharedPrefix(def.engine) : def.engine,
-      settings,
-    }
-  })
-  return { definitions: rewritten, count, strippedSettings: allStrippedSettings }
+	let count = 0
+	const allStrippedSettings: string[] = []
+	const rewritten = definitions.map((def) => {
+		if (def.kind !== 'table') return def
+		const hasSharedEngine = def.engine.startsWith('Shared')
+		const { settings, stripped } = stripCloudSettings(def.settings)
+		if (!hasSharedEngine && stripped.length === 0) return def
+		if (hasSharedEngine) count++
+		allStrippedSettings.push(...stripped)
+		return {
+			...def,
+			engine: hasSharedEngine ? stripSharedPrefix(def.engine) : def.engine,
+			settings,
+		}
+	})
+	return {
+		definitions: rewritten,
+		count,
+		strippedSettings: allStrippedSettings,
+	}
 }
 
-function createObsessionDBPlugin(_options: ObsessionDBPluginOptions): ObsessionDBPlugin {
-  return {
-    manifest: { name: 'obsessiondb', apiVersion: 1 },
-    commands: [...AUTH_COMMANDS, SELECT_SERVICE_COMMAND] as unknown as PluginCommand[],
-    extendCommands: [
-      {
-        command: ['generate', 'migrate', 'status', 'drift', 'check'],
-        flags: [
-          {
-            name: '--force-shared-engines',
-            type: 'boolean',
-            description: 'Keep Shared engine prefixes (skip stripping)',
-          },
-          {
-            name: '--no-shared-engines',
-            type: 'boolean',
-            description: 'Strip Shared engine prefixes (even on ObsessionDB)',
-          },
-        ],
-      },
-      {
-        command: ['generate', 'migrate', 'status', 'drift', 'check', 'query'],
-        flags: [
-          {
-            name: '--service',
-            type: 'string',
-            description: 'Override the selected ObsessionDB service by name for this command',
-          },
-        ],
-      },
-      ...BACKFILL_EXTEND_COMMANDS,
-    ],
-    hooks: {
-      async getContext({ configPath, flags }) {
-        const creds = await loadCredentials()
-        if (!creds) return
-        const effectiveCreds = { ...creds, base_url: resolveBaseUrl(creds.base_url) }
+function createObsessionDBPlugin(
+	_options: ObsessionDBPluginOptions,
+): ObsessionDBPlugin {
+	return {
+		manifest: { name: 'obsessiondb', apiVersion: 1 },
+		commands: [
+			...AUTH_COMMANDS,
+			SELECT_SERVICE_COMMAND,
+		] as unknown as PluginCommand[],
+		extendCommands: [
+			{
+				command: ['generate', 'migrate', 'status', 'drift', 'check'],
+				flags: [
+					{
+						name: '--force-shared-engines',
+						type: 'boolean',
+						description: 'Keep Shared engine prefixes (skip stripping)',
+					},
+					{
+						name: '--no-shared-engines',
+						type: 'boolean',
+						description: 'Strip Shared engine prefixes (even on ObsessionDB)',
+					},
+				],
+			},
+			{
+				command: ['generate', 'migrate', 'status', 'drift', 'check', 'query'],
+				flags: [
+					{
+						name: '--service',
+						type: 'string',
+						description:
+							'Override the selected ObsessionDB service by name for this command',
+					},
+				],
+			},
+			...BACKFILL_EXTEND_COMMANDS,
+		],
+		hooks: {
+			async getContext({ configPath, flags }) {
+				const creds = await loadCredentials()
+				if (!creds) return
+				const effectiveCreds = {
+					...creds,
+					base_url: resolveBaseUrl(creds.base_url),
+				}
 
-        const serviceOverride = flags['--service']
-        const overrideName = typeof serviceOverride === 'string' ? serviceOverride.trim() : ''
+				const serviceOverride = flags['--service']
+				const overrideName =
+					typeof serviceOverride === 'string' ? serviceOverride.trim() : ''
 
-        let service: SelectedService | null
-        if (overrideName.length > 0) {
-          const services = await listServices(effectiveCreds)
-          const match = services.find((s) => s.name === overrideName)
-          if (!match) {
-            const available = services.map((s) => s.name).join(', ') || '<none>'
-            throw new Error(
-              `obsessiondb: service "${overrideName}" not found. Available services: ${available}`,
-            )
-          }
-          service = { service_id: match.id, service_name: match.name }
-        } else {
-          service = await loadSelectedService(configPath)
-        }
-        if (!service) return
+				let service: SelectedService | null
+				if (overrideName.length > 0) {
+					const services = await listServices(effectiveCreds)
+					const match = services.find((s) => s.name === overrideName)
+					if (!match) {
+						const available = services.map((s) => s.name).join(', ') || '<none>'
+						throw new Error(
+							`obsessiondb: service "${overrideName}" not found. Available services: ${available}`,
+						)
+					}
+					service = { service_id: match.id, service_name: match.name }
+				} else {
+					service = await loadSelectedService(configPath)
+				}
+				if (!service) return
 
-        return {
-          executor: createRemoteExecutor({
-            credentials: effectiveCreds,
-            serviceId: service.service_id,
-          }),
-        }
-      },
-      async onInit(context) {
-        if (context.jsonMode) return
-        const creds = await loadCredentials()
-        if (!creds) return
-        const service = await loadSelectedService(context.configPath)
-        if (service) {
-          console.log(
-            `obsessiondb: routing queries through ${service.service_name}`,
-          )
-        } else {
-          console.log(
-            'obsessiondb: authenticated but no service selected (run `chkit obsessiondb select-service`)',
-          )
-        }
-      },
-      onSchemaLoaded(context) {
-        const shouldStrip = resolveStripBehavior(context.config, context.flags)
-        if (!shouldStrip) return
+				return {
+					executor: createRemoteExecutor({
+						credentials: effectiveCreds,
+						serviceId: service.service_id,
+					}),
+				}
+			},
+			async onInit(context) {
+				if (context.jsonMode) return
+				const creds = await loadCredentials()
+				if (!creds) return
+				const effectiveCreds = {
+					...creds,
+					base_url: resolveBaseUrl(creds.base_url),
+				}
+				const serviceOverride = context.flags['--service']
+				const overrideName =
+					typeof serviceOverride === 'string' ? serviceOverride.trim() : ''
 
-        const rewritten = rewriteSharedEngines(context.definitions)
-        if (rewritten.count > 0) {
-          console.log(
-            `obsessiondb: Rewrote ${rewritten.count} Shared engine(s) to standard ClickHouse equivalents.`,
-          )
-        }
-        if (rewritten.strippedSettings.length > 0) {
-          const unique = [...new Set(rewritten.strippedSettings)]
-          console.log(
-            `obsessiondb: Stripped cloud-only setting(s): ${unique.join(', ')}`,
-          )
-        }
-        return rewritten.definitions
-      },
-      async onBeforePluginCommand(context) {
-        return handleBackfillCommand(context)
-      },
-    },
-  }
+				let service: SelectedService | null
+				if (overrideName.length > 0) {
+					const services = await listServices(effectiveCreds)
+					const match = services.find((s) => s.name === overrideName)
+					if (!match) return
+					service = { service_id: match.id, service_name: match.name }
+				} else {
+					service = await loadSelectedService(context.configPath)
+				}
+				if (service) {
+					console.log(`obsessiondb: using service "${service.service_name}"\n`)
+				} else {
+					console.log(
+						'obsessiondb: authenticated but no service selected (run `chkit obsessiondb select-service`)',
+					)
+				}
+			},
+			onSchemaLoaded(context) {
+				const shouldStrip = resolveStripBehavior(context.config, context.flags)
+				if (!shouldStrip) return
+
+				const rewritten = rewriteSharedEngines(context.definitions)
+				if (rewritten.count > 0) {
+					console.log(
+						`obsessiondb: Rewrote ${rewritten.count} Shared engine(s) to standard ClickHouse equivalents.`,
+					)
+				}
+				if (rewritten.strippedSettings.length > 0) {
+					const unique = [...new Set(rewritten.strippedSettings)]
+					console.log(
+						`obsessiondb: Stripped cloud-only setting(s): ${unique.join(', ')}`,
+					)
+				}
+				return rewritten.definitions
+			},
+			async onBeforePluginCommand(context) {
+				return handleBackfillCommand(context)
+			},
+		},
+	}
 }
 
-export function obsessiondb(options: ObsessionDBPluginOptions = {}): ObsessionDBRegistration {
-  return {
-    plugin: createObsessionDBPlugin(options),
-    name: 'obsessiondb',
-    enabled: true,
-    options,
-  }
+export function obsessiondb(
+	options: ObsessionDBPluginOptions = {},
+): ObsessionDBRegistration {
+	return {
+		plugin: createObsessionDBPlugin(options),
+		name: 'obsessiondb',
+		enabled: true,
+		options,
+	}
 }

--- a/packages/plugin-obsessiondb/src/query/remote-executor.test.ts
+++ b/packages/plugin-obsessiondb/src/query/remote-executor.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+	normalizeQueryData,
+	normalizeQueryJsonResult,
+} from './remote-executor.js'
+
+describe('normalizeQueryData', () => {
+	test('maps array rows to objects using response metadata', () => {
+		const rows = normalizeQueryData<{ database: string; name: string }>({
+			data: [
+				['default', 'users'],
+				['default', 'events'],
+			],
+			meta: [
+				{ name: 'database', type: 'String' },
+				{ name: 'name', type: 'String' },
+			],
+			rows: 2,
+		})
+
+		expect(rows).toEqual([
+			{ database: 'default', name: 'users' },
+			{ database: 'default', name: 'events' },
+		])
+	})
+
+	test('keeps object rows unchanged', () => {
+		const rows = normalizeQueryData<{ database: string; name: string }>({
+			data: [{ database: 'default', name: 'users' }],
+			meta: [
+				{ name: 'database', type: 'String' },
+				{ name: 'name', type: 'String' },
+			],
+			rows: 1,
+		})
+
+		expect(rows).toEqual([{ database: 'default', name: 'users' }])
+	})
+
+	test('normalizes ClickHouse JSON shape', () => {
+		const result = normalizeQueryJsonResult<{ database: string; name: string }>(
+			{
+				data: [['default', 'users']],
+				meta: [
+					{ name: 'database', type: 'String' },
+					{ name: 'name', type: 'String' },
+				],
+				rows: 1,
+				statistics: { elapsed: 0.1, rows_read: 1, bytes_read: 10 },
+				query_id: 'query-id',
+			},
+		)
+
+		expect(result).toEqual({
+			data: [{ database: 'default', name: 'users' }],
+			meta: [
+				{ name: 'database', type: 'String' },
+				{ name: 'name', type: 'String' },
+			],
+			rows: 1,
+			statistics: { elapsed: 0.1, rows_read: 1, bytes_read: 10 },
+			query_id: 'query-id',
+		})
+	})
+})

--- a/packages/plugin-obsessiondb/src/query/remote-executor.ts
+++ b/packages/plugin-obsessiondb/src/query/remote-executor.ts
@@ -1,86 +1,141 @@
-import type { ClickHouseExecutor, QueryStatus, SchemaObjectRef } from '@chkit/clickhouse'
+import type {
+	ClickHouseExecutor,
+	ClickHouseJsonQueryResult,
+	QueryStatus,
+	SchemaObjectRef,
+} from '@chkit/clickhouse'
 import {
-  buildIntrospectedTables,
-  inferSchemaKindFromEngine,
-  type SystemColumnRow,
-  type SystemSkippingIndexRow,
-  type SystemTableRow,
+	buildIntrospectedTables,
+	inferSchemaKindFromEngine,
+	type SystemColumnRow,
+	type SystemSkippingIndexRow,
+	type SystemTableRow,
 } from '@chkit/clickhouse'
 import type { Credentials } from '../auth/index.js'
-import { createApiClient, type ApiClient } from '../client.js'
+import { type ApiClient, createApiClient } from '../client.js'
 
 function throwIfError(
-  res: Awaited<ReturnType<ApiClient['workbench']['query']['execute']>>,
+	res: Awaited<ReturnType<ApiClient['workbench']['query']['execute']>>,
 ): void {
-  if (res.error) {
-    throw new Error(res.error)
-  }
+	if (res.error) {
+		throw new Error(res.error)
+	}
+}
+
+export function normalizeQueryData<T>(
+	res: Awaited<ReturnType<ApiClient['workbench']['query']['execute']>>,
+): T[] {
+	const columnNames = res.meta.map((col) => col.name)
+	return res.data.map((row) => {
+		if (!Array.isArray(row)) return row as T
+		return Object.fromEntries(
+			row.map((value, idx) => [columnNames[idx] ?? String(idx), value]),
+		) as T
+	})
+}
+
+export function normalizeQueryJsonResult<T extends Record<string, unknown>>(
+	res: Awaited<ReturnType<ApiClient['workbench']['query']['execute']>>,
+): ClickHouseJsonQueryResult<T> {
+	const out: ClickHouseJsonQueryResult<T> = {
+		data: normalizeQueryData<T>(res),
+		meta: res.meta,
+		rows: res.rows,
+	}
+	if (res.statistics) out.statistics = res.statistics
+	if (res.query_id) out.query_id = res.query_id
+	return out
 }
 
 export function createRemoteExecutor(deps: {
-  credentials: Credentials
-  serviceId: string
+	credentials: Credentials
+	serviceId: string
 }): ClickHouseExecutor {
-  const { credentials, serviceId } = deps
-  const client = createApiClient(credentials)
+	const { credentials, serviceId } = deps
+	const client = createApiClient(credentials)
 
-  const executor: ClickHouseExecutor = {
-    async command(sql) {
-      const res = await client.workbench.query.execute({ serviceId, query: sql })
-      throwIfError(res)
-    },
+	const executor: ClickHouseExecutor = {
+		async command(sql) {
+			const res = await client.workbench.query.execute({
+				serviceId,
+				query: sql,
+			})
+			throwIfError(res)
+		},
 
-    async query<T>(sql: string): Promise<T[]> {
-      const res = await client.workbench.query.execute({ serviceId, query: sql })
-      throwIfError(res)
-      return res.data as T[]
-    },
+		async query<T>(sql: string): Promise<T[]> {
+			const res = await client.workbench.query.execute({
+				serviceId,
+				query: sql,
+			})
+			throwIfError(res)
+			return normalizeQueryData<T>(res)
+		},
 
-    async insert<T extends Record<string, unknown>>(params: { table: string; values: T[]; compressed?: boolean }) {
-      if (params.values.length === 0) return
-      const columns = Object.keys(params.values[0]!)
-      const rows = params.values
-        .map(
-          (row) =>
-            `(${columns.map((col) => {
-              const val = row[col]
-              if (val === null || val === undefined) return 'NULL'
-              if (typeof val === 'number') return String(val)
-              return `'${String(val).replace(/'/g, "\\'")}'`
-            }).join(', ')})`,
-        )
-        .join(', ')
-      await executor.command(`INSERT INTO ${params.table} (${columns.join(', ')}) VALUES ${rows}`)
-    },
+		async queryJson<T extends Record<string, unknown>>(
+			sql: string,
+		): Promise<ClickHouseJsonQueryResult<T>> {
+			const res = await client.workbench.query.execute({
+				serviceId,
+				query: sql,
+			})
+			throwIfError(res)
+			return normalizeQueryJsonResult<T>(res)
+		},
 
-    async submit(sql, queryId?) {
-      const res = await client.workbench.query.execute({
-        serviceId,
-        query: sql,
-        settings: queryId ? { query_id: queryId } : undefined,
-      })
-      throwIfError(res)
-      return queryId ?? 'submitted'
-    },
+		async insert<T extends Record<string, unknown>>(params: {
+			table: string
+			values: T[]
+			compressed?: boolean
+		}) {
+			if (params.values.length === 0) return
+			const columns = Object.keys(params.values[0]!)
+			const rows = params.values
+				.map(
+					(row) =>
+						`(${columns
+							.map((col) => {
+								const val = row[col]
+								if (val === null || val === undefined) return 'NULL'
+								if (typeof val === 'number') return String(val)
+								return `'${String(val).replace(/'/g, "\\'")}'`
+							})
+							.join(', ')})`,
+				)
+				.join(', ')
+			await executor.command(
+				`INSERT INTO ${params.table} (${columns.join(', ')}) VALUES ${rows}`,
+			)
+		},
 
-    async queryStatus(queryId, options?) {
-      const afterFilter = options?.afterTime
-        ? `AND event_time >= '${options.afterTime}'`
-        : ''
+		async submit(sql, queryId?) {
+			const res = await client.workbench.query.execute({
+				serviceId,
+				query: sql,
+				settings: queryId ? { query_id: queryId } : undefined,
+			})
+			throwIfError(res)
+			return queryId ?? 'submitted'
+		},
 
-      const running = await executor.query<{ query_id: string }>(
-        `SELECT query_id FROM system.processes WHERE user = currentUser() AND query_id = '${queryId}' LIMIT 1`,
-      )
-      if (running.length > 0) return { status: 'running' as const }
+		async queryStatus(queryId, options?) {
+			const afterFilter = options?.afterTime
+				? `AND event_time >= '${options.afterTime}'`
+				: ''
 
-      const log = await executor.query<{
-        type: string
-        written_rows: string
-        written_bytes: string
-        query_duration_ms: string
-        exception: string
-      }>(
-        `SELECT type, written_rows, written_bytes, query_duration_ms, exception
+			const running = await executor.query<{ query_id: string }>(
+				`SELECT query_id FROM system.processes WHERE user = currentUser() AND query_id = '${queryId}' LIMIT 1`,
+			)
+			if (running.length > 0) return { status: 'running' as const }
+
+			const log = await executor.query<{
+				type: string
+				written_rows: string
+				written_bytes: string
+				query_duration_ms: string
+				exception: string
+			}>(
+				`SELECT type, written_rows, written_bytes, query_duration_ms, exception
 FROM system.query_log
 WHERE user = currentUser()
   AND query_id = '${queryId}'
@@ -88,66 +143,72 @@ WHERE user = currentUser()
   ${afterFilter}
 ORDER BY event_time DESC
 LIMIT 1`,
-      )
+			)
 
-      if (log.length === 0) return { status: 'unknown' as const }
-      const row = log[0]!
+			if (log.length === 0) return { status: 'unknown' as const }
+			const row = log[0]!
 
-      if (row.type === 'QueryFinish') {
-        return {
-          status: 'finished' as const,
-          writtenRows: Number(row.written_rows),
-          writtenBytes: Number(row.written_bytes),
-          durationMs: Number(row.query_duration_ms),
-        }
-      }
+			if (row.type === 'QueryFinish') {
+				return {
+					status: 'finished' as const,
+					writtenRows: Number(row.written_rows),
+					writtenBytes: Number(row.written_bytes),
+					durationMs: Number(row.query_duration_ms),
+				}
+			}
 
-      return {
-        status: 'failed' as const,
-        durationMs: Number(row.query_duration_ms),
-        error: row.exception,
-      } satisfies QueryStatus
-    },
+			return {
+				status: 'failed' as const,
+				durationMs: Number(row.query_duration_ms),
+				error: row.exception,
+			} satisfies QueryStatus
+		},
 
-    async listSchemaObjects() {
-      const rows = await executor.query<{ database: string; name: string; engine: string }>(
-        `SELECT database, name, engine
+		async listSchemaObjects() {
+			const rows = await executor.query<{
+				database: string
+				name: string
+				engine: string
+			}>(
+				`SELECT database, name, engine
 FROM system.tables
 WHERE is_temporary = 0
   AND database NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
   AND name NOT LIKE '_chkit_%'`,
-      )
+			)
 
-      const out: SchemaObjectRef[] = []
-      for (const row of rows) {
-        const kind = inferSchemaKindFromEngine(row.engine)
-        if (!kind) continue
-        out.push({ kind, database: row.database, name: row.name })
-      }
-      return out
-    },
+			const out: SchemaObjectRef[] = []
+			for (const row of rows) {
+				const kind = inferSchemaKindFromEngine(row.engine)
+				if (!kind) continue
+				out.push({ kind, database: row.database, name: row.name })
+			}
+			return out
+		},
 
-    async listTableDetails(databases) {
-      if (databases.length === 0) return []
-      const quoted = databases.map((db) => `'${db.replace(/'/g, "''")}'`).join(', ')
+		async listTableDetails(databases) {
+			if (databases.length === 0) return []
+			const quoted = databases
+				.map((db) => `'${db.replace(/'/g, "''")}'`)
+				.join(', ')
 
-      const [tables, columns, indexes] = await Promise.all([
-        executor.query<SystemTableRow>(
-          `SELECT database, name, engine, create_table_query FROM system.tables WHERE is_temporary = 0 AND database IN (${quoted})`,
-        ),
-        executor.query<SystemColumnRow>(
-          `SELECT database, \`table\`, name, type, default_kind, default_expression, comment, position FROM system.columns WHERE database IN (${quoted})`,
-        ),
-        executor.query<SystemSkippingIndexRow>(
-          `SELECT database, \`table\`, name, expr, type, granularity FROM system.data_skipping_indices WHERE database IN (${quoted})`,
-        ),
-      ])
+			const [tables, columns, indexes] = await Promise.all([
+				executor.query<SystemTableRow>(
+					`SELECT database, name, engine, create_table_query FROM system.tables WHERE is_temporary = 0 AND database IN (${quoted})`,
+				),
+				executor.query<SystemColumnRow>(
+					`SELECT database, \`table\`, name, type, default_kind, default_expression, comment, position FROM system.columns WHERE database IN (${quoted})`,
+				),
+				executor.query<SystemSkippingIndexRow>(
+					`SELECT database, \`table\`, name, expr, type, granularity FROM system.data_skipping_indices WHERE database IN (${quoted})`,
+				),
+			])
 
-      return buildIntrospectedTables(tables, columns, indexes)
-    },
+			return buildIntrospectedTables(tables, columns, indexes)
+		},
 
-    async close() {},
-  }
+		async close() {},
+	}
 
-  return executor
+	return executor
 }

--- a/packages/plugin-obsessiondb/src/query/remote-executor.ts
+++ b/packages/plugin-obsessiondb/src/query/remote-executor.ts
@@ -98,7 +98,7 @@ export function createRemoteExecutor(deps: {
 								const val = row[col]
 								if (val === null || val === undefined) return 'NULL'
 								if (typeof val === 'number') return String(val)
-								return `'${String(val).replace(/'/g, "\\'")}'`
+								return `'${String(val).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
 							})
 							.join(', ')})`,
 				)

--- a/skills/chkit/SKILL.md
+++ b/skills/chkit/SKILL.md
@@ -185,6 +185,16 @@ chkit check --json       # Machine-readable output
 
 Evaluates: pending migrations, checksum mismatches, schema drift, plugin checks. Exit code 1 on failure.
 
+### query — Run SQL against the configured target
+
+```sh
+chkit query "SELECT count() FROM users"
+chkit query "SELECT count() FROM users" --json
+chkit query "SELECT count() FROM users" --service customer-b  # ObsessionDB plugin
+```
+
+Uses the active executor: direct `clickhouse` config by default, or the ObsessionDB plugin service when loaded.
+
 ## Rename Workflow
 
 To rename a table or column without drop+recreate:
@@ -229,6 +239,7 @@ export default defineConfig({
 | `@chkit/plugin-codegen` | `bun add -d @chkit/plugin-codegen` | `chkit codegen` | Generate TypeScript types + Zod schemas |
 | `@chkit/plugin-pull` | `bun add -d @chkit/plugin-pull` | `chkit pull` | Introspect live ClickHouse into schema files |
 | `@chkit/plugin-backfill` | `bun add -d @chkit/plugin-backfill` | `chkit backfill` | Time-windowed data backfill with checkpoints |
+| `@chkit/plugin-obsessiondb` | `bun add -d @chkit/plugin-obsessiondb` | `chkit query --service <name>` | Route commands through an ObsessionDB service |
 
 ## Common Workflows
 


### PR DESCRIPTION
## Summary
- Adds `chkit query "<sql>"` as a core command that runs ad-hoc SQL through the active executor — default ClickHouse, or whichever executor a plugin supplies — with table-style output by default and `--json` for machine output.
- Threads positional args through `CommandRunContext` so commands can receive non-flag arguments (used by `query`).
- ObsessionDB plugin: when loaded, registers `--service <name>` on `generate`, `migrate`, `status`, `drift`, `check`, and `query`. The flag resolves the service by name via `listServices()` and routes that single invocation through it, without changing the saved selection in `.chkit/obsessiondb.json`.
- Adds docs for the new command and the per-command service override, plus a changeset.

## Test plan
- [ ] `bun verify` passes
- [ ] `chkit query --help` lists `--service` under the obsessiondb plugin section when the plugin is loaded
- [ ] `chkit query "SELECT 1"` runs against the default ClickHouse config
- [ ] `chkit query "SELECT count() FROM users" --service <name>` routes to that ObsessionDB service for the one query
- [ ] `--service <bogus>` errors with the list of available service names

🤖 Generated with [Claude Code](https://claude.com/claude-code)