### PR TITLE
Add user profile config fallback

### DIFF
--- a/.changeset/profile-config-fallback.md
+++ b/.changeset/profile-config-fallback.md
@@ -1,0 +1,6 @@
+---
+"chkit": minor
+"@chkit/plugin-obsessiondb": patch
+---
+
+Add user-profile config fallback so `chkit query` works from any directory without a local `clickhouse.config.ts`. When no project config is found in the current directory, chkit now looks for `~/.config/chkit/config.ts` (honoring `XDG_CONFIG_HOME`). If ObsessionDB credentials exist (`~/.config/chkit/credentials.json`), chkit synthesizes a minimal query-only config and loads the ObsessionDB plugin through an optional runtime import. ObsessionDB bootstrap commands such as `chkit obsessiondb login` can also run before credentials exist. Project-only commands (`generate`, `migrate`, `status`, `drift`, `check`, `codegen`, `pull`) still require a project config. The ObsessionDB plugin now persists the selected service to `~/.config/chkit/obsessiondb.json` when running in profile mode, and query errors now point users to `login`, `select-service`, or `--service` as appropriate.

--- a/.claude/skills/code-architecture/SKILL.md
+++ b/.claude/skills/code-architecture/SKILL.md
@@ -16,6 +16,8 @@ Apply these patterns when:
 ## Function Order (High-level to details)
 
 ```ts
+// Good — main entry near the top, details below
+
 // 1. Constants, types, schemas
 const CONFIG = { ... } as const
 type Options = { ... }
@@ -33,6 +35,24 @@ async function processData() { ... }
 // 4. Utilities
 function formatDate(date: Date) { ... }
 ```
+
+```ts
+// Bad — bottom-up ordering: utilities first, main entry buried at the bottom.
+// Compiles fine because of JS hoisting, but readers have to scroll past
+// internals before reaching the entry point. This is the most common
+// violation — it's the default ordering in a lot of JS/TS code, but it
+// inverts the reading order we want.
+
+function formatDate(date: Date) { ... }            // utility
+async function initialize() { ... }                // supporting
+async function processData() { ... }               // supporting
+export async function runTask() {                  // main, but readers hit it LAST
+  await initialize()
+  await processData()
+}
+```
+
+When reviewing a file: locate the main exported entry first. If it isn't near the top (after types/constants), the file is inverted — reorder it.
 
 ## Avoid Bloat Proxy Functions
 

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "resolve": {
+    "conditions": ["source", "bun"]
+  },
   "duplicates": {
     "ignore": [
       "packages/**/*.test.ts",

--- a/apps/docs/src/content/docs/cli/plugin.md
+++ b/apps/docs/src/content/docs/cli/plugin.md
@@ -42,18 +42,13 @@ Some plugins have top-level CLI shortcuts:
 
 ### Plugin registration
 
-Plugins are registered in the `plugins` array of `clickhouse.config.ts`. Two registration styles are supported:
+Plugins are registered inline in the `plugins` array of `clickhouse.config.ts`:
 
-1. **Typed inline** — import and call the plugin function directly:
-   ```ts
-   import { codegen } from '@chkit/plugin-codegen'
-   plugins: [codegen({ outFile: './types.ts' })]
-   ```
+```ts
+import { codegen } from '@chkit/plugin-codegen'
 
-2. **Legacy path-based** — specify a file path to resolve:
-   ```ts
-   plugins: [{ resolve: './plugins/my-plugin.ts', options: {} }]
-   ```
+plugins: [codegen({ outFile: './types.ts' })]
+```
 
 ### Plugin lifecycle hooks
 

--- a/apps/docs/src/content/docs/plugins/codegen.md
+++ b/apps/docs/src/content/docs/plugins/codegen.md
@@ -57,8 +57,6 @@ export default defineConfig({
 })
 ```
 
-Legacy path-based registration via `{ resolve: './plugins/codegen.ts', options: {...} }` remains supported.
-
 ## Options
 
 - `outFile` (default: `./src/generated/chkit-types.ts`)

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.14",
         "@changesets/cli": "^2.29.8",
-        "@chkit/plugin-backfill": "workspace:*",
         "@chkit/plugin-obsessiondb": "workspace:*",
         "@orpc/client": "1.13.4",
         "@orpc/contract": "1.13.4",

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/docs": {
       "name": "@chkit/docs",
-      "version": "0.0.2-beta.10",
+      "version": "0.0.2-beta.11",
       "dependencies": {
         "@astrojs/starlight": "^0.37.6",
         "astro": "^5.6.1",
@@ -32,7 +32,7 @@
     },
     "packages/cli": {
       "name": "chkit",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "bin": {
         "chkit": "./dist/bin/chkit.js",
       },
@@ -43,10 +43,13 @@
         "@logtape/logtape": "^2.0.5",
         "fast-glob": "^3.3.2",
       },
+      "optionalDependencies": {
+        "@chkit/plugin-obsessiondb": "workspace:*",
+      },
     },
     "packages/clickhouse": {
       "name": "@chkit/clickhouse",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "@clickhouse/client": "^1.11.0",
@@ -56,14 +59,14 @@
     },
     "packages/codegen": {
       "name": "@chkit/codegen",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "@chkit/core": "workspace:*",
       },
     },
     "packages/core": {
       "name": "@chkit/core",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "fast-glob": "^3.3.2",
       },
@@ -73,7 +76,7 @@
     },
     "packages/plugin-backfill": {
       "name": "@chkit/plugin-backfill",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -84,7 +87,7 @@
     },
     "packages/plugin-codegen": {
       "name": "@chkit/plugin-codegen",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "zod": "^4.3.6",
@@ -92,7 +95,7 @@
     },
     "packages/plugin-obsessiondb": {
       "name": "@chkit/plugin-obsessiondb",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -103,7 +106,7 @@
     },
     "packages/plugin-pull": {
       "name": "@chkit/plugin-pull",
-      "version": "0.1.0-beta.21",
+      "version": "0.1.0-beta.22",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",
     "@changesets/cli": "^2.29.8",
-    "@chkit/plugin-backfill": "workspace:*",
     "@chkit/plugin-obsessiondb": "workspace:*",
     "@orpc/client": "1.13.4",
     "@orpc/contract": "1.13.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,5 +44,8 @@
     "@chkit/codegen": "workspace:*",
     "@chkit/core": "workspace:*",
     "@logtape/logtape": "^2.0.5"
+  },
+  "optionalDependencies": {
+    "@chkit/plugin-obsessiondb": "workspace:*"
   }
 }

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -2,14 +2,7 @@
 import process from 'node:process'
 import type { ParsedFlags } from '@chkit/core'
 
-import { checkCommand } from '../commands/check/command.js'
-import { driftCommand } from '../commands/drift/command.js'
-import { generateCommand } from '../commands/generate/command.js'
 import { cmdInit } from '../commands/init.js'
-import { migrateCommand } from '../commands/migrate/command.js'
-import { pluginCommand } from '../commands/plugin.js'
-import { queryCommand } from '../commands/query.js'
-import { statusCommand } from '../commands/status.js'
 import { getInternalPlugins } from '../internal-plugins/index.js'
 import { parseCommandArgs, runResolvedCommand } from '../runtime/command-dispatch.js'
 import { createCommandRegistry } from '../runtime/command-registry.js'
@@ -36,16 +29,6 @@ const PROJECT_ONLY_COMMANDS = new Set([
   'codegen',
   'pull',
 ])
-
-const CORE_COMMANDS = [
-  generateCommand,
-  migrateCommand,
-  statusCommand,
-  driftCommand,
-  checkCommand,
-  queryCommand,
-  pluginCommand,
-]
 
 function firstPluginPositional(argv: string[]): string | undefined {
   const globalFlags = new Map<string, (typeof GLOBAL_FLAGS)[number]>(
@@ -156,7 +139,6 @@ async function run(): Promise<void> {
   })
 
   const registry = createCommandRegistry({
-    coreCommands: CORE_COMMANDS,
     globalFlags: GLOBAL_FLAGS,
     pluginExtensions: collectExtensions(pluginRuntime),
     pluginCommands: collectPluginCommands(pluginRuntime),
@@ -164,7 +146,13 @@ async function run(): Promise<void> {
 
   const resolved = registry.get(commandName)
   let initFlags: ParsedFlags = {}
-  if (resolved && !resolved.isPlugin && commandName !== 'plugin' && !argv.includes('--help') && !argv.includes('-h')) {
+  if (
+    resolved &&
+    !resolved.subcommands &&
+    commandName !== 'plugin' &&
+    !argv.includes('--help') &&
+    !argv.includes('-h')
+  ) {
     const parsed = parseCommandArgs(commandName, argv.slice(1), registry.resolveFlags(commandName))
     if (!parsed) return
     initFlags = parsed.flags
@@ -188,7 +176,7 @@ async function run(): Promise<void> {
 
   debug(
     'cli',
-    `command "${commandName}" resolved: ${resolved ? (resolved.isPlugin ? 'plugin' : 'core') : 'not found'}`,
+    `command "${commandName}" resolved: ${resolved ? `plugin (${resolved.pluginName ?? '?'})` : 'not found'}`,
   )
 
   try {
@@ -240,19 +228,27 @@ async function printGlobalHelp(argv: string[]): Promise<void> {
   let registry: ReturnType<typeof createCommandRegistry>
   try {
     const { config, path: configPath } = await loadConfig(configPathArg)
-    const pluginRuntime = await loadPluginRuntime({ config, configPath, cliVersion: CLI_VERSION })
+    const pluginRuntime = await loadPluginRuntime({
+      config,
+      configPath,
+      cliVersion: CLI_VERSION,
+      internalPlugins: getInternalPlugins(),
+    })
     registry = createCommandRegistry({
-      coreCommands: CORE_COMMANDS,
       globalFlags: GLOBAL_FLAGS,
       pluginExtensions: collectExtensions(pluginRuntime),
       pluginCommands: collectPluginCommands(pluginRuntime),
     })
   } catch {
+    const internal = getInternalPlugins()
     registry = createCommandRegistry({
-      coreCommands: CORE_COMMANDS,
       globalFlags: GLOBAL_FLAGS,
       pluginExtensions: [],
-      pluginCommands: [],
+      pluginCommands: internal.flatMap((plugin) => {
+        const commands = plugin.commands
+        if (!commands || commands.length === 0) return []
+        return [{ pluginName: plugin.manifest.name, commands, manifestName: plugin.manifest.name }]
+      }),
     })
   }
   console.log(formatGlobalHelp(registry, CLI_VERSION))

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -26,6 +26,16 @@ const WELL_KNOWN_PLUGIN_COMMANDS: Record<string, string> = {
   pull: 'Pull',
 }
 
+const PROJECT_ONLY_COMMANDS = new Set([
+  'generate',
+  'migrate',
+  'status',
+  'drift',
+  'check',
+  'codegen',
+  'pull',
+])
+
 const CORE_COMMANDS = [
   generateCommand,
   migrateCommand,
@@ -40,6 +50,11 @@ function extractConfigPath(argv: string[]): string | undefined {
   const idx = argv.indexOf('--config')
   if (idx === -1) return undefined
   return argv[idx + 1]
+}
+
+function allowsConfiglessObsessionDBBootstrap(commandName: string | undefined, argv: string[]): boolean {
+  if (commandName === 'obsessiondb') return true
+  return commandName === 'plugin' && argv[1] === 'obsessiondb'
 }
 
 function formatFatalError(error: unknown): string {
@@ -105,7 +120,20 @@ async function run(): Promise<void> {
   }
 
   const configPathArg = extractConfigPath(argv)
-  const { config, path: configPath } = await loadConfig(configPathArg)
+  const { config, path: configPath, source: configSource } = await loadConfig(configPathArg, {}, {
+    command: commandName,
+    allowSynthesizedProfileConfig: allowsConfiglessObsessionDBBootstrap(commandName, argv),
+  })
+
+  if (configSource !== 'project' && PROJECT_ONLY_COMMANDS.has(commandName)) {
+    console.error(
+      `Command "${commandName}" requires a project config (clickhouse.config.ts) in the current directory.\n` +
+        `You are running chkit from a user profile (no local config found).`,
+    )
+    process.exitCode = 1
+    return
+  }
+
   const pluginRuntime = await loadPluginRuntime({
     config,
     configPath,

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -15,6 +15,7 @@ import { parseCommandArgs, runResolvedCommand } from '../runtime/command-dispatc
 import { createCommandRegistry } from '../runtime/command-registry.js'
 import { loadConfig } from '../runtime/config.js'
 import { debug } from '../runtime/debug.js'
+import { extractConfigPath } from '../runtime/extract-config-path.js'
 import { GLOBAL_FLAGS } from '../runtime/global-flags.js'
 import { formatCommandHelp, formatGlobalHelp } from '../runtime/help.js'
 import { configureCliLogging } from '../runtime/logging.js'
@@ -46,15 +47,27 @@ const CORE_COMMANDS = [
   pluginCommand,
 ]
 
-function extractConfigPath(argv: string[]): string | undefined {
-  const idx = argv.indexOf('--config')
-  if (idx === -1) return undefined
-  return argv[idx + 1]
+function firstPluginPositional(argv: string[]): string | undefined {
+  const globalFlags = new Map<string, (typeof GLOBAL_FLAGS)[number]>(
+    GLOBAL_FLAGS.map((flag) => [flag.name, flag]),
+  )
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (!token) continue
+    const eqIdx = token.startsWith('--') ? token.indexOf('=') : -1
+    const name = eqIdx === -1 ? token : token.slice(0, eqIdx)
+    const flag = globalFlags.get(name)
+    if (flag) {
+      if (flag.type !== 'boolean' && eqIdx === -1) i += 1
+      continue
+    }
+    return token
+  }
 }
 
 function allowsConfiglessObsessionDBBootstrap(commandName: string | undefined, argv: string[]): boolean {
   if (commandName === 'obsessiondb') return true
-  return commandName === 'plugin' && argv[1] === 'obsessiondb'
+  return commandName === 'plugin' && firstPluginPositional(argv) === 'obsessiondb'
 }
 
 function formatFatalError(error: unknown): string {
@@ -120,7 +133,8 @@ async function run(): Promise<void> {
   }
 
   const configPathArg = extractConfigPath(argv)
-  const { config, path: configPath, source: configSource } = await loadConfig(configPathArg, {}, {
+  const env = { command: commandName, mode: process.env.NODE_ENV }
+  const { config, path: configPath, source: configSource } = await loadConfig(configPathArg, env, {
     command: commandName,
     allowSynthesizedProfileConfig: allowsConfiglessObsessionDBBootstrap(commandName, argv),
   })

--- a/packages/cli/src/commands/check/command.ts
+++ b/packages/cli/src/commands/check/command.ts
@@ -1,6 +1,7 @@
 import { mkdir } from 'node:fs/promises'
 
-import { typedFlags, type CommandDef, type CommandRunContext } from '../../plugins.js'
+import { typedFlags, type ChxPluginCommand } from '../../plugins.js'
+import { resolveDirs } from '../../runtime/config.js'
 import { debug } from '../../runtime/debug.js'
 import { GLOBAL_FLAGS } from '../../runtime/global-flags.js'
 import { emitJson } from '../../runtime/json-output.js'
@@ -18,108 +19,107 @@ import {
 
 const STRICT_FLAG = { name: '--strict', type: 'boolean', description: 'Enable all policy checks' } as const
 
-export const checkCommand: CommandDef = {
+export const checkCommand: ChxPluginCommand = {
   name: 'check',
   description: 'Run policy checks for CI and release gates',
   flags: [STRICT_FLAG],
-  run: cmdCheck,
-}
+  async run(context): Promise<undefined | number> {
+    const { flags, config, configPath, pluginRuntime, pluginContext } = context
+    const f = typedFlags(flags, [...GLOBAL_FLAGS, STRICT_FLAG] as const)
+    const strict = f['--strict'] === true
+    const jsonMode = f['--json'] === true
+    const tableSelector = f['--table']
+    const { migrationsDir, metaDir } = resolveDirs(config)
+    debug('check', `flags: strict=${strict}, json=${jsonMode}`)
+    await mkdir(migrationsDir, { recursive: true })
 
-async function cmdCheck(runCtx: CommandRunContext): Promise<void> {
-  const { flags, config, configPath, dirs, pluginRuntime, ctx } = runCtx
-  const f = typedFlags(flags, [...GLOBAL_FLAGS, STRICT_FLAG] as const)
-  const strict = f['--strict'] === true
-  const jsonMode = f['--json'] === true
-  const tableSelector = f['--table']
-  const { migrationsDir, metaDir } = dirs
-  debug('check', `flags: strict=${strict}, json=${jsonMode}`)
-  await mkdir(migrationsDir, { recursive: true })
-
-  if (!ctx.hasExecutor) {
-    throw new Error('clickhouse config is required for check (journal is stored in ClickHouse)')
-  }
-  const db = ctx.executor
-  const database = config.clickhouse?.database
-
-  const journalStore = createJournalStore(db)
-  const files = await listMigrations(migrationsDir)
-  const journal = await journalStore.readJournal()
-  const databaseMissing = journalStore.databaseMissing
-  const appliedNames = new Set(journal.applied.map((entry) => entry.name))
-  const pending = files.filter((file) => !appliedNames.has(file))
-  const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
-  const snapshot = await readSnapshot(metaDir)
-  const tableScope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot?.definitions ?? []))
-
-  if (tableScope.enabled && tableScope.matchCount === 0) {
-    const payload = {
-      strict,
-      ok: true,
-      failedChecks: [],
-      pendingCount: 0,
-      checksumMismatchCount: 0,
-      drifted: false,
-      driftEvaluated: false,
-      driftReasonCounts: {},
-      driftReasonTotals: { total: 0, object: 0, table: 0 },
-      plugins: {},
-      scope: tableScope,
-      warning: `No tables matched selector "${tableScope.selector ?? ''}".`,
+    if (!pluginContext.hasExecutor) {
+      throw new Error('clickhouse config is required for check (journal is stored in ClickHouse)')
     }
-    if (jsonMode) {
-      emitJson('check', payload)
-    } else {
-      console.log(`No tables matched selector "${tableScope.selector ?? ''}". Check is a no-op.`)
+    const db = pluginContext.executor
+    const database = config.clickhouse?.database
+
+    const journalStore = createJournalStore(db)
+    const files = await listMigrations(migrationsDir)
+    const journal = await journalStore.readJournal()
+    const databaseMissing = journalStore.databaseMissing
+    const appliedNames = new Set(journal.applied.map((entry) => entry.name))
+    const pending = files.filter((file) => !appliedNames.has(file))
+    const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
+    const snapshot = await readSnapshot(metaDir)
+    const tableScope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot?.definitions ?? []))
+
+    if (tableScope.enabled && tableScope.matchCount === 0) {
+      const payload = {
+        strict,
+        ok: true,
+        failedChecks: [],
+        pendingCount: 0,
+        checksumMismatchCount: 0,
+        drifted: false,
+        driftEvaluated: false,
+        driftReasonCounts: {},
+        driftReasonTotals: { total: 0, object: 0, table: 0 },
+        plugins: {},
+        scope: tableScope,
+        warning: `No tables matched selector "${tableScope.selector ?? ''}".`,
+      }
+      if (jsonMode) {
+        emitJson('check', payload)
+      } else {
+        console.log(`No tables matched selector "${tableScope.selector ?? ''}". Check is a no-op.`)
+      }
+      return 0
     }
-    return
-  }
 
-  const drift = snapshot ? await buildDriftPayload(config, metaDir, snapshot, tableScope, db) : null
-  const policy = resolvePolicy(strict, config.check)
+    const drift = snapshot ? await buildDriftPayload(config, metaDir, snapshot, tableScope, db) : null
+    const policy = resolvePolicy(strict, config.check)
 
-  await pluginRuntime.runOnConfigLoaded({
-    command: 'check',
-    config,
-    configPath,
-    tableScope,
-    flags,
-  })
-  const pluginResults = await pluginRuntime.runOnCheck({
-    command: 'check',
-    config,
-    configPath,
-    jsonMode,
-    tableScope,
-    flags,
-  })
-
-  const inputs: CheckInputs = {
-    strict,
-    policy,
-    pending,
-    checksumMismatches,
-    drift,
-    pluginResults,
-    tableScope,
-    databaseMissing,
-    database,
-  }
-  const result = evaluateCheck(inputs)
-
-  debug(
-    'check',
-    `results: pending=${pending.length}, checksumMismatches=${checksumMismatches.length}, drift=${drift?.drifted ?? 'n/a'}, pluginChecks=${pluginResults.length}, failedChecks=[${result.failedChecks.join(', ')}]`,
-  )
-
-  if (jsonMode) {
-    emitCheckJson(inputs, result)
-    return
-  }
-
-  renderCheckText(inputs, result)
-  if (pluginResults.length > 0) {
-    await pluginRuntime.runOnCheckReport(pluginResults, (line) => {
-      console.log(line)
+    await pluginRuntime.runOnConfigLoaded({
+      command: 'check',
+      config,
+      configPath,
+      tableScope,
+      flags,
     })
-  }
+    const pluginResults = await pluginRuntime.runOnCheck({
+      command: 'check',
+      config,
+      configPath,
+      jsonMode,
+      tableScope,
+      flags,
+    })
+
+    const inputs: CheckInputs = {
+      strict,
+      policy,
+      pending,
+      checksumMismatches,
+      drift,
+      pluginResults,
+      tableScope,
+      databaseMissing,
+      database,
+    }
+    const result = evaluateCheck(inputs)
+
+    debug(
+      'check',
+      `results: pending=${pending.length}, checksumMismatches=${checksumMismatches.length}, drift=${drift?.drifted ?? 'n/a'}, pluginChecks=${pluginResults.length}, failedChecks=[${result.failedChecks.join(', ')}]`,
+    )
+
+    if (jsonMode) {
+      emitCheckJson(inputs, result)
+      return 0
+    }
+
+    renderCheckText(inputs, result)
+    if (pluginResults.length > 0) {
+      await pluginRuntime.runOnCheckReport(pluginResults, (line) => {
+        console.log(line)
+      })
+    }
+    return 0
+  },
 }

--- a/packages/cli/src/commands/drift/command.ts
+++ b/packages/cli/src/commands/drift/command.ts
@@ -1,120 +1,120 @@
 import { join } from 'node:path'
 
-import { typedFlags, type CommandDef, type CommandRunContext } from '../../plugins.js'
+import { typedFlags, type ChxPluginCommand } from '../../plugins.js'
+import { resolveDirs } from '../../runtime/config.js'
 import { GLOBAL_FLAGS } from '../../runtime/global-flags.js'
 import { emitJson } from '../../runtime/json-output.js'
 import { readSnapshot } from '../../runtime/migration-store.js'
 import { resolveTableScope, tableKeysFromDefinitions } from '../../runtime/table-scope.js'
 import { buildDriftPayload, type DriftPayload } from './payload.js'
 
-export const driftCommand: CommandDef = {
+export const driftCommand: ChxPluginCommand = {
   name: 'drift',
   description: 'Compare snapshot state with current ClickHouse objects',
   flags: [],
-  run: cmdDrift,
-}
-
-async function cmdDrift(runCtx: CommandRunContext): Promise<void> {
-  const { flags, config, dirs, ctx } = runCtx
-  const f = typedFlags(flags, GLOBAL_FLAGS)
-  const tableSelector = f['--table']
-  const jsonMode = f['--json'] === true
-  const { metaDir } = dirs
-  const snapshot = await readSnapshot(metaDir)
-  if (!snapshot) {
-    throw new Error('Snapshot not found. Run `chkit generate` before drift checks.')
-  }
-  const scope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot.definitions))
-  if (scope.enabled && scope.matchCount === 0) {
-    const payload: DriftPayload = {
-      scope,
-      snapshotFile: join(metaDir, 'snapshot.json'),
-      expectedCount: 0,
-      actualCount: 0,
-      drifted: false,
-      missing: [],
-      extra: [],
-      kindMismatches: [],
-      objectDrift: [],
-      tableDrift: [],
+  async run(context): Promise<undefined | number> {
+    const { flags, config, pluginContext } = context
+    const f = typedFlags(flags, GLOBAL_FLAGS)
+    const tableSelector = f['--table']
+    const jsonMode = f['--json'] === true
+    const { metaDir } = resolveDirs(config)
+    const snapshot = await readSnapshot(metaDir)
+    if (!snapshot) {
+      throw new Error('Snapshot not found. Run `chkit generate` before drift checks.')
     }
+    const scope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot.definitions))
+    if (scope.enabled && scope.matchCount === 0) {
+      const payload: DriftPayload = {
+        scope,
+        snapshotFile: join(metaDir, 'snapshot.json'),
+        expectedCount: 0,
+        actualCount: 0,
+        drifted: false,
+        missing: [],
+        extra: [],
+        kindMismatches: [],
+        objectDrift: [],
+        tableDrift: [],
+      }
+      if (jsonMode) {
+        emitJson('drift', {
+          ...payload,
+          warning: `No tables matched selector "${scope.selector ?? ''}".`,
+        })
+        return 0
+      }
+      console.log(`No tables matched selector "${scope.selector ?? ''}". Drift check is a no-op.`)
+      return 0
+    }
+    if (!pluginContext.hasExecutor) {
+      throw new Error('clickhouse config is required for drift checks')
+    }
+    const payload = await buildDriftPayload(config, metaDir, snapshot, scope, pluginContext.executor)
+
     if (jsonMode) {
-      emitJson('drift', {
-        ...payload,
-        warning: `No tables matched selector "${scope.selector ?? ''}".`,
-      })
-      return
+      emitJson('drift', payload)
+      return 0
     }
-    console.log(`No tables matched selector "${scope.selector ?? ''}". Drift check is a no-op.`)
-    return
-  }
-  if (!ctx.hasExecutor) {
-    throw new Error('clickhouse config is required for drift checks')
-  }
-  const payload = await buildDriftPayload(config, metaDir, snapshot, scope, ctx.executor)
 
-  if (jsonMode) {
-    emitJson('drift', payload)
-    return
-  }
-
-  if (payload.databaseMissing) {
-    console.log(`\u26A0 Database "${payload.database ?? ''}" does not exist on the target server.`)
-    console.log('  It will be created when you run: chkit migrate --apply\n')
-  }
-
-  console.log(`Expected objects: ${payload.expectedCount}`)
-  console.log(`Actual objects:   ${payload.actualCount}`)
-  console.log(`Drifted:          ${payload.drifted ? 'yes' : 'no'}`)
-  if (payload.scope?.enabled) {
-    console.log(`Table scope:      ${payload.scope.selector ?? ''} (${payload.scope.matchCount} matched)`)
-    for (const table of payload.scope.matchedTables) console.log(`- ${table}`)
-  }
-  if (payload.missing.length > 0) {
-    console.log('\nMissing objects:')
-    for (const item of payload.missing) console.log(`- ${item}`)
-  }
-  if (payload.extra.length > 0) {
-    console.log('\nUnexpected objects:')
-    for (const item of payload.extra) console.log(`- ${item}`)
-  }
-  if (payload.kindMismatches.length > 0) {
-    console.log('\nKind mismatches:')
-    for (const item of payload.kindMismatches) {
-      console.log(`- ${item.object}: expected=${item.expected} actual=${item.actual}`)
+    if (payload.databaseMissing) {
+      console.log(`⚠ Database "${payload.database ?? ''}" does not exist on the target server.`)
+      console.log('  It will be created when you run: chkit migrate --apply\n')
     }
-  }
-  if (payload.objectDrift.length > 0) {
-    console.log('\nObject drift reasons:')
-    for (const item of payload.objectDrift) {
-      if (item.code === 'kind_mismatch') {
-        console.log(
-          `- ${item.code} ${item.object}: expected=${item.expectedKind ?? ''} actual=${item.actualKind ?? ''}`
-        )
-        continue
+
+    console.log(`Expected objects: ${payload.expectedCount}`)
+    console.log(`Actual objects:   ${payload.actualCount}`)
+    console.log(`Drifted:          ${payload.drifted ? 'yes' : 'no'}`)
+    if (payload.scope?.enabled) {
+      console.log(`Table scope:      ${payload.scope.selector ?? ''} (${payload.scope.matchCount} matched)`)
+      for (const table of payload.scope.matchedTables) console.log(`- ${table}`)
+    }
+    if (payload.missing.length > 0) {
+      console.log('\nMissing objects:')
+      for (const item of payload.missing) console.log(`- ${item}`)
+    }
+    if (payload.extra.length > 0) {
+      console.log('\nUnexpected objects:')
+      for (const item of payload.extra) console.log(`- ${item}`)
+    }
+    if (payload.kindMismatches.length > 0) {
+      console.log('\nKind mismatches:')
+      for (const item of payload.kindMismatches) {
+        console.log(`- ${item.object}: expected=${item.expected} actual=${item.actual}`)
       }
-      console.log(`- ${item.code} ${item.object}`)
     }
-  }
-  if (payload.tableDrift.length > 0) {
-    console.log('\nTable shape drift:')
-    for (const item of payload.tableDrift) {
-      console.log(`- ${item.table}`)
-      if (item.missingColumns.length > 0) console.log(`  missingColumns=${item.missingColumns.join(',')}`)
-      if (item.extraColumns.length > 0) console.log(`  extraColumns=${item.extraColumns.join(',')}`)
-      if (item.changedColumns.length > 0) console.log(`  changedColumns=${item.changedColumns.join(',')}`)
-      if (item.settingDiffs.length > 0) console.log(`  settingDiffs=${item.settingDiffs.join(',')}`)
-      if (item.indexDiffs.length > 0) console.log(`  indexDiffs=${item.indexDiffs.join(',')}`)
-      if (item.ttlMismatch) console.log('  ttlMismatch=true')
-      if (item.engineMismatch) console.log('  engineMismatch=true')
-      if (item.primaryKeyMismatch) console.log('  primaryKeyMismatch=true')
-      if (item.orderByMismatch) console.log('  orderByMismatch=true')
-      if (item.uniqueKeyMismatch) console.log('  uniqueKeyMismatch=true')
-      if (item.partitionByMismatch) console.log('  partitionByMismatch=true')
-      if (item.projectionDiffs.length > 0) {
-        console.log(`  projectionDiffs=${item.projectionDiffs.join(',')}`)
+    if (payload.objectDrift.length > 0) {
+      console.log('\nObject drift reasons:')
+      for (const item of payload.objectDrift) {
+        if (item.code === 'kind_mismatch') {
+          console.log(
+            `- ${item.code} ${item.object}: expected=${item.expectedKind ?? ''} actual=${item.actualKind ?? ''}`
+          )
+          continue
+        }
+        console.log(`- ${item.code} ${item.object}`)
       }
-      console.log(`  reasonCodes=${item.reasonCodes.join(',')}`)
     }
-  }
+    if (payload.tableDrift.length > 0) {
+      console.log('\nTable shape drift:')
+      for (const item of payload.tableDrift) {
+        console.log(`- ${item.table}`)
+        if (item.missingColumns.length > 0) console.log(`  missingColumns=${item.missingColumns.join(',')}`)
+        if (item.extraColumns.length > 0) console.log(`  extraColumns=${item.extraColumns.join(',')}`)
+        if (item.changedColumns.length > 0) console.log(`  changedColumns=${item.changedColumns.join(',')}`)
+        if (item.settingDiffs.length > 0) console.log(`  settingDiffs=${item.settingDiffs.join(',')}`)
+        if (item.indexDiffs.length > 0) console.log(`  indexDiffs=${item.indexDiffs.join(',')}`)
+        if (item.ttlMismatch) console.log('  ttlMismatch=true')
+        if (item.engineMismatch) console.log('  engineMismatch=true')
+        if (item.primaryKeyMismatch) console.log('  primaryKeyMismatch=true')
+        if (item.orderByMismatch) console.log('  orderByMismatch=true')
+        if (item.uniqueKeyMismatch) console.log('  uniqueKeyMismatch=true')
+        if (item.partitionByMismatch) console.log('  partitionByMismatch=true')
+        if (item.projectionDiffs.length > 0) {
+          console.log(`  projectionDiffs=${item.projectionDiffs.join(',')}`)
+        }
+        console.log(`  reasonCodes=${item.reasonCodes.join(',')}`)
+      }
+    }
+    return 0
+  },
 }

--- a/packages/cli/src/commands/generate/command.ts
+++ b/packages/cli/src/commands/generate/command.ts
@@ -76,6 +76,7 @@ async function cmdGenerate(ctx: import('../../plugins.js').ChxPluginCommandConte
     config,
     tableScope: resolveTableScope(tableSelector, tableKeysFromDefinitions(definitions)),
     flags,
+    jsonMode,
     definitions,
   })
 

--- a/packages/cli/src/commands/generate/command.ts
+++ b/packages/cli/src/commands/generate/command.ts
@@ -1,8 +1,8 @@
 import { generateArtifacts } from '@chkit/codegen'
-import process from 'node:process'
 import { ChxValidationError, planDiff } from '@chkit/core'
 
-import { defineFlags, typedFlags, type CommandDef, type CommandRunContext } from '../../plugins.js'
+import { defineFlags, typedFlags, type ChxPluginCommand } from '../../plugins.js'
+import { resolveDirs } from '../../runtime/config.js'
 import { GLOBAL_FLAGS } from '../../runtime/global-flags.js'
 import { emitJson } from '../../runtime/json-output.js'
 import { readSnapshot } from '../../runtime/migration-store.js'
@@ -43,15 +43,16 @@ const GENERATE_FLAGS = defineFlags([
   { name: '--dryrun', type: 'boolean', description: 'Print plan without writing artifacts' },
 ] as const)
 
-export const generateCommand: CommandDef = {
+export const generateCommand: ChxPluginCommand = {
   name: 'generate',
   description: 'Generate migration artifacts from schema definitions',
   flags: GENERATE_FLAGS,
   run: cmdGenerate,
 }
 
-async function cmdGenerate(ctx: CommandRunContext): Promise<void> {
-  const { flags, config, configPath, dirs, pluginRuntime } = ctx
+async function cmdGenerate(ctx: import('../../plugins.js').ChxPluginCommandContext): Promise<undefined | number> {
+  const { flags, config, configPath, pluginRuntime } = ctx
+  const dirs = resolveDirs(config)
   const f = typedFlags(flags, [...GLOBAL_FLAGS, ...GENERATE_FLAGS] as const)
   const migrationName = f['--name']
   const migrationId = f['--migration-id']
@@ -107,7 +108,7 @@ async function cmdGenerate(ctx: CommandRunContext): Promise<void> {
     } else {
       console.log(`No tables matched selector "${resolvedScope.selector ?? ''}". No changes planned.`)
     }
-    return
+    return 0
   }
 
   assertNoConflictingTableMappings(tableMappings)
@@ -132,8 +133,7 @@ async function cmdGenerate(ctx: CommandRunContext): Promise<void> {
           error: 'validation_failed',
           issues: error.issues,
         })
-        process.exitCode = 1
-        return
+        return 1
       }
 
       const details = error.issues.map((issue) => `- [${issue.code}] ${issue.message}`).join('\n')
@@ -164,7 +164,7 @@ async function cmdGenerate(ctx: CommandRunContext): Promise<void> {
 
   if (planMode) {
     emitGeneratePlanOutput(plan, jsonMode, resolvedScope)
-    return
+    return 0
   }
 
   const artifactDefinitions = resolvedScope.enabled
@@ -206,4 +206,5 @@ async function cmdGenerate(ctx: CommandRunContext): Promise<void> {
   }
 
   emitGenerateApplyOutput(result, artifactDefinitions, plan, jsonMode, resolvedScope)
+  return 0
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,7 +9,7 @@ export async function cmdInit(): Promise<void> {
 
   const wroteConfig = await writeIfMissing(
     configPath,
-    `import { defineConfig } from '@chkit/core'\n\nexport default defineConfig({\n  schema: './src/db/schema/**/*.ts',\n  outDir: './chkit',\n  migrationsDir: './chkit/migrations',\n  metaDir: './chkit/meta',\n  plugins: [\n    // Typed plugin registration (recommended):\n    // import { codegen } from '@chkit/plugin-codegen'\n    // codegen({ emitZod: true }),\n\n    // Legacy path-based registration (still supported):\n    // { resolve: './plugins/example-plugin.ts', options: {}, enabled: true },\n  ],\n  clickhouse: {\n    url: process.env.CLICKHOUSE_URL ?? 'http://localhost:8123',\n    username: process.env.CLICKHOUSE_USER ?? 'default',\n    password: process.env.CLICKHOUSE_PASSWORD ?? '',\n    database: process.env.CLICKHOUSE_DB ?? 'default',\n  },\n})\n`
+    `import { defineConfig } from '@chkit/core'\n\nexport default defineConfig({\n  schema: './src/db/schema/**/*.ts',\n  outDir: './chkit',\n  migrationsDir: './chkit/migrations',\n  metaDir: './chkit/meta',\n  plugins: [\n    // Register plugins inline. Example:\n    // import { codegen } from '@chkit/plugin-codegen'\n    // codegen({ emitZod: true }),\n  ],\n  clickhouse: {\n    url: process.env.CLICKHOUSE_URL ?? 'http://localhost:8123',\n    username: process.env.CLICKHOUSE_USER ?? 'default',\n    password: process.env.CLICKHOUSE_PASSWORD ?? '',\n    database: process.env.CLICKHOUSE_DB ?? 'default',\n  },\n})\n`
   )
 
   const wroteSchema = await writeIfMissing(

--- a/packages/cli/src/commands/migrate/command.ts
+++ b/packages/cli/src/commands/migrate/command.ts
@@ -1,7 +1,7 @@
 import { mkdir } from 'node:fs/promises'
-import process from 'node:process'
 
-import { defineFlags, typedFlags, type CommandDef, type CommandRunContext } from '../../plugins.js'
+import { defineFlags, typedFlags, type ChxPluginCommand } from '../../plugins.js'
+import { resolveDirs } from '../../runtime/config.js'
 import { GLOBAL_FLAGS } from '../../runtime/global-flags.js'
 import { emitJson } from '../../runtime/json-output.js'
 import { createJournalStore } from '../../runtime/journal-store.js'
@@ -33,28 +33,30 @@ const MIGRATE_FLAGS = defineFlags([
   { name: '--allow-destructive', type: 'boolean', description: 'Allow destructive migrations tagged with risk=danger' },
 ] as const)
 
-export const migrateCommand: CommandDef = {
+export const migrateCommand: ChxPluginCommand = {
   name: 'migrate',
   description: 'Review or execute pending migrations',
   flags: MIGRATE_FLAGS,
   run: cmdMigrate,
 }
 
-async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
-  const { flags, config, configPath, dirs, pluginRuntime, ctx } = runCtx
+async function cmdMigrate(
+  runCtx: import('../../plugins.js').ChxPluginCommandContext,
+): Promise<undefined | number> {
+  const { flags, config, configPath, pluginRuntime, pluginContext } = runCtx
   const f = typedFlags(flags, [...GLOBAL_FLAGS, ...MIGRATE_FLAGS] as const)
   const executeRequested = f['--apply'] === true || f['--execute'] === true
   const allowDestructive = f['--allow-destructive'] === true
   const tableSelector = f['--table']
   const jsonMode = f['--json'] === true
 
-  const { migrationsDir, metaDir } = dirs
+  const { migrationsDir, metaDir } = resolveDirs(config)
   debug('migrate', `flags: execute=${executeRequested}, allowDestructive=${allowDestructive}, json=${jsonMode}`)
 
-  if (!ctx.hasExecutor) {
+  if (!pluginContext.hasExecutor) {
     throw new Error('clickhouse config is required for migrate (journal is stored in ClickHouse)')
   }
-  const db = ctx.executor
+  const db = pluginContext.executor
   const journalStore = createJournalStore(db)
   const snapshot = await readSnapshot(metaDir)
   const tableScope = resolveTableScope(tableSelector, tableKeysFromDefinitions(snapshot?.definitions ?? []))
@@ -85,8 +87,7 @@ async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
         error: 'Checksum mismatch detected on applied migrations',
         checksumMismatches,
       })
-      process.exitCode = 1
-      return
+      return 1
     }
     throw new Error(
       `Checksum mismatch detected on applied migrations: ${checksumMismatches.map((item) => item.name).join(', ')}`,
@@ -105,7 +106,7 @@ async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
     } else {
       console.log(`No tables matched selector "${tableScope.selector ?? ''}". No migrations selected.`)
     }
-    return
+    return 0
   }
 
   const pending = tableScope.enabled
@@ -118,12 +119,12 @@ async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
     } else {
       console.log('No pending migrations.')
     }
-    return
+    return 0
   }
 
   if (jsonMode && !executeRequested) {
     emitJson('migrate', { mode, scope: tableScope, pending })
-    return
+    return 0
   }
 
   if (!jsonMode) {
@@ -140,13 +141,13 @@ async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
       if (!jsonMode) {
         console.log('\nPlan only. Re-run with --apply to apply and journal these migrations.')
       }
-      return
+      return 0
     }
 
     const confirmed = await confirmApply()
     if (!confirmed) {
       console.log('Migration apply cancelled by user.')
-      return
+      return 0
     }
   }
 
@@ -163,8 +164,7 @@ async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
         destructiveMigrations: destructive.migrations,
         destructiveOperations: destructive.operations,
       })
-      process.exitCode = 3
-      return
+      return 3
     }
 
     if (isBackgroundOrCI()) {
@@ -206,8 +206,9 @@ async function cmdMigrate(runCtx: CommandRunContext): Promise<void> {
 
   if (jsonMode) {
     emitJson('migrate', { mode: 'execute', scope: tableScope, applied: appliedNow })
-    return
+    return 0
   }
 
   console.log('\nMigrations recorded in ClickHouse _chkit_migrations table.')
+  return 0
 }

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -1,24 +1,24 @@
-import { typedFlags, type CommandDef, type CommandRunContext, type ParsedFlags } from '../plugins.js'
+import { typedFlags, type ChxPluginCommand, type ParsedFlags } from '../plugins.js'
 import { GLOBAL_FLAGS } from '../runtime/global-flags.js'
 import { emitJson, printOutput } from '../runtime/json-output.js'
 import { parseFlags, UnknownFlagError, MissingFlagValueError } from '@chkit/core'
 import { resolveTableScope, tableKeysFromDefinitions } from '../runtime/table-scope.js'
 import { loadSchemaDefinitions } from '../runtime/schema-loader.js'
 
-export const pluginCommand: CommandDef = {
+export const pluginCommand: ChxPluginCommand = {
   name: 'plugin',
   description: 'List plugins and run plugin namespace commands',
   flags: [],
   run: cmdPlugin,
 }
 
-async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
-  const { flags, positionals, config, configPath, pluginRuntime } = ctx
+async function cmdPlugin(ctx: import('../plugins.js').ChxPluginCommandContext): Promise<undefined | number> {
+  const { flags, args, config, configPath, pluginRuntime } = ctx
   const jsonMode = flags['--json'] === true
 
-  const pluginName = positionals[0]
-  const commandName = positionals[1]
-  const commandArgs = positionals.slice(2)
+  const pluginName = args[0]
+  const commandName = args[1]
+  const commandArgs = args.slice(2)
 
   if (pluginRuntime.plugins.length === 0) {
     if (jsonMode) {
@@ -26,8 +26,7 @@ async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
         error: 'No plugins configured. Add entries to config.plugins first.',
         plugins: [],
       })
-      process.exitCode = 1
-      return
+      return 1
     }
     throw new Error('No plugins configured. Add entries to config.plugins first.')
   }
@@ -46,7 +45,7 @@ async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
 
     if (jsonMode) {
       emitJson('plugin', payload)
-      return
+      return 0
     }
 
     console.log('Configured plugins:')
@@ -60,7 +59,7 @@ async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
         console.log(`  - ${command.name}${command.description ? `: ${command.description}` : ''}`)
       }
     }
-    return
+    return 0
   }
 
   const selectedPlugin = pluginRuntime.plugins.find(
@@ -85,19 +84,19 @@ async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
 
     if (jsonMode) {
       emitJson('plugin', payload)
-      return
+      return 0
     }
 
     if (commands.length === 0) {
       console.log(`Plugin "${selectedPlugin.plugin.manifest.name}" has no registered commands.`)
-      return
+      return 0
     }
 
     console.log(`Plugin commands for "${selectedPlugin.plugin.manifest.name}":`)
     for (const command of commands) {
       console.log(`- ${command.name}${command.description ? `: ${command.description}` : ''}`)
     }
-    return
+    return 0
   }
 
   const gf = typedFlags(flags, GLOBAL_FLAGS)
@@ -124,8 +123,7 @@ async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
         } else {
           console.error(error.message)
         }
-        process.exitCode = 1
-        return
+        return 1
       }
       throw error
     }
@@ -143,5 +141,5 @@ async function cmdPlugin(ctx: CommandRunContext): Promise<void> {
     },
   })
 
-  if (exitCode !== 0) process.exitCode = exitCode
+  return exitCode
 }

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -1,47 +1,46 @@
 import type { ClickHouseJsonQueryResult } from '@chkit/clickhouse'
-import type { CommandDef, CommandRunContext } from '../plugins.js'
+import type { ChxPluginCommand } from '../plugins.js'
 
 const DEFAULT_SHOWN_ROW_LIMIT = 25
 
-export const queryCommand: CommandDef = {
+export const queryCommand: ChxPluginCommand = {
 	name: 'query',
 	description: 'Run a SQL query against the configured target',
 	flags: [],
-	run: cmdQuery,
-}
+	async run(context): Promise<undefined | number> {
+		const { flags, args, pluginContext } = context
+		const jsonMode = flags['--json'] === true
 
-async function cmdQuery(runCtx: CommandRunContext): Promise<void> {
-	const { flags, positionals, ctx } = runCtx
-	const jsonMode = flags['--json'] === true
+		const sql = args[0]
+		if (!sql || sql.trim().length === 0) {
+			throw new Error(
+				'query requires a SQL string as the first positional argument (e.g. `chkit query "SELECT 1"`)',
+			)
+		}
+		if (args.length > 1) {
+			throw new Error(
+				'query accepts a single SQL string. Wrap it in quotes if it contains spaces.',
+			)
+		}
 
-	const sql = positionals[0]
-	if (!sql || sql.trim().length === 0) {
-		throw new Error(
-			'query requires a SQL string as the first positional argument (e.g. `chkit query "SELECT 1"`)',
-		)
-	}
-	if (positionals.length > 1) {
-		throw new Error(
-			'query accepts a single SQL string. Wrap it in quotes if it contains spaces.',
-		)
-	}
+		if (!pluginContext.hasExecutor) {
+			throw new Error(
+				'No target configured. Provide clickhouse settings in your config or install a plugin (e.g. obsessiondb) that supplies one.',
+			)
+		}
 
-	if (!ctx.hasExecutor) {
-		throw new Error(
-			'No target configured. Provide clickhouse settings in your config or install a plugin (e.g. obsessiondb) that supplies one.',
-		)
-	}
+		if (jsonMode) {
+			const payload = pluginContext.executor.queryJson
+				? await pluginContext.executor.queryJson(sql)
+				: rowsToJsonResult(await pluginContext.executor.query<Record<string, unknown>>(sql))
+			printQueryJson(payload)
+			return 0
+		}
 
-	if (jsonMode) {
-		const payload = ctx.executor.queryJson
-			? await ctx.executor.queryJson(sql)
-			: rowsToJsonResult(await ctx.executor.query<Record<string, unknown>>(sql))
-		printQueryJson(payload)
-		return
-	}
-
-	const rows = await ctx.executor.query<Record<string, unknown>>(sql)
-	printRows(rows)
+		const rows = await pluginContext.executor.query<Record<string, unknown>>(sql)
+		printRows(rows)
+		return 0
+	},
 }
 
 function printQueryJson(payload: ClickHouseJsonQueryResult): void {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,72 +1,72 @@
 import { mkdir } from 'node:fs/promises'
 
-import type { CommandDef, CommandRunContext } from '../plugins.js'
+import type { ChxPluginCommand } from '../plugins.js'
+import { resolveDirs } from '../runtime/config.js'
 import { debug } from '../runtime/debug.js'
 import { emitJson } from '../runtime/json-output.js'
 import { createJournalStore } from '../runtime/journal-store.js'
 import { findChecksumMismatches, listMigrations } from '../runtime/migration-store.js'
 
-export const statusCommand: CommandDef = {
+export const statusCommand: ChxPluginCommand = {
   name: 'status',
   description: 'Show migration status and checksum mismatch information',
   flags: [],
-  run: cmdStatus,
-}
+  async run(context): Promise<undefined | number> {
+    const { flags, config, pluginContext } = context
+    const jsonMode = flags['--json'] === true
+    const { migrationsDir } = resolveDirs(config)
 
-async function cmdStatus(runCtx: CommandRunContext): Promise<void> {
-  const { flags, config, dirs, ctx } = runCtx
-  const jsonMode = flags['--json'] === true
-  const { migrationsDir } = dirs
+    if (!pluginContext.hasExecutor) {
+      throw new Error('clickhouse config is required for status (journal is stored in ClickHouse)')
+    }
+    const db = pluginContext.executor
+    const database = config.clickhouse?.database
+    const journalStore = createJournalStore(db)
 
-  if (!ctx.hasExecutor) {
-    throw new Error('clickhouse config is required for status (journal is stored in ClickHouse)')
-  }
-  const db = ctx.executor
-  const database = config.clickhouse?.database
-  const journalStore = createJournalStore(db)
+    await mkdir(migrationsDir, { recursive: true })
+    const files = await listMigrations(migrationsDir)
+    const journal = await journalStore.readJournal()
+    const appliedNames = new Set(journal.applied.map((entry) => entry.name))
+    const pending = files.filter((f) => !appliedNames.has(f))
+    const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
 
-  await mkdir(migrationsDir, { recursive: true })
-  const files = await listMigrations(migrationsDir)
-  const journal = await journalStore.readJournal()
-  const appliedNames = new Set(journal.applied.map((entry) => entry.name))
-  const pending = files.filter((f) => !appliedNames.has(f))
-  const checksumMismatches = await findChecksumMismatches(migrationsDir, journal)
+    debug('status', `files=${files.length}, applied=${journal.applied.length}, pending=${pending.length}, checksumMismatches=${checksumMismatches.length}`)
 
-  debug('status', `files=${files.length}, applied=${journal.applied.length}, pending=${pending.length}, checksumMismatches=${checksumMismatches.length}`)
+    const databaseMissing = journalStore.databaseMissing
+    const payload = {
+      migrationsDir,
+      total: files.length,
+      applied: journal.applied.length,
+      pending: pending.length,
+      pendingMigrations: pending,
+      checksumMismatchCount: checksumMismatches.length,
+      checksumMismatches,
+      ...(databaseMissing ? { databaseMissing: true, database } : {}),
+    }
 
-  const databaseMissing = journalStore.databaseMissing
-  const payload = {
-    migrationsDir,
-    total: files.length,
-    applied: journal.applied.length,
-    pending: pending.length,
-    pendingMigrations: pending,
-    checksumMismatchCount: checksumMismatches.length,
-    checksumMismatches,
-    ...(databaseMissing ? { databaseMissing: true, database } : {}),
-  }
+    if (jsonMode) {
+      emitJson('status', payload)
+      return 0
+    }
 
-  if (jsonMode) {
-    emitJson('status', payload)
-    return
-  }
+    if (databaseMissing) {
+      console.log(`⚠ Database "${database ?? ''}" does not exist on the target server.`)
+      console.log('  It will be created when you run: chkit migrate --apply\n')
+    }
 
-  if (databaseMissing) {
-    console.log(`\u26A0 Database "${database ?? ''}" does not exist on the target server.`)
-    console.log('  It will be created when you run: chkit migrate --apply\n')
-  }
+    console.log(`Migrations directory: ${migrationsDir}`)
+    console.log(`Total migrations:     ${files.length}`)
+    console.log(`Applied:              ${journal.applied.length}`)
+    console.log(`Pending:              ${pending.length}`)
 
-  console.log(`Migrations directory: ${migrationsDir}`)
-  console.log(`Total migrations:     ${files.length}`)
-  console.log(`Applied:              ${journal.applied.length}`)
-  console.log(`Pending:              ${pending.length}`)
-
-  if (pending.length > 0) {
-    console.log('\nPending migrations:')
-    for (const item of pending) console.log(`- ${item}`)
-  }
-  if (checksumMismatches.length > 0) {
-    console.log('\nChecksum mismatches on applied migrations:')
-    for (const item of checksumMismatches) console.log(`- ${item.name}`)
-  }
+    if (pending.length > 0) {
+      console.log('\nPending migrations:')
+      for (const item of pending) console.log(`- ${item}`)
+    }
+    if (checksumMismatches.length > 0) {
+      console.log('\nChecksum mismatches on applied migrations:')
+      for (const item of checksumMismatches) console.log(`- ${item.name}`)
+    }
+    return 0
+  },
 }

--- a/packages/cli/src/internal-plugins/core/plugin.ts
+++ b/packages/cli/src/internal-plugins/core/plugin.ts
@@ -1,0 +1,21 @@
+import { checkCommand } from '../../commands/check/command.js'
+import { driftCommand } from '../../commands/drift/command.js'
+import { generateCommand } from '../../commands/generate/command.js'
+import { migrateCommand } from '../../commands/migrate/command.js'
+import { pluginCommand } from '../../commands/plugin.js'
+import { queryCommand } from '../../commands/query.js'
+import { statusCommand } from '../../commands/status.js'
+import { definePlugin } from '../../plugins.js'
+
+export const corePlugin = definePlugin({
+  manifest: { name: 'core', apiVersion: 1 },
+  commands: [
+    generateCommand,
+    migrateCommand,
+    statusCommand,
+    driftCommand,
+    checkCommand,
+    queryCommand,
+    pluginCommand,
+  ],
+})

--- a/packages/cli/src/internal-plugins/index.ts
+++ b/packages/cli/src/internal-plugins/index.ts
@@ -1,7 +1,8 @@
 import type { ChxPlugin } from '../plugins.js'
 
+import { corePlugin } from './core/plugin.js'
 import { createSkillHintPlugin } from './skill-hint/plugin.js'
 
 export function getInternalPlugins(): ChxPlugin[] {
-  return [createSkillHintPlugin()]
+  return [corePlugin, createSkillHintPlugin()]
 }

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -140,6 +140,7 @@ export interface ChxOnConfigLoadedContext extends ChxPluginHookContextBase {
 }
 
 export interface ChxOnSchemaLoadedContext extends ChxPluginHookContextBase {
+  jsonMode?: boolean
   definitions: SchemaDefinition[]
 }
 
@@ -244,7 +245,7 @@ export interface ChxPluginCommand<TOptions = Record<string, unknown>> {
 export interface ChxPluginHooks {
   getContext?: (
     input: ChxGetContextInput
-  ) => PluginContext | Partial<PluginContext> | void | Promise<PluginContext | Partial<PluginContext> | void>
+  ) => PluginContext | Partial<PluginContext> | undefined | Promise<PluginContext | Partial<PluginContext> | undefined>
   onInit?: (context: ChxOnInitContext) => void | Promise<void>
   onComplete?: (context: ChxOnCompleteContext) => void | Promise<void>
   onBeforePluginCommand?: (

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -1,10 +1,10 @@
 import type {
-  ChxInlinePluginRegistration,
-  ChxPluginRegistration,
   FlagDef,
+  FlagMapping,
   MigrationPlan,
   ParsedFlags,
   ResolvedChxConfig,
+  SafeParseable,
   SchemaDefinition,
 } from '@chkit/core'
 import type { ClickHouseExecutor } from '@chkit/clickhouse'
@@ -16,8 +16,10 @@ export {
   MissingFlagValueError,
   UnknownFlagError,
   type FlagDef,
+  type FlagMapping,
   type InferFlags,
   type ParsedFlags,
+  type SafeParseable,
 } from '@chkit/core'
 
 export interface TableScope {
@@ -29,6 +31,7 @@ export interface TableScope {
 
 export interface LoadedPlugin {
   options: Record<string, unknown>
+  rawOptions: Record<string, unknown>
   plugin: ChxPlugin
 }
 
@@ -86,7 +89,7 @@ export interface PluginRuntime {
     commandName: string,
     context: Omit<
       ChxPluginCommandContext,
-      'pluginName' | 'options' | 'tableScope'
+      'pluginName' | 'options' | 'rawOptions' | 'tableScope' | 'pluginRuntime' | 'pluginContext'
     > & {
       tableScope?: TableScope
     },
@@ -105,24 +108,6 @@ export interface ChxGetContextInput {
   command: string
   flags: ParsedFlags
   defaults: PluginContext
-}
-
-export interface CommandDef {
-  name: string
-  description: string
-  flags: readonly FlagDef[]
-  run: (ctx: CommandRunContext) => Promise<void>
-}
-
-export interface CommandRunContext {
-  command: string
-  flags: ParsedFlags
-  positionals: string[]
-  config: ResolvedChxConfig
-  configPath: string
-  dirs: { outDir: string; migrationsDir: string; metaDir: string }
-  pluginRuntime: PluginRuntime
-  ctx: PluginContext
 }
 
 export interface CommandExtension {
@@ -230,23 +215,30 @@ export type ChxOnBeforePluginCommandResult =
   | { handled: true; exitCode: number }
   | { handled: false }
 
-export interface ChxPluginCommandContext {
+export interface ChxPluginCommandContext<TOptions = Record<string, unknown>> {
   pluginName: string
   config: ResolvedChxConfig
   configPath: string
   jsonMode: boolean
   args: string[]
   flags: ParsedFlags
-  options: Record<string, unknown>
+  options: TOptions
+  rawOptions: Record<string, unknown>
   tableScope: TableScope
   print: (value: unknown) => void
+  pluginRuntime: PluginRuntime
+  pluginContext: PluginContext
 }
 
-export interface ChxPluginCommand {
+export interface ChxPluginCommand<TOptions = Record<string, unknown>> {
   name: string
   description?: string
   flags?: readonly FlagDef[]
-  run: (context: ChxPluginCommandContext) => undefined | number | Promise<undefined | number>
+  optionsSchema?: SafeParseable<TOptions>
+  flagMapping?: FlagMapping
+  run: (
+    context: ChxPluginCommandContext<TOptions>,
+  ) => undefined | number | Promise<undefined | number>
 }
 
 export interface ChxPluginHooks {
@@ -281,6 +273,7 @@ export interface ChxPluginHooks {
 
 export interface ChxPlugin {
   manifest: ChxPluginManifest
+  optionsSchema?: SafeParseable<Record<string, unknown>>
   hooks?: ChxPluginHooks
   commands?: ChxPluginCommand[]
   extendCommands?: CommandExtension[]
@@ -288,18 +281,4 @@ export interface ChxPlugin {
 
 export function definePlugin(plugin: ChxPlugin): ChxPlugin {
   return plugin
-}
-
-export function definePluginConfig<TOptions extends object = Record<string, unknown>>(
-  registration: Omit<ChxInlinePluginRegistration<ChxPlugin, TOptions>, 'plugin'> & {
-    plugin: ChxPlugin
-  }
-): ChxInlinePluginRegistration<ChxPlugin, TOptions> {
-  return registration
-}
-
-export function isInlinePluginRegistration(
-  registration: ChxPluginRegistration
-): registration is ChxInlinePluginRegistration<ChxPlugin> {
-  return typeof registration === 'object' && registration !== null && 'plugin' in registration
 }

--- a/packages/cli/src/runtime/command-dispatch.ts
+++ b/packages/cli/src/runtime/command-dispatch.ts
@@ -8,7 +8,6 @@ import {
 
 import { typedFlags, type PluginRuntime } from '../plugins.js'
 import type { CommandRegistry, RegisteredCommand } from './command-registry.js'
-import { resolveDirs } from './config.js'
 import { debug } from './debug.js'
 import { GLOBAL_FLAGS } from './global-flags.js'
 import { printOutput } from './json-output.js'
@@ -34,7 +33,6 @@ function extractPositionals(
 		const name = eqIdx === -1 ? token : token.slice(0, eqIdx)
 		const def = byName.get(name)
 		if (def && def.type !== 'boolean' && eqIdx === -1) {
-			// Consume the value following a string/string[] flag in space form
 			i += 1
 		}
 	}
@@ -170,7 +168,7 @@ async function resolvePluginTableScope(input: {
 	}
 }
 
-async function runPluginCommand(input: {
+export async function runResolvedCommand(input: {
 	argv: string[]
 	commandName: string
 	resolved: RegisteredCommand
@@ -180,6 +178,7 @@ async function runPluginCommand(input: {
 	pluginRuntime: PluginRuntime
 	onAmbiguousPluginSubcommand?: () => void
 }): Promise<void> {
+	debug('dispatch', `routing to plugin command "${input.commandName}"`)
 	const argsAfterCommand = input.argv.slice(1)
 	let subcommandName: string | undefined
 
@@ -197,12 +196,34 @@ async function runPluginCommand(input: {
 		}
 	}
 
-	const allPluginFlags = input.registry.resolveFlags(
-		input.commandName,
-		subcommandName,
-	)
-	const flags = parseFlagsOrReport(argsAfterCommand, allPluginFlags)
-	if (!flags) return
+	const isPluginCommandForwarder = input.commandName === 'plugin'
+	const isQuery = input.commandName === 'query'
+
+	let flags: ParsedFlags
+	let positionals: string[] = []
+
+	if (isPluginCommandForwarder) {
+		// The plugin command forwards unparsed args to a target plugin command,
+		// so we only strip known global flags and pass the rest through.
+		const { jsonMode, tableSelector, rest } = stripGlobalFlags(argsAfterCommand)
+		const parsed: ParsedFlags = {}
+		if (jsonMode) parsed['--json'] = true
+		if (tableSelector) parsed['--table'] = tableSelector
+		flags = parsed
+		positionals = rest
+	} else {
+		const allFlags = input.registry.resolveFlags(input.commandName, subcommandName)
+		if (isQuery) {
+			const parsed = parseCommandArgs(input.commandName, argsAfterCommand, allFlags)
+			if (!parsed) return
+			flags = parsed.flags
+			positionals = parsed.positionals
+		} else {
+			const parsedFlags = parseFlagsOrReport(argsAfterCommand, allFlags)
+			if (!parsedFlags) return
+			flags = parsedFlags
+		}
+	}
 
 	const gf = typedFlags(flags, GLOBAL_FLAGS)
 	const jsonMode = gf['--json'] === true
@@ -241,7 +262,7 @@ async function runPluginCommand(input: {
 			configPath: input.configPath,
 			jsonMode,
 			tableScope,
-			args: [],
+			args: positionals,
 			flags,
 			print(value) {
 				printOutput(value, jsonMode)
@@ -250,84 +271,4 @@ async function runPluginCommand(input: {
 	)
 
 	if (exitCode !== 0) process.exitCode = exitCode
-}
-
-function parseArgsForCoreCommand(input: {
-	commandName: string
-	argv: string[]
-	registry: CommandRegistry
-}): { flags: ParsedFlags; positionals: string[] } | null {
-	const argsAfterCommand = input.argv.slice(1)
-
-	if (input.commandName === 'plugin') {
-		// The `plugin` command forwards unparsed args to a target plugin command,
-		// so we can't use parseFlags here — only strip the known global flags
-		// and pass the rest through as positionals.
-		const { jsonMode, tableSelector, rest } = stripGlobalFlags(argsAfterCommand)
-		const flags: ParsedFlags = {}
-		if (jsonMode) flags['--json'] = true
-		if (tableSelector) flags['--table'] = tableSelector
-		return { flags, positionals: rest }
-	}
-
-	const allFlags = input.registry.resolveFlags(input.commandName)
-	return parseCommandArgs(input.commandName, argsAfterCommand, allFlags)
-}
-
-async function runCoreOrBuiltinCommand(input: {
-	argv: string[]
-	commandName: string
-	resolved: RegisteredCommand
-	registry: CommandRegistry
-	config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
-	configPath: string
-	pluginRuntime: PluginRuntime
-}): Promise<void> {
-	const parsed = parseArgsForCoreCommand(input)
-	if (!parsed) return
-	const { flags, positionals } = parsed
-
-	if (!input.resolved.run)
-		throw new Error(`Command '${input.commandName}' has no run handler`)
-
-	const dirs = resolveDirs(input.config)
-	const ctx = await input.pluginRuntime.resolveContext({
-		config: input.config,
-		configPath: input.configPath,
-		command: input.commandName,
-		flags,
-	})
-	try {
-		await input.resolved.run({
-			command: input.commandName,
-			flags,
-			positionals,
-			config: input.config,
-			configPath: input.configPath,
-			dirs,
-			pluginRuntime: input.pluginRuntime,
-			ctx,
-		})
-	} finally {
-		await input.pluginRuntime.disposeContext(ctx)
-	}
-}
-
-export async function runResolvedCommand(input: {
-	argv: string[]
-	commandName: string
-	resolved: RegisteredCommand
-	registry: CommandRegistry
-	config: Parameters<PluginRuntime['runOnConfigLoaded']>[0]['config']
-	configPath: string
-	pluginRuntime: PluginRuntime
-	onAmbiguousPluginSubcommand?: () => void
-}): Promise<void> {
-	if (input.resolved.isPlugin && !input.resolved.run) {
-		debug('dispatch', `routing to plugin command "${input.commandName}"`)
-		await runPluginCommand(input)
-		return
-	}
-	debug('dispatch', `routing to core command "${input.commandName}"`)
-	await runCoreOrBuiltinCommand(input)
 }

--- a/packages/cli/src/runtime/command-dispatch.ts
+++ b/packages/cli/src/runtime/command-dispatch.ts
@@ -30,9 +30,11 @@ function extractPositionals(
 			positionals.push(token)
 			continue
 		}
-		const def = byName.get(token)
-		if (def && def.type !== 'boolean') {
-			// Consume the value following a string/string[] flag
+		const eqIdx = token.indexOf('=')
+		const name = eqIdx === -1 ? token : token.slice(0, eqIdx)
+		const def = byName.get(name)
+		if (def && def.type !== 'boolean' && eqIdx === -1) {
+			// Consume the value following a string/string[] flag in space form
 			i += 1
 		}
 	}
@@ -59,14 +61,16 @@ function splitQueryArgs(
 			break
 		}
 
-		const def = byName.get(token)
+		const eqIdx = token.startsWith('--') ? token.indexOf('=') : -1
+		const name = eqIdx === -1 ? token : token.slice(0, eqIdx)
+		const def = byName.get(name)
 		if (!def) {
 			positionals.push(token)
 			continue
 		}
 
 		flagArgs.push(token)
-		if (def.type !== 'boolean') {
+		if (def.type !== 'boolean' && eqIdx === -1) {
 			const next = argv[i + 1]
 			if (next !== undefined) {
 				flagArgs.push(next)
@@ -114,9 +118,16 @@ function stripGlobalFlags(argv: string[]): {
 			i++
 			continue
 		}
+		if (token.startsWith('--config=')) {
+			continue
+		}
 		if (token === '--table' && i + 1 < argv.length) {
 			tableSelector = argv[i + 1]
 			i++
+			continue
+		}
+		if (token.startsWith('--table=')) {
+			tableSelector = token.slice('--table='.length)
 			continue
 		}
 		rest.push(token)

--- a/packages/cli/src/runtime/command-dispatch.ts
+++ b/packages/cli/src/runtime/command-dispatch.ts
@@ -232,27 +232,29 @@ export async function runResolvedCommand(input: {
 		tableSelector: gf['--table'],
 	})
 
-	try {
-		await input.pluginRuntime.runOnConfigLoaded({
-			command: input.commandName,
-			config: input.config,
-			configPath: input.configPath,
-			tableScope,
-			flags,
-		})
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
-		if (jsonMode) {
-			console.log(JSON.stringify({ ok: false, error: message }))
-		} else {
-			console.error(message)
-		}
-		process.exitCode = 2
-		return
-	}
-
 	const pluginName = input.resolved.pluginName ?? input.commandName
 	const pluginCommandName = subcommandName ?? input.commandName
+
+	if (pluginName !== 'core') {
+		try {
+			await input.pluginRuntime.runOnConfigLoaded({
+				command: input.commandName,
+				config: input.config,
+				configPath: input.configPath,
+				tableScope,
+				flags,
+			})
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			if (jsonMode) {
+				console.log(JSON.stringify({ ok: false, error: message }))
+			} else {
+				console.error(message)
+			}
+			process.exitCode = 2
+			return
+		}
+	}
 
 	const exitCode = await input.pluginRuntime.runPluginCommand(
 		pluginName,

--- a/packages/cli/src/runtime/command-registry.ts
+++ b/packages/cli/src/runtime/command-registry.ts
@@ -1,14 +1,12 @@
-import type { ChxPluginCommand, CommandDef, CommandExtension, FlagDef } from '../plugins.js'
+import type { ChxPluginCommand, CommandExtension, FlagDef } from '../plugins.js'
 
 export interface RegisteredCommand {
   name: string
   description: string
   flags: readonly FlagDef[]
   pluginFlags: Array<{ pluginName: string; flags: readonly FlagDef[] }>
-  isPlugin: boolean
   pluginName?: string
   subcommands?: RegisteredCommand[]
-  run: CommandDef['run'] | null
 }
 
 export interface CommandRegistry {
@@ -18,8 +16,9 @@ export interface CommandRegistry {
   resolveFlags(name: string, subcommand?: string): FlagDef[]
 }
 
+const FLATTEN_PLUGIN_NAMES = new Set(['core'])
+
 export function createCommandRegistry(input: {
-  coreCommands: CommandDef[]
   globalFlags: readonly FlagDef[]
   pluginExtensions: Array<{ pluginName: string; extensions: CommandExtension[] }>
   pluginCommands: Array<{ pluginName: string; commands: ChxPluginCommand[]; manifestName: string }>
@@ -27,17 +26,45 @@ export function createCommandRegistry(input: {
   const commands: RegisteredCommand[] = []
   const byName = new Map<string, RegisteredCommand>()
 
-  for (const cmd of input.coreCommands) {
-    const registered: RegisteredCommand = {
+  for (const { pluginName, commands: pluginCmds, manifestName } of input.pluginCommands) {
+    if (pluginCmds.length === 0) continue
+
+    const flatten =
+      FLATTEN_PLUGIN_NAMES.has(manifestName) ||
+      (pluginCmds.length === 1 && pluginCmds[0]?.name === manifestName)
+
+    if (flatten) {
+      for (const cmd of pluginCmds) {
+        const registered: RegisteredCommand = {
+          name: cmd.name,
+          description: cmd.description ?? '',
+          flags: cmd.flags ?? [],
+          pluginFlags: [],
+          pluginName,
+        }
+        commands.push(registered)
+        byName.set(cmd.name, registered)
+      }
+      continue
+    }
+
+    const subcommands: RegisteredCommand[] = pluginCmds.map((cmd) => ({
       name: cmd.name,
-      description: cmd.description,
-      flags: cmd.flags,
+      description: cmd.description ?? '',
+      flags: cmd.flags ?? [],
       pluginFlags: [],
-      isPlugin: false,
-      run: cmd.run,
+      pluginName,
+    }))
+    const registered: RegisteredCommand = {
+      name: pluginName,
+      description: `Plugin: ${pluginName}`,
+      flags: [],
+      pluginFlags: [],
+      pluginName,
+      subcommands,
     }
     commands.push(registered)
-    byName.set(cmd.name, registered)
+    byName.set(pluginName, registered)
   }
 
   for (const { pluginName, extensions } of input.pluginExtensions) {
@@ -49,45 +76,6 @@ export function createCommandRegistry(input: {
           cmd.pluginFlags.push({ pluginName, flags: ext.flags })
         }
       }
-    }
-  }
-
-  for (const { pluginName, commands: pluginCmds, manifestName } of input.pluginCommands) {
-    if (pluginCmds.length === 1 && pluginCmds[0]?.name === manifestName) {
-      const cmd = pluginCmds[0]
-      const registered: RegisteredCommand = {
-        name: manifestName,
-        description: cmd.description ?? '',
-        flags: cmd.flags ?? [],
-        pluginFlags: [],
-        isPlugin: true,
-        pluginName,
-        run: null,
-      }
-      commands.push(registered)
-      byName.set(manifestName, registered)
-    } else if (pluginCmds.length > 0) {
-      const subcommands: RegisteredCommand[] = pluginCmds.map((cmd) => ({
-        name: cmd.name,
-        description: cmd.description ?? '',
-        flags: cmd.flags ?? [],
-        pluginFlags: [],
-        isPlugin: true,
-        pluginName,
-        run: null,
-      }))
-      const registered: RegisteredCommand = {
-        name: pluginName,
-        description: `Plugin: ${pluginName}`,
-        flags: [],
-        pluginFlags: [],
-        isPlugin: true,
-        pluginName,
-        subcommands,
-        run: null,
-      }
-      commands.push(registered)
-      byName.set(pluginName, registered)
     }
   }
 

--- a/packages/cli/src/runtime/config-merge.ts
+++ b/packages/cli/src/runtime/config-merge.ts
@@ -1,5 +1,3 @@
-import { basename } from 'node:path'
-
 import type {
   ChxPluginRegistration,
   ChxUserClickHouseConfig,
@@ -10,31 +8,15 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function stripExt(name: string): string {
-  return name.replace(/\.[^./\\]+$/, '')
-}
-
 export function pluginNameOf(reg: ChxPluginRegistration): string | undefined {
-  if (typeof reg === 'string') {
-    const last = basename(reg)
-    return last ? stripExt(last) : undefined
-  }
   if (!isObject(reg)) return undefined
-  if ('plugin' in reg) {
-    if (typeof reg.name === 'string' && reg.name.length > 0) return reg.name
-    const plugin = (reg as { plugin?: unknown }).plugin
-    if (isObject(plugin)) {
-      const manifest = (plugin as { manifest?: unknown }).manifest
-      if (isObject(manifest) && typeof manifest.name === 'string' && manifest.name.length > 0) {
-        return manifest.name
-      }
-    }
-    return undefined
-  }
   if (typeof reg.name === 'string' && reg.name.length > 0) return reg.name
-  if (typeof reg.resolve === 'string' && reg.resolve.length > 0) {
-    const last = basename(reg.resolve)
-    return last ? stripExt(last) : undefined
+  const plugin = (reg as { plugin?: unknown }).plugin
+  if (isObject(plugin)) {
+    const manifest = (plugin as { manifest?: unknown }).manifest
+    if (isObject(manifest) && typeof manifest.name === 'string' && manifest.name.length > 0) {
+      return manifest.name
+    }
   }
   return undefined
 }

--- a/packages/cli/src/runtime/config-merge.ts
+++ b/packages/cli/src/runtime/config-merge.ts
@@ -1,0 +1,100 @@
+import { basename } from 'node:path'
+
+import type {
+  ChxPluginRegistration,
+  ChxUserClickHouseConfig,
+  ChxUserConfig,
+} from '@chkit/core'
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stripExt(name: string): string {
+  return name.replace(/\.[^./\\]+$/, '')
+}
+
+export function pluginNameOf(reg: ChxPluginRegistration): string | undefined {
+  if (typeof reg === 'string') {
+    const last = basename(reg)
+    return last ? stripExt(last) : undefined
+  }
+  if (!isObject(reg)) return undefined
+  if ('plugin' in reg) {
+    if (typeof reg.name === 'string' && reg.name.length > 0) return reg.name
+    const plugin = (reg as { plugin?: unknown }).plugin
+    if (isObject(plugin)) {
+      const manifest = (plugin as { manifest?: unknown }).manifest
+      if (isObject(manifest) && typeof manifest.name === 'string' && manifest.name.length > 0) {
+        return manifest.name
+      }
+    }
+    return undefined
+  }
+  if (typeof reg.name === 'string' && reg.name.length > 0) return reg.name
+  if (typeof reg.resolve === 'string' && reg.resolve.length > 0) {
+    const last = basename(reg.resolve)
+    return last ? stripExt(last) : undefined
+  }
+  return undefined
+}
+
+function mergePlugins(
+  base: ChxPluginRegistration[] | undefined,
+  overlay: ChxPluginRegistration[] | undefined,
+): ChxPluginRegistration[] | undefined {
+  if (!base && !overlay) return undefined
+  if (!base) return overlay
+  if (!overlay) return base
+
+  const overlayNames = new Set<string>()
+  for (const reg of overlay) {
+    const name = pluginNameOf(reg)
+    if (name) overlayNames.add(name)
+  }
+
+  const result: ChxPluginRegistration[] = []
+  for (const reg of base) {
+    const name = pluginNameOf(reg)
+    if (name && overlayNames.has(name)) continue
+    result.push(reg)
+  }
+  for (const reg of overlay) result.push(reg)
+  return result
+}
+
+function mergeClickhouse(
+  base: ChxUserClickHouseConfig | undefined,
+  overlay: ChxUserClickHouseConfig | undefined,
+): ChxUserClickHouseConfig | undefined {
+  if (!base && !overlay) return undefined
+  if (!base) return overlay
+  if (!overlay) return base
+  return { ...base, ...overlay }
+}
+
+function mergeShallow<T extends object>(
+  base: T | undefined,
+  overlay: T | undefined,
+): T | undefined {
+  if (!base && !overlay) return undefined
+  if (!base) return overlay
+  if (!overlay) return base
+  return { ...base, ...overlay }
+}
+
+export function mergeUserConfig(
+  base: ChxUserConfig,
+  overlay: ChxUserConfig,
+): ChxUserConfig {
+  return {
+    schema: overlay.schema ?? base.schema,
+    outDir: overlay.outDir ?? base.outDir,
+    migrationsDir: overlay.migrationsDir ?? base.migrationsDir,
+    metaDir: overlay.metaDir ?? base.metaDir,
+    plugins: mergePlugins(base.plugins, overlay.plugins),
+    check: mergeShallow(base.check, overlay.check),
+    safety: mergeShallow(base.safety, overlay.safety),
+    clickhouse: mergeClickhouse(base.clickhouse, overlay.clickhouse),
+  }
+}

--- a/packages/cli/src/runtime/config.ts
+++ b/packages/cli/src/runtime/config.ts
@@ -10,11 +10,27 @@ import {
   type ChxConfigEnv,
   type ChxConfigFn,
   type ChxConfigInput,
+  type ChxPluginRegistration,
   type ResolvedChxConfig,
 } from '@chkit/core'
+
 import { debug } from './debug.js'
+import {
+  getUserConfigDir,
+  SYNTHESIZED_CONFIG_FILENAME,
+  USER_CREDENTIALS_FILE,
+  USER_PROFILE_CONFIG_FILE,
+} from './user-config.js'
 
 export const DEFAULT_CONFIG_FILE = 'clickhouse.config.ts'
+
+export type ConfigSource = 'project' | 'profile' | 'synthesized'
+
+export interface LoadedConfig {
+  config: ResolvedChxConfig
+  path: string
+  source: ConfigSource
+}
 
 function isConfigFunction(candidate: ChxConfigInput): candidate is ChxConfigFn {
   return typeof candidate === 'function'
@@ -22,19 +38,72 @@ function isConfigFunction(candidate: ChxConfigInput): candidate is ChxConfigFn {
 
 export async function loadConfig(
   configPathArg?: string,
-  env: ChxConfigEnv = {}
-): Promise<{ config: ResolvedChxConfig; path: string }> {
-  const configPath = resolve(process.cwd(), configPathArg ?? DEFAULT_CONFIG_FILE)
-  debug('config', `resolving config at ${configPath}`)
-  if (!existsSync(configPath)) {
-    throw new Error(`Config not found at ${configPath}. Run 'chkit init' first.`)
+  env: ChxConfigEnv = {},
+  options: {
+    command?: string
+    cwd?: string
+    userConfigDir?: string
+    allowSynthesizedProfileConfig?: boolean
+  } = {},
+): Promise<LoadedConfig> {
+  const cwd = options.cwd ?? process.cwd()
+  const userDir = options.userConfigDir ?? getUserConfigDir()
+
+  if (configPathArg) {
+    const explicitPath = resolve(cwd, configPathArg)
+    debug('config', `resolving explicit config at ${explicitPath}`)
+    if (!existsSync(explicitPath)) {
+      throw new Error(`Config not found at ${explicitPath}.`)
+    }
+    return loadFromFile(explicitPath, env, 'project')
   }
 
+  const projectPath = resolve(cwd, DEFAULT_CONFIG_FILE)
+  debug('config', `looking for project config at ${projectPath}`)
+  if (existsSync(projectPath)) {
+    return loadFromFile(projectPath, env, 'project')
+  }
+
+  const profilePath = resolve(userDir, USER_PROFILE_CONFIG_FILE)
+  debug('config', `looking for user profile config at ${profilePath}`)
+  if (existsSync(profilePath)) {
+    return loadFromFile(profilePath, env, 'profile')
+  }
+
+  const credentialsPath = resolve(userDir, USER_CREDENTIALS_FILE)
+  if (existsSync(credentialsPath)) {
+    debug('config', `synthesizing query-only config from credentials at ${credentialsPath}`)
+    return synthesizeProfileConfig(userDir)
+  }
+
+  if (options.allowSynthesizedProfileConfig) {
+    debug('config', 'synthesizing profile config without existing credentials')
+    return synthesizeProfileConfig(userDir)
+  }
+
+  if (options.command === 'query') {
+    throw new Error(
+      `No project config found at ${projectPath}, and no ObsessionDB profile is available.\n` +
+        `Run 'chkit obsessiondb login' to query ObsessionDB from any directory, or run 'chkit init' in a project.`,
+    )
+  }
+
+  throw new Error(
+    `Config not found at ${projectPath}.\n` +
+      `Either run 'chkit init' in your project, or run 'chkit obsessiondb login' to use chkit from any directory.`,
+  )
+}
+
+async function loadFromFile(
+  configPath: string,
+  env: ChxConfigEnv,
+  source: ConfigSource,
+): Promise<LoadedConfig> {
   const mod = await import(pathToFileURL(configPath).href)
   const candidate = (mod.default ?? mod.config) as ChxConfigInput | undefined
   if (!candidate) {
     throw new Error(
-      `Config file ${configPath} must export a default/config object or a function via defineConfig.`
+      `Config file ${configPath} must export a default/config object or a function via defineConfig.`,
     )
   }
 
@@ -43,15 +112,44 @@ export async function loadConfig(
   const userConfig = isFn ? await candidate(env) : (candidate as ChxConfig)
   const config = resolveConfig(userConfig)
 
-  debug('config', `loaded`, {
+  debug('config', `loaded (source=${source})`, {
     schema: config.schema,
     outDir: config.outDir,
     migrationsDir: config.migrationsDir,
-    clickhouse: config.clickhouse ? `${config.clickhouse.url} (db: ${config.clickhouse.database ?? 'default'})` : 'not configured',
+    clickhouse: config.clickhouse
+      ? `${config.clickhouse.url} (db: ${config.clickhouse.database ?? 'default'})`
+      : 'not configured',
     plugins: (config.plugins ?? []).length,
   })
 
-  return { config, path: configPath }
+  return { config, path: configPath, source }
+}
+
+async function loadObsessionDBRegistration(): Promise<ChxPluginRegistration> {
+  try {
+    const mod = (await import('@chkit/plugin-obsessiondb')) as {
+      obsessiondb?: () => ChxPluginRegistration
+    }
+    if (typeof mod.obsessiondb !== 'function') {
+      throw new Error('missing obsessiondb export')
+    }
+    return mod.obsessiondb()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `ObsessionDB profile fallback requires @chkit/plugin-obsessiondb, but it could not be loaded: ${message}`,
+    )
+  }
+}
+
+async function synthesizeProfileConfig(userDir: string): Promise<LoadedConfig> {
+  const path = resolve(userDir, SYNTHESIZED_CONFIG_FILENAME)
+  const config = resolveConfig({
+    schema: [],
+    plugins: [await loadObsessionDBRegistration()],
+  })
+  debug('config', `synthesized profile config at virtual path ${path}`)
+  return { config, path, source: 'synthesized' }
 }
 
 export async function writeIfMissing(filePath: string, content: string): Promise<boolean> {

--- a/packages/cli/src/runtime/config.ts
+++ b/packages/cli/src/runtime/config.ts
@@ -6,18 +6,20 @@ import { pathToFileURL } from 'node:url'
 
 import {
   resolveConfig,
+  SYNTHESIZED_CONFIG_PATH,
   type ChxConfig,
   type ChxConfigEnv,
   type ChxConfigFn,
   type ChxConfigInput,
   type ChxPluginRegistration,
+  type ChxUserConfig,
   type ResolvedChxConfig,
 } from '@chkit/core'
 
+import { mergeUserConfig } from './config-merge.js'
 import { debug } from './debug.js'
 import {
   getUserConfigDir,
-  SYNTHESIZED_CONFIG_FILENAME,
   USER_CREDENTIALS_FILE,
   USER_PROFILE_CONFIG_FILE,
 } from './user-config.js'
@@ -30,6 +32,16 @@ export interface LoadedConfig {
   config: ResolvedChxConfig
   path: string
   source: ConfigSource
+  profileLayered: boolean
+}
+
+interface RawConfig {
+  raw: ChxUserConfig
+  path: string
+}
+
+interface ProfileLayer extends RawConfig {
+  source: 'profile' | 'synthesized'
 }
 
 function isConfigFunction(candidate: ChxConfigInput): candidate is ChxConfigFn {
@@ -49,36 +61,35 @@ export async function loadConfig(
   const cwd = options.cwd ?? process.cwd()
   const userDir = options.userConfigDir ?? getUserConfigDir()
 
+  const projectPath = configPathArg
+    ? resolve(cwd, configPathArg)
+    : resolve(cwd, DEFAULT_CONFIG_FILE)
+
   if (configPathArg) {
-    const explicitPath = resolve(cwd, configPathArg)
-    debug('config', `resolving explicit config at ${explicitPath}`)
-    if (!existsSync(explicitPath)) {
-      throw new Error(`Config not found at ${explicitPath}.`)
+    debug('config', `resolving explicit config at ${projectPath}`)
+    if (!existsSync(projectPath)) {
+      throw new Error(`Config not found at ${projectPath}.`)
     }
-    return loadFromFile(explicitPath, env, 'project')
+  } else {
+    debug('config', `looking for project config at ${projectPath}`)
   }
 
-  const projectPath = resolve(cwd, DEFAULT_CONFIG_FILE)
-  debug('config', `looking for project config at ${projectPath}`)
-  if (existsSync(projectPath)) {
-    return loadFromFile(projectPath, env, 'project')
+  const projectExists = existsSync(projectPath)
+
+  if (projectExists) {
+    const project = await readRawConfig(projectPath, env)
+    const layer = await readProfileLayer(userDir, env, options.allowSynthesizedProfileConfig)
+    if (layer) {
+      debug('config', `layering profile (${layer.source}, path=${layer.path}) under project`)
+      const merged = mergeUserConfig(layer.raw, project.raw)
+      return finalize(merged, project.path, 'project', true)
+    }
+    return finalize(project.raw, project.path, 'project', false)
   }
 
-  const profilePath = resolve(userDir, USER_PROFILE_CONFIG_FILE)
-  debug('config', `looking for user profile config at ${profilePath}`)
-  if (existsSync(profilePath)) {
-    return loadFromFile(profilePath, env, 'profile')
-  }
-
-  const credentialsPath = resolve(userDir, USER_CREDENTIALS_FILE)
-  if (existsSync(credentialsPath)) {
-    debug('config', `synthesizing query-only config from credentials at ${credentialsPath}`)
-    return synthesizeProfileConfig(userDir)
-  }
-
-  if (options.allowSynthesizedProfileConfig) {
-    debug('config', 'synthesizing profile config without existing credentials')
-    return synthesizeProfileConfig(userDir)
+  const layer = await readProfileLayer(userDir, env, options.allowSynthesizedProfileConfig)
+  if (layer) {
+    return finalize(layer.raw, layer.path, layer.source, false)
   }
 
   if (options.command === 'query') {
@@ -94,11 +105,7 @@ export async function loadConfig(
   )
 }
 
-async function loadFromFile(
-  configPath: string,
-  env: ChxConfigEnv,
-  source: ConfigSource,
-): Promise<LoadedConfig> {
+async function readRawConfig(configPath: string, env: ChxConfigEnv): Promise<RawConfig> {
   const mod = await import(pathToFileURL(configPath).href)
   const candidate = (mod.default ?? mod.config) as ChxConfigInput | undefined
   if (!candidate) {
@@ -108,11 +115,45 @@ async function loadFromFile(
   }
 
   const isFn = isConfigFunction(candidate)
-  debug('config', `config export is ${isFn ? 'function' : 'object'}`)
-  const userConfig = isFn ? await candidate(env) : (candidate as ChxConfig)
-  const config = resolveConfig(userConfig)
+  debug('config', `config export is ${isFn ? 'function' : 'object'} (path=${configPath})`)
+  const raw = isFn ? await candidate(env) : (candidate as ChxConfig)
+  return { raw, path: configPath }
+}
 
-  debug('config', `loaded (source=${source})`, {
+async function readProfileLayer(
+  userDir: string,
+  env: ChxConfigEnv,
+  allowSynthesized: boolean | undefined,
+): Promise<ProfileLayer | null> {
+  const profilePath = resolve(userDir, USER_PROFILE_CONFIG_FILE)
+  if (existsSync(profilePath)) {
+    debug('config', `found profile config at ${profilePath}`)
+    const { raw } = await readRawConfig(profilePath, env)
+    return { raw, path: profilePath, source: 'profile' }
+  }
+
+  const credentialsPath = resolve(userDir, USER_CREDENTIALS_FILE)
+  if (existsSync(credentialsPath)) {
+    debug('config', `synthesizing profile layer from credentials at ${credentialsPath}`)
+    return synthesizedProfileLayer()
+  }
+
+  if (allowSynthesized) {
+    debug('config', 'synthesizing profile layer without existing credentials')
+    return synthesizedProfileLayer()
+  }
+
+  return null
+}
+
+function finalize(
+  raw: ChxUserConfig,
+  path: string,
+  source: ConfigSource,
+  profileLayered: boolean,
+): LoadedConfig {
+  const config = resolveConfig(raw)
+  debug('config', `loaded (source=${source}, profileLayered=${profileLayered})`, {
     schema: config.schema,
     outDir: config.outDir,
     migrationsDir: config.migrationsDir,
@@ -121,8 +162,7 @@ async function loadFromFile(
       : 'not configured',
     plugins: (config.plugins ?? []).length,
   })
-
-  return { config, path: configPath, source }
+  return { config, path, source, profileLayered }
 }
 
 async function loadObsessionDBRegistration(): Promise<ChxPluginRegistration> {
@@ -142,14 +182,12 @@ async function loadObsessionDBRegistration(): Promise<ChxPluginRegistration> {
   }
 }
 
-async function synthesizeProfileConfig(userDir: string): Promise<LoadedConfig> {
-  const path = resolve(userDir, SYNTHESIZED_CONFIG_FILENAME)
-  const config = resolveConfig({
+async function synthesizedProfileLayer(): Promise<ProfileLayer> {
+  const raw: ChxUserConfig = {
     schema: [],
     plugins: [await loadObsessionDBRegistration()],
-  })
-  debug('config', `synthesized profile config at virtual path ${path}`)
-  return { config, path, source: 'synthesized' }
+  }
+  return { raw, path: SYNTHESIZED_CONFIG_PATH, source: 'synthesized' }
 }
 
 export async function writeIfMissing(filePath: string, content: string): Promise<boolean> {

--- a/packages/cli/src/runtime/config.ts
+++ b/packages/cli/src/runtime/config.ts
@@ -26,7 +26,8 @@ import {
 
 export const DEFAULT_CONFIG_FILE = 'clickhouse.config.ts'
 
-export type ConfigSource = 'project' | 'profile' | 'synthesized'
+export type ConfigSource = 'project' | 'profile'
+export type ProfileOrigin = 'file' | 'credentials' | 'synthetic'
 
 export interface LoadedConfig {
   config: ResolvedChxConfig
@@ -41,7 +42,8 @@ interface RawConfig {
 }
 
 interface ProfileLayer extends RawConfig {
-  source: 'profile' | 'synthesized'
+  source: 'profile'
+  origin: ProfileOrigin
 }
 
 function isConfigFunction(candidate: ChxConfigInput): candidate is ChxConfigFn {
@@ -129,18 +131,18 @@ async function readProfileLayer(
   if (existsSync(profilePath)) {
     debug('config', `found profile config at ${profilePath}`)
     const { raw } = await readRawConfig(profilePath, env)
-    return { raw, path: profilePath, source: 'profile' }
+    return { raw, path: profilePath, source: 'profile', origin: 'file' }
   }
 
   const credentialsPath = resolve(userDir, USER_CREDENTIALS_FILE)
   if (existsSync(credentialsPath)) {
     debug('config', `synthesizing profile layer from credentials at ${credentialsPath}`)
-    return synthesizedProfileLayer()
+    return synthesizedProfileLayer('credentials')
   }
 
   if (allowSynthesized) {
     debug('config', 'synthesizing profile layer without existing credentials')
-    return synthesizedProfileLayer()
+    return synthesizedProfileLayer('synthetic')
   }
 
   return null
@@ -182,12 +184,12 @@ async function loadObsessionDBRegistration(): Promise<ChxPluginRegistration> {
   }
 }
 
-async function synthesizedProfileLayer(): Promise<ProfileLayer> {
+async function synthesizedProfileLayer(origin: 'credentials' | 'synthetic'): Promise<ProfileLayer> {
   const raw: ChxUserConfig = {
     schema: [],
     plugins: [await loadObsessionDBRegistration()],
   }
-  return { raw, path: SYNTHESIZED_CONFIG_PATH, source: 'synthesized' }
+  return { raw, path: SYNTHESIZED_CONFIG_PATH, source: 'profile', origin }
 }
 
 export async function writeIfMissing(filePath: string, content: string): Promise<boolean> {

--- a/packages/cli/src/runtime/config.ts
+++ b/packages/cli/src/runtime/config.ts
@@ -27,7 +27,7 @@ import {
 export const DEFAULT_CONFIG_FILE = 'clickhouse.config.ts'
 
 export type ConfigSource = 'project' | 'profile'
-export type ProfileOrigin = 'file' | 'credentials' | 'synthetic'
+type ProfileOrigin = 'file' | 'credentials' | 'synthetic'
 
 export interface LoadedConfig {
   config: ResolvedChxConfig

--- a/packages/cli/src/runtime/extract-config-path.ts
+++ b/packages/cli/src/runtime/extract-config-path.ts
@@ -1,0 +1,9 @@
+export function extractConfigPath(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (token === '--') return undefined
+    if (token === '--config') return argv[i + 1]
+    if (token?.startsWith('--config=')) return token.slice('--config='.length)
+  }
+  return undefined
+}

--- a/packages/cli/src/runtime/help.ts
+++ b/packages/cli/src/runtime/help.ts
@@ -12,8 +12,8 @@ export function formatGlobalHelp(registry: CommandRegistry, version: string): st
 
   lines.push(`  ${'init'.padEnd(14)} Scaffold a new project with config and example schema`)
 
-  const coreCommands = registry.commands.filter((c) => !c.isPlugin)
-  const pluginCommands = registry.commands.filter((c) => c.isPlugin)
+  const coreCommands = registry.commands.filter((c) => c.pluginName === 'core')
+  const pluginCommands = registry.commands.filter((c) => c.pluginName !== 'core')
 
   for (const cmd of coreCommands) {
     lines.push(`  ${cmd.name.padEnd(14)} ${cmd.description}`)

--- a/packages/cli/src/runtime/plugin-runtime/index.ts
+++ b/packages/cli/src/runtime/plugin-runtime/index.ts
@@ -1,7 +1,5 @@
-import { resolve } from 'node:path'
-
 import { createClickHouseExecutor } from '@chkit/clickhouse'
-import type { ResolvedChxConfig } from '@chkit/core'
+import { resolveOptions, type ResolvedChxConfig } from '@chkit/core'
 
 import type {
   ChxPlugin,
@@ -13,7 +11,6 @@ import { debug } from '../debug.js'
 import { formatPluginError } from './errors.js'
 import { wrapExecutorWithDebug } from './executor-debug.js'
 import {
-  importPluginModule,
   normalizePluginRegistration,
   validatePlugin,
 } from './loader.js'
@@ -32,6 +29,18 @@ import {
   runOnSchemaLoaded,
 } from './hooks.js'
 
+function resolvePluginOptions(
+  plugin: ChxPlugin,
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!plugin.optionsSchema) return options
+  const result = plugin.optionsSchema.safeParse(options)
+  // Soft-validate at load time: command-level optionsSchema catches strict errors at dispatch.
+  // This lets hooks see filled-in defaults when valid, and raw values otherwise.
+  if (!result.success) return options
+  return result.data
+}
+
 export async function loadPluginRuntime(input: {
   config: ResolvedChxConfig
   configPath: string
@@ -41,22 +50,13 @@ export async function loadPluginRuntime(input: {
   const registrations = input.config.plugins ?? []
   const loaded: LoadedPlugin[] = []
   const byName = new Map<string, LoadedPlugin>()
-  const configDir = resolve(input.configPath, '..')
 
   for (const registration of registrations) {
     const normalized = normalizePluginRegistration(registration)
     if (!normalized.enabled) continue
 
-    const plugin =
-      normalized.kind === 'inline'
-        ? normalized.inlinePlugin
-        : await importPluginModule(resolve(configDir, normalized.resolvePath))
-    if (!plugin) continue
-
-    const sourceLabel =
-      normalized.kind === 'inline'
-        ? `inline registration${normalized.nameHint ? ` (${normalized.nameHint})` : ''}`
-        : resolve(configDir, normalized.resolvePath)
+    const plugin = normalized.plugin
+    const sourceLabel = `inline registration${normalized.nameHint ? ` (${normalized.nameHint})` : ''}`
     validatePlugin(input.cliVersion, plugin, sourceLabel)
 
     if (normalized.nameHint && normalized.nameHint !== plugin.manifest.name) {
@@ -79,19 +79,21 @@ export async function loadPluginRuntime(input: {
       },
     )
 
-    const item: LoadedPlugin = { plugin, options: normalized.options }
+    const resolved = resolvePluginOptions(plugin, normalized.options)
+    const item: LoadedPlugin = { plugin, options: resolved, rawOptions: normalized.options }
     loaded.push(item)
     byName.set(plugin.manifest.name, item)
   }
 
   for (const plugin of input.internalPlugins ?? []) {
     if (byName.has(plugin.manifest.name)) continue
-    const item: LoadedPlugin = { plugin, options: {} }
+    const resolved = resolvePluginOptions(plugin, {})
+    const item: LoadedPlugin = { plugin, options: resolved, rawOptions: {} }
     loaded.push(item)
     byName.set(plugin.manifest.name, item)
   }
 
-  return {
+  const runtimeSelf: PluginRuntime = {
     plugins: loaded,
     async resolveContext(input) {
       const hasClickhouseConfig = !!input.config.clickhouse
@@ -184,12 +186,41 @@ export async function loadPluginRuntime(input: {
       )
       if (beforeResult.handled) return beforeResult.exitCode
 
+      let resolvedOptions: Record<string, unknown> = item.options
+      if (command.optionsSchema) {
+        try {
+          resolvedOptions = resolveOptions(
+            command.optionsSchema,
+            item.options,
+            context.flags,
+            command.flagMapping ?? {},
+          )
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          if (context.jsonMode) {
+            context.print({ ok: false, command: commandName, error: message })
+          } else {
+            context.print(`${commandName} failed: ${message}`)
+          }
+          return 2
+        }
+      }
+
+      const pluginContext = await runtimeSelf.resolveContext({
+        config: context.config,
+        configPath: context.configPath,
+        command: commandName,
+        flags: context.flags,
+      })
       try {
         const code = await command.run({
           ...context,
           pluginName,
-          options: item.options,
+          options: resolvedOptions,
+          rawOptions: item.rawOptions,
           tableScope: context.tableScope ?? UNFILTERED_TABLE_SCOPE,
+          pluginRuntime: runtimeSelf,
+          pluginContext,
         })
         return typeof code === 'number' ? code : 0
       } catch (error) {
@@ -198,7 +229,10 @@ export async function loadPluginRuntime(input: {
           `command:${commandName}`,
           error,
         )
+      } finally {
+        await runtimeSelf.disposeContext(pluginContext)
       }
     },
   }
+  return runtimeSelf
 }

--- a/packages/cli/src/runtime/plugin-runtime/index.ts
+++ b/packages/cli/src/runtime/plugin-runtime/index.ts
@@ -101,8 +101,8 @@ export async function loadPluginRuntime(input: {
         'context',
         `resolving executor — clickhouse config: ${hasClickhouseConfig ? 'yes' : 'no'}`,
       )
-      const rawExecutor = hasClickhouseConfig
-        ? createClickHouseExecutor(input.config.clickhouse!)
+      const rawExecutor = input.config.clickhouse
+        ? createClickHouseExecutor(input.config.clickhouse)
         : NULL_EXECUTOR
       const defaults: PluginContext = {
         executor: wrapExecutorWithDebug(rawExecutor),

--- a/packages/cli/src/runtime/plugin-runtime/loader.ts
+++ b/packages/cli/src/runtime/plugin-runtime/loader.ts
@@ -1,18 +1,10 @@
-import { pathToFileURL } from 'node:url'
-
-import type {
-  ChxLegacyPluginRegistration,
-  ChxPluginRegistration,
-} from '@chkit/core'
+import type { ChxPluginRegistration } from '@chkit/core'
 
 import type { ChxPlugin } from '../../plugins.js'
-import { isInlinePluginRegistration } from '../../plugins.js'
 
 export interface NormalizedRegistration {
-  kind: 'legacy' | 'inline'
-  resolvePath: string
-  inlinePlugin?: ChxPlugin
-  nameHint?: string
+  plugin: ChxPlugin
+  nameHint: string | undefined
   enabled: boolean
   options: Record<string, unknown>
 }
@@ -20,33 +12,11 @@ export interface NormalizedRegistration {
 export function normalizePluginRegistration(
   entry: ChxPluginRegistration,
 ): NormalizedRegistration {
-  if (typeof entry === 'string') {
-    return {
-      kind: 'legacy',
-      resolvePath: entry,
-      enabled: true,
-      options: {},
-    }
-  }
-
-  if (isInlinePluginRegistration(entry)) {
-    return {
-      kind: 'inline',
-      resolvePath: '',
-      inlinePlugin: entry.plugin,
-      nameHint: entry.name,
-      enabled: entry.enabled !== false,
-      options: entry.options ?? {},
-    }
-  }
-
-  const legacy = entry as ChxLegacyPluginRegistration
   return {
-    kind: 'legacy',
-    resolvePath: legacy.resolve,
-    nameHint: legacy.name,
-    enabled: legacy.enabled !== false,
-    options: legacy.options ?? {},
+    plugin: entry.plugin as ChxPlugin,
+    nameHint: entry.name,
+    enabled: entry.enabled !== false,
+    options: entry.options ?? {},
   }
 }
 
@@ -61,11 +31,11 @@ function parseCliMajor(version: string): number {
 export function validatePlugin(
   cliVersion: string,
   plugin: ChxPlugin,
-  sourcePath: string,
+  sourceLabel: string,
 ): void {
   const name = plugin.manifest.name
   if (!name || name.trim().length === 0) {
-    throw new Error(`Plugin at ${sourcePath} has an empty manifest.name.`)
+    throw new Error(`Plugin at ${sourceLabel} has an empty manifest.name.`)
   }
 
   if (plugin.manifest.apiVersion !== 1) {
@@ -94,21 +64,4 @@ export function validatePlugin(
       `Plugin "${name}" is incompatible with CLI ${cliVersion}. Requires cli major <= ${compatibility.maxMajor}.`,
     )
   }
-}
-
-export async function importPluginModule(absolutePath: string): Promise<ChxPlugin> {
-  const mod = (await import(pathToFileURL(absolutePath).href)) as {
-    default?: unknown
-    plugin?: unknown
-  }
-  const candidate = (mod.default ?? mod.plugin) as ChxPlugin | undefined
-  if (!candidate || typeof candidate !== 'object') {
-    throw new Error(
-      `Plugin module ${absolutePath} must export default definePlugin(...)`,
-    )
-  }
-  if (!candidate.manifest || typeof candidate.manifest !== 'object') {
-    throw new Error(`Plugin module ${absolutePath} is missing manifest.`)
-  }
-  return candidate
 }

--- a/packages/cli/src/runtime/user-config.ts
+++ b/packages/cli/src/runtime/user-config.ts
@@ -10,7 +10,6 @@ export function getUserConfigDir(): string {
 
 export const USER_PROFILE_CONFIG_FILE = 'config.ts'
 export const USER_CREDENTIALS_FILE = 'credentials.json'
-export const SYNTHESIZED_CONFIG_FILENAME = 'clickhouse.config.ts'
 
 export function getUserProfileConfigPath(): string {
   return join(getUserConfigDir(), USER_PROFILE_CONFIG_FILE)
@@ -18,10 +17,6 @@ export function getUserProfileConfigPath(): string {
 
 export function getUserCredentialsPath(): string {
   return join(getUserConfigDir(), USER_CREDENTIALS_FILE)
-}
-
-export function getSynthesizedConfigPath(): string {
-  return join(getUserConfigDir(), SYNTHESIZED_CONFIG_FILENAME)
 }
 
 export function isUnderUserConfigDir(path: string): boolean {

--- a/packages/cli/src/runtime/user-config.ts
+++ b/packages/cli/src/runtime/user-config.ts
@@ -1,0 +1,31 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+
+export function getUserConfigDir(): string {
+  const xdgConfig = process.env.XDG_CONFIG_HOME
+  const configDir = xdgConfig && xdgConfig.length > 0 ? xdgConfig : join(homedir(), '.config')
+  return join(configDir, 'chkit')
+}
+
+export const USER_PROFILE_CONFIG_FILE = 'config.ts'
+export const USER_CREDENTIALS_FILE = 'credentials.json'
+export const SYNTHESIZED_CONFIG_FILENAME = 'clickhouse.config.ts'
+
+export function getUserProfileConfigPath(): string {
+  return join(getUserConfigDir(), USER_PROFILE_CONFIG_FILE)
+}
+
+export function getUserCredentialsPath(): string {
+  return join(getUserConfigDir(), USER_CREDENTIALS_FILE)
+}
+
+export function getSynthesizedConfigPath(): string {
+  return join(getUserConfigDir(), SYNTHESIZED_CONFIG_FILENAME)
+}
+
+export function isUnderUserConfigDir(path: string): boolean {
+  const userDir = resolve(getUserConfigDir())
+  const target = resolve(path)
+  return target === userDir || target.startsWith(`${userDir}/`)
+}

--- a/packages/cli/src/runtime/user-config.ts
+++ b/packages/cli/src/runtime/user-config.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import process from 'node:process'
 
 export function getUserConfigDir(): string {
@@ -10,17 +10,3 @@ export function getUserConfigDir(): string {
 
 export const USER_PROFILE_CONFIG_FILE = 'config.ts'
 export const USER_CREDENTIALS_FILE = 'credentials.json'
-
-export function getUserProfileConfigPath(): string {
-  return join(getUserConfigDir(), USER_PROFILE_CONFIG_FILE)
-}
-
-export function getUserCredentialsPath(): string {
-  return join(getUserConfigDir(), USER_CREDENTIALS_FILE)
-}
-
-export function isUnderUserConfigDir(path: string): boolean {
-  const userDir = resolve(getUserConfigDir())
-  const target = resolve(path)
-  return target === userDir || target.startsWith(`${userDir}/`)
-}

--- a/packages/cli/src/test/e2e-testkit.ts
+++ b/packages/cli/src/test/e2e-testkit.ts
@@ -9,12 +9,10 @@ import { join, resolve } from 'node:path'
 
 // Re-export all shared utilities so CLI tests only need one import
 export {
-  type LiveEnv,
   getRequiredEnv,
   createLiveExecutor,
   createStatelessLiveExecutor,
   quoteIdent,
-  createRunTag,
   createPrefix,
   createJournalTableName,
   waitForTable,
@@ -23,7 +21,7 @@ export {
 } from '@chkit/clickhouse/e2e-testkit'
 
 const WORKSPACE_ROOT = resolve(import.meta.dir, '../../../..')
-export const CLI_ENTRY = join(WORKSPACE_ROOT, 'packages/cli/src/bin/chkit.ts')
+const CLI_ENTRY = join(WORKSPACE_ROOT, 'packages/cli/src/bin/chkit.ts')
 export const CORE_ENTRY = join(WORKSPACE_ROOT, 'packages/core/src/index.ts')
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/test/plugin.test.ts
+++ b/packages/cli/src/test/plugin.test.ts
@@ -70,13 +70,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport default definePlugin({\n  manifest: { name: 'plan-augment', apiVersion: 1 },\n  hooks: {\n    onPlanCreated({ plan }) {\n      return {\n        ...plan,\n        operations: [\n          ...plan.operations,\n          {\n            type: 'create_database',\n            key: 'database:plugin_db',\n            risk: 'safe',\n            sql: 'CREATE DATABASE IF NOT EXISTS plugin_db;',\n          },\n        ],\n        riskSummary: {\n          safe: plan.riskSummary.safe + 1,\n          caution: plan.riskSummary.caution,\n          danger: plan.riskSummary.danger,\n        },\n      }\n    },\n  },\n})\n`,
+        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport const plugin = definePlugin({\n  manifest: { name: 'plan-augment', apiVersion: 1 },\n  hooks: {\n    onPlanCreated({ plan }) {\n      return {\n        ...plan,\n        operations: [\n          ...plan.operations,\n          {\n            type: 'create_database',\n            key: 'database:plugin_db',\n            risk: 'safe',\n            sql: 'CREATE DATABASE IF NOT EXISTS plugin_db;',\n          },\n        ],\n        riskSummary: {\n          safe: plan.riskSummary.safe + 1,\n          caution: plan.riskSummary.caution,\n          danger: plan.riskSummary.danger,\n        },\n      }\n    },\n  },\n})\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './plan-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -98,13 +98,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport default definePlugin({\n  manifest: { name: 'echoer', apiVersion: 1 },\n  commands: [\n    {\n      name: 'echo',\n      description: 'Echo args for tests',\n      run({ args, jsonMode, print }) {\n        if (jsonMode) {\n          print({ ok: true, args })\n          return\n        }\n        print(args.join(','))\n      },\n    },\n  ],\n})\n`,
+        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport const plugin = definePlugin({\n  manifest: { name: 'echoer', apiVersion: 1 },\n  commands: [\n    {\n      name: 'echo',\n      description: 'Echo args for tests',\n      run({ args, jsonMode, print }) {\n        if (jsonMode) {\n          print({ ok: true, args })\n          return\n        }\n        print(args.join(','))\n      },\n    },\n  ],\n})\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './commands-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -134,19 +134,19 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         targetPath,
-        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport default definePlugin({\n  manifest: { name: 'target', apiVersion: 1 },\n  commands: [\n    {\n      name: 'greet',\n      description: 'Original greet',\n      run({ print }) {\n        print({ source: 'original' })\n        return 0\n      },\n    },\n  ],\n})\n`,
+        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport const plugin = definePlugin({\n  manifest: { name: 'target', apiVersion: 1 },\n  commands: [\n    {\n      name: 'greet',\n      description: 'Original greet',\n      run({ print }) {\n        print({ source: 'original' })\n        return 0\n      },\n    },\n  ],\n})\n`,
         'utf8'
       )
 
       await writeFile(
         interceptorPath,
-        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport default definePlugin({\n  manifest: { name: 'interceptor', apiVersion: 1 },\n  hooks: {\n    onBeforePluginCommand(context) {\n      if (context.targetPlugin === 'target' && context.command === 'greet') {\n        context.print({ source: 'intercepted', target: context.targetPlugin })\n        return { handled: true, exitCode: 0 }\n      }\n      return { handled: false }\n    },\n  },\n})\n`,
+        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport const plugin = definePlugin({\n  manifest: { name: 'interceptor', apiVersion: 1 },\n  hooks: {\n    onBeforePluginCommand(context) {\n      if (context.targetPlugin === 'target' && context.command === 'greet') {\n        context.print({ source: 'intercepted', target: context.targetPlugin })\n        return { handled: true, exitCode: 0 }\n      }\n      return { handled: false }\n    },\n  },\n})\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [\n    { resolve: './target-plugin.ts' },\n    { resolve: './interceptor-plugin.ts' },\n  ],\n}\n`,
+        `import { plugin as target } from '${targetPath}'\nimport { plugin as interceptor } from '${interceptorPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [\n    { plugin: target },\n    { plugin: interceptor },\n  ],\n}\n`,
         'utf8'
       )
 
@@ -174,19 +174,19 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         targetPath,
-        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport default definePlugin({\n  manifest: { name: 'target', apiVersion: 1 },\n  commands: [\n    {\n      name: 'greet',\n      description: 'Original greet',\n      run({ print }) {\n        print({ source: 'original' })\n        return 0\n      },\n    },\n  ],\n})\n`,
+        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport const plugin = definePlugin({\n  manifest: { name: 'target', apiVersion: 1 },\n  commands: [\n    {\n      name: 'greet',\n      description: 'Original greet',\n      run({ print }) {\n        print({ source: 'original' })\n        return 0\n      },\n    },\n  ],\n})\n`,
         'utf8'
       )
 
       await writeFile(
         interceptorPath,
-        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport default definePlugin({\n  manifest: { name: 'interceptor', apiVersion: 1 },\n  hooks: {\n    onBeforePluginCommand() {\n      return { handled: false }\n    },\n  },\n})\n`,
+        `import { definePlugin } from '${CLI_ENTRY}'\n\nexport const plugin = definePlugin({\n  manifest: { name: 'interceptor', apiVersion: 1 },\n  hooks: {\n    onBeforePluginCommand() {\n      return { handled: false }\n    },\n  },\n})\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [\n    { resolve: './target-plugin.ts' },\n    { resolve: './interceptor-plugin.ts' },\n  ],\n}\n`,
+        `import { plugin as target } from '${targetPath}'\nimport { plugin as interceptor } from '${interceptorPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [\n    { plugin: target },\n    { plugin: interceptor },\n  ],\n}\n`,
         'utf8'
       )
 
@@ -214,13 +214,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createPullPlugin } from '${PULL_PLUGIN_ENTRY}'\n\nexport default createPullPlugin({\n  outFile: '${outFile}',\n  databases: ['app'],\n  introspect: async () => [\n    {\n      database: 'app',\n      name: 'users',\n      engine: 'MergeTree()',\n      primaryKey: '(id)',\n      orderBy: '(id)',\n      columns: [\n        { name: 'id', type: 'UInt64' },\n        { name: 'email', type: 'String' },\n      ],\n      settings: {},\n      indexes: [],\n      projections: [],\n    },\n  ],\n})\n`,
+        `import { pull } from '${PULL_PLUGIN_ENTRY}'\n\nexport const registration = pull({\n  outFile: '${outFile}',\n  databases: ['app'],\n  introspect: async () => [\n    {\n      database: 'app',\n      name: 'users',\n      engine: 'MergeTree()',\n      primaryKey: '(id)',\n      orderBy: '(id)',\n      columns: [\n        { name: 'id', type: 'UInt64' },\n        { name: 'email', type: 'String' },\n      ],\n      settings: {},\n      indexes: [],\n      projections: [],\n    },\n  ],\n})\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  clickhouse: {\n    url: 'http://localhost:8123',\n    username: 'default',\n    password: '',\n    database: 'default',\n  },\n  plugins: [{ resolve: './pull-plugin.ts' }],\n}\n`,
+        `import { registration } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  clickhouse: {\n    url: 'http://localhost:8123',\n    username: 'default',\n    password: '',\n    database: 'default',\n  },\n  plugins: [registration],\n}\n`,
         'utf8'
       )
 
@@ -260,13 +260,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createPullPlugin } from '${PULL_PLUGIN_ENTRY}'\n\nexport default createPullPlugin({\n  outFile: '${outFile}',\n  databases: ['app'],\n  introspect: async () => [\n    {\n      database: 'app',\n      name: 'events',\n      engine: 'MergeTree()',\n      primaryKey: '(id)',\n      orderBy: '(id)',\n      columns: [\n        { name: 'id', type: 'UInt64' },\n      ],\n      settings: {},\n      indexes: [],\n      projections: [],\n    },\n  ],\n})\n`,
+        `import { pull } from '${PULL_PLUGIN_ENTRY}'\n\nexport const registration = pull({\n  outFile: '${outFile}',\n  databases: ['app'],\n  introspect: async () => [\n    {\n      database: 'app',\n      name: 'events',\n      engine: 'MergeTree()',\n      primaryKey: '(id)',\n      orderBy: '(id)',\n      columns: [\n        { name: 'id', type: 'UInt64' },\n      ],\n      settings: {},\n      indexes: [],\n      projections: [],\n    },\n  ],\n})\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  clickhouse: {\n    url: 'http://localhost:8123',\n    username: 'default',\n    password: '',\n    database: 'default',\n  },\n  plugins: [{ resolve: './pull-plugin.ts' }],\n}\n`,
+        `import { registration } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  clickhouse: {\n    url: 'http://localhost:8123',\n    username: 'default',\n    password: '',\n    database: 'default',\n  },\n  plugins: [registration],\n}\n`,
         'utf8'
       )
 
@@ -297,13 +297,13 @@ describe('plugin runtime', () => {
       try {
         await writeFile(
           pluginPath,
-          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin()\n`,
           'utf8'
         )
 
         await writeFile(
           fixture.configPath,
-          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ plugin }],\n}\n`,
           'utf8'
         )
 
@@ -356,13 +356,13 @@ describe('plugin runtime', () => {
       try {
         await writeFile(
           pluginPath,
-          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin()\n`,
           'utf8'
         )
 
         await writeFile(
           fixture.configPath,
-          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ plugin }],\n}\n`,
           'utf8'
         )
 
@@ -447,13 +447,13 @@ describe('plugin runtime', () => {
       try {
         await writeFile(
           pluginPath,
-          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin()\n`,
           'utf8'
         )
 
         await writeFile(
           fixture.configPath,
-          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ plugin }],\n}\n`,
           'utf8'
         )
 
@@ -520,13 +520,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -544,13 +544,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin({ chunkHours: 2 })\n`,
+        `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin({ chunkHours: 2 })\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -577,12 +577,12 @@ describe('plugin runtime', () => {
       try {
         await writeFile(
           pluginPath,
-          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin()\n`,
           'utf8'
         )
         await writeFile(
           fixture.configPath,
-          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ plugin }],\n}\n`,
           'utf8'
         )
 
@@ -639,12 +639,12 @@ describe('plugin runtime', () => {
       try {
         await writeFile(
           pluginPath,
-          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport default createBackfillPlugin()\n`,
+          `import { createBackfillPlugin } from '${BACKFILL_PLUGIN_ENTRY}'\n\nexport const plugin = createBackfillPlugin()\n`,
           'utf8'
         )
         await writeFile(
           fixture.configPath,
-          `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ resolve: './backfill-plugin.ts' }],\n}\n`,
+          `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  ${chConfig}\n  plugins: [{ plugin }],\n}\n`,
           'utf8'
         )
 
@@ -758,13 +758,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
+        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport const plugin = createCodegenPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -865,13 +865,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
+        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport const plugin = createCodegenPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -890,13 +890,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
+        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport const plugin = createCodegenPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts', options: { runOnGenerate: false } }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin, options: { runOnGenerate: false } }],\n}\n`,
         'utf8'
       )
 
@@ -914,13 +914,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
+        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport const plugin = createCodegenPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -943,13 +943,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
+        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport const plugin = createCodegenPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 
@@ -991,17 +991,10 @@ describe('plugin runtime', () => {
 
   test('codegen returns exit code 2 for invalid plugin options', async () => {
     const fixture = await createFixture()
-    const pluginPath = join(fixture.dir, 'codegen-plugin.ts')
     try {
       await writeFile(
-        pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
-        'utf8'
-      )
-
-      await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts', options: { bigintMode: 'nope' } }],\n}\n`,
+        `import { codegen } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [codegen({ bigintMode: 'nope' })],\n}\n`,
         'utf8'
       )
 
@@ -1021,13 +1014,13 @@ describe('plugin runtime', () => {
     try {
       await writeFile(
         pluginPath,
-        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport default createCodegenPlugin()\n`,
+        `import { createCodegenPlugin } from '${CODEGEN_PLUGIN_ENTRY}'\n\nexport const plugin = createCodegenPlugin()\n`,
         'utf8'
       )
 
       await writeFile(
         fixture.configPath,
-        `export default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ resolve: './codegen-plugin.ts' }],\n}\n`,
+        `import { plugin } from '${pluginPath}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [{ plugin }],\n}\n`,
         'utf8'
       )
 

--- a/packages/cli/src/test/runtime/command-dispatch.test.ts
+++ b/packages/cli/src/test/runtime/command-dispatch.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { FlagDef } from '@chkit/core'
-import { parseCommandArgs } from '../../runtime/command-dispatch.js'
+import type { FlagDef, ResolvedChxConfig } from '@chkit/core'
+import type { PluginRuntime } from '../../plugins.js'
+import { parseCommandArgs, runResolvedCommand } from '../../runtime/command-dispatch.js'
+import type { CommandRegistry, RegisteredCommand } from '../../runtime/command-registry.js'
 import { GLOBAL_FLAGS } from '../../runtime/global-flags.js'
 
 const SERVICE_FLAG: FlagDef = {
@@ -44,5 +46,94 @@ describe('parseCommandArgs', () => {
 		expect(parsed?.flags['--json']).toBe(true)
 		expect(parsed?.flags['--service']).toBe('prod')
 		expect(parsed?.positionals).toEqual(['SELECT 1'])
+	})
+})
+
+const TEST_CONFIG: ResolvedChxConfig = {
+	schema: [],
+	outDir: '.chkit',
+	migrationsDir: 'migrations',
+	metaDir: '.chkit/meta',
+	plugins: [],
+	check: { failOnPending: true, failOnChecksumMismatch: true, failOnDrift: true },
+	safety: { allowDestructive: false },
+}
+
+function makeRegistry(): CommandRegistry {
+	return {
+		commands: [],
+		globalFlags: GLOBAL_FLAGS,
+		get: () => undefined,
+		resolveFlags: () => [...GLOBAL_FLAGS],
+	}
+}
+
+function makeResolved(pluginName: string): RegisteredCommand {
+	return {
+		name: pluginName,
+		description: '',
+		flags: [],
+		pluginFlags: [],
+		pluginName,
+	}
+}
+
+function makeRuntime(): { runtime: PluginRuntime; configLoadedCalls: () => number } {
+	let configLoadedCalls = 0
+	const runtime: PluginRuntime = {
+		plugins: [],
+		getCommand: () => null,
+		resolveContext: async () => {
+			throw new Error('not used')
+		},
+		disposeContext: async () => {},
+		runOnInit: async () => {},
+		runOnComplete: async () => {},
+		runOnConfigLoaded: async () => {
+			configLoadedCalls += 1
+		},
+		runOnSchemaLoaded: async (context) => context.definitions,
+		runOnPlanCreated: async (_context, plan) => plan,
+		runOnBeforeApply: async (context) => context.statements,
+		runOnAfterApply: async () => {},
+		runOnCheck: async () => [],
+		runOnCheckReport: async () => {},
+		runOnBeforePluginCommand: async () => ({ handled: false }),
+		runPluginCommand: async () => 0,
+	}
+	return { runtime, configLoadedCalls: () => configLoadedCalls }
+}
+
+describe('runResolvedCommand', () => {
+	test('does not run onConfigLoaded for the internal core command wrapper', async () => {
+		const { runtime, configLoadedCalls } = makeRuntime()
+
+		await runResolvedCommand({
+			argv: ['generate'],
+			commandName: 'generate',
+			resolved: makeResolved('core'),
+			registry: makeRegistry(),
+			config: TEST_CONFIG,
+			configPath: '/tmp/clickhouse.config.ts',
+			pluginRuntime: runtime,
+		})
+
+		expect(configLoadedCalls()).toBe(0)
+	})
+
+	test('still runs onConfigLoaded once for top-level plugin commands', async () => {
+		const { runtime, configLoadedCalls } = makeRuntime()
+
+		await runResolvedCommand({
+			argv: ['codegen'],
+			commandName: 'codegen',
+			resolved: makeResolved('codegen'),
+			registry: makeRegistry(),
+			config: TEST_CONFIG,
+			configPath: '/tmp/clickhouse.config.ts',
+			pluginRuntime: runtime,
+		})
+
+		expect(configLoadedCalls()).toBe(1)
 	})
 })

--- a/packages/cli/src/test/runtime/config-fallback.test.ts
+++ b/packages/cli/src/test/runtime/config-fallback.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { loadConfig } from '../../runtime/config.js'
+
+interface Sandbox {
+  root: string
+  cwd: string
+  userConfigDir: string
+  cleanup: () => void
+}
+
+function createSandbox(): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), 'chkit-fallback-'))
+  const cwd = join(root, 'project')
+  const userConfigDir = join(root, 'xdg', 'chkit')
+  mkdirSync(cwd, { recursive: true })
+  mkdirSync(userConfigDir, { recursive: true })
+  return {
+    root,
+    cwd,
+    userConfigDir,
+    cleanup() {
+      rmSync(root, { recursive: true, force: true })
+    },
+  }
+}
+
+const PROJECT_CONFIG = `export default { schema: ['./schema/*.ts'], outDir: './chkit' }`
+const PROFILE_CONFIG = `export default { schema: [], plugins: [] }`
+
+describe('loadConfig fallback', () => {
+  test('loads project config when clickhouse.config.ts exists in cwd', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(join(sandbox.cwd, 'clickhouse.config.ts'), PROJECT_CONFIG)
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('project')
+    expect(result.path).toBe(join(sandbox.cwd, 'clickhouse.config.ts'))
+    expect(result.config.schema).toEqual(['./schema/*.ts'])
+    sandbox.cleanup()
+  })
+
+  test('falls back to user profile config.ts when no project config exists', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(join(sandbox.userConfigDir, 'config.ts'), PROFILE_CONFIG)
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('profile')
+    expect(result.path).toBe(join(sandbox.userConfigDir, 'config.ts'))
+    sandbox.cleanup()
+  })
+
+  test('synthesizes a config with obsessiondb plugin when only credentials.json exists', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(
+      join(sandbox.userConfigDir, 'credentials.json'),
+      JSON.stringify({ access_token: 'abc', base_url: 'https://x' }),
+    )
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('synthesized')
+    expect(result.path).toBe(join(sandbox.userConfigDir, 'clickhouse.config.ts'))
+    expect(result.config.plugins).toHaveLength(1)
+    expect(result.config.schema).toEqual([])
+    sandbox.cleanup()
+  })
+
+  test('throws when neither config nor credentials exist', async () => {
+    const sandbox = createSandbox()
+
+    await expect(
+      loadConfig(undefined, {}, { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir }),
+    ).rejects.toThrow(/Config not found/)
+    sandbox.cleanup()
+  })
+
+  test('uses a query-specific error when no project config or profile exists', async () => {
+    const sandbox = createSandbox()
+
+    await expect(
+      loadConfig(undefined, {}, {
+        command: 'query',
+        cwd: sandbox.cwd,
+        userConfigDir: sandbox.userConfigDir,
+      }),
+    ).rejects.toThrow(/Run 'chkit obsessiondb login' to query ObsessionDB/)
+    sandbox.cleanup()
+  })
+
+  test('can synthesize a config without credentials for ObsessionDB bootstrap commands', async () => {
+    const sandbox = createSandbox()
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      {
+        cwd: sandbox.cwd,
+        userConfigDir: sandbox.userConfigDir,
+        allowSynthesizedProfileConfig: true,
+      },
+    )
+
+    expect(result.source).toBe('synthesized')
+    expect(result.path).toBe(join(sandbox.userConfigDir, 'clickhouse.config.ts'))
+    expect(result.config.plugins).toHaveLength(1)
+    expect(result.config.schema).toEqual([])
+    sandbox.cleanup()
+  })
+
+  test('explicit --config path overrides fallback resolution', async () => {
+    const sandbox = createSandbox()
+    const explicit = join(sandbox.root, 'custom.config.ts')
+    writeFileSync(explicit, PROJECT_CONFIG)
+    writeFileSync(
+      join(sandbox.userConfigDir, 'credentials.json'),
+      JSON.stringify({ access_token: 'abc', base_url: 'https://x' }),
+    )
+
+    const result = await loadConfig(
+      explicit,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('project')
+    expect(result.path).toBe(explicit)
+    sandbox.cleanup()
+  })
+})

--- a/packages/cli/src/test/runtime/config-fallback.test.ts
+++ b/packages/cli/src/test/runtime/config-fallback.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path'
 
 import { loadConfig } from '../../runtime/config.js'
 
+const CLI_ENTRY = join(import.meta.dir, '../../bin/chkit.ts')
+
 interface Sandbox {
   root: string
   cwd: string
@@ -30,6 +32,24 @@ function createSandbox(): Sandbox {
 
 const PROJECT_CONFIG = `export default { schema: ['./schema/*.ts'], outDir: './chkit' }`
 const PROFILE_CONFIG = `export default { schema: [], plugins: [] }`
+
+function runCli(sandbox: Sandbox, args: string[]) {
+  const result = Bun.spawnSync({
+    cmd: ['bun', CLI_ENTRY, ...args],
+    cwd: sandbox.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME: join(sandbox.root, 'xdg'),
+    },
+  })
+  return {
+    exitCode: result.exitCode,
+    stdout: new TextDecoder().decode(result.stdout),
+    stderr: new TextDecoder().decode(result.stderr),
+  }
+}
 
 describe('loadConfig fallback', () => {
   test('loads project config when clickhouse.config.ts exists in cwd', async () => {
@@ -77,7 +97,7 @@ describe('loadConfig fallback', () => {
     )
 
     expect(result.source).toBe('synthesized')
-    expect(result.path).toBe(join(sandbox.userConfigDir, 'clickhouse.config.ts'))
+    expect(result.path).toBe('<default:obsessiondb>')
     expect(result.config.plugins).toHaveLength(1)
     expect(result.config.schema).toEqual([])
     sandbox.cleanup()
@@ -119,9 +139,23 @@ describe('loadConfig fallback', () => {
     )
 
     expect(result.source).toBe('synthesized')
-    expect(result.path).toBe(join(sandbox.userConfigDir, 'clickhouse.config.ts'))
+    expect(result.path).toBe('<default:obsessiondb>')
     expect(result.config.plugins).toHaveLength(1)
     expect(result.config.schema).toEqual([])
+    sandbox.cleanup()
+  })
+
+  test('recognizes ObsessionDB bootstrap commands after global plugin flags', () => {
+    const sandbox = createSandbox()
+
+    const result = runCli(sandbox, ['plugin', '--json', 'obsessiondb'])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      command: 'plugin',
+      plugin: 'obsessiondb',
+    })
     sandbox.cleanup()
   })
 
@@ -142,6 +176,158 @@ describe('loadConfig fallback', () => {
 
     expect(result.source).toBe('project')
     expect(result.path).toBe(explicit)
+    sandbox.cleanup()
+  })
+})
+
+describe('loadConfig profile layering', () => {
+  test('layers profile config under project (project keys win, profile keys fill gaps)', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(
+      join(sandbox.userConfigDir, 'config.ts'),
+      `export default {
+        schema: [],
+        outDir: './from-profile',
+        clickhouse: { url: 'https://profile/clickhouse', username: 'pu', database: 'pdb' },
+      }`,
+    )
+    writeFileSync(
+      join(sandbox.cwd, 'clickhouse.config.ts'),
+      `export default {
+        schema: ['./schema/*.ts'],
+        clickhouse: { url: 'https://project/clickhouse' },
+      }`,
+    )
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('project')
+    expect(result.profileLayered).toBe(true)
+    expect(result.config.outDir).toBe('./from-profile')
+    expect(result.config.schema).toEqual(['./schema/*.ts'])
+    expect(result.config.clickhouse?.url).toBe('https://project/clickhouse')
+    expect(result.config.clickhouse?.username).toBe('pu')
+    expect(result.config.clickhouse?.database).toBe('pdb')
+    sandbox.cleanup()
+  })
+
+  test('layers synthesized obsessiondb plugin under a project that has no plugins', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(
+      join(sandbox.cwd, 'clickhouse.config.ts'),
+      `export default { schema: ['./schema/*.ts'] }`,
+    )
+    writeFileSync(
+      join(sandbox.userConfigDir, 'credentials.json'),
+      JSON.stringify({ access_token: 'abc', base_url: 'https://x' }),
+    )
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('project')
+    expect(result.profileLayered).toBe(true)
+    expect(result.path).toBe(join(sandbox.cwd, 'clickhouse.config.ts'))
+    expect(result.config.plugins).toHaveLength(1)
+    sandbox.cleanup()
+  })
+
+  test('project plugin with same name replaces profile plugin (no duplicates)', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(
+      join(sandbox.userConfigDir, 'config.ts'),
+      `export default {
+        schema: [],
+        plugins: [{ plugin: { manifest: { name: 'obsessiondb', apiVersion: 1 } }, name: 'obsessiondb', options: { source: 'profile' } }],
+      }`,
+    )
+    writeFileSync(
+      join(sandbox.cwd, 'clickhouse.config.ts'),
+      `export default {
+        schema: ['./schema/*.ts'],
+        plugins: [{ plugin: { manifest: { name: 'obsessiondb', apiVersion: 1 } }, name: 'obsessiondb', options: { source: 'project' } }],
+      }`,
+    )
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.config.plugins).toHaveLength(1)
+    const reg = result.config.plugins[0] as { options?: { source?: string } }
+    expect(reg.options?.source).toBe('project')
+    sandbox.cleanup()
+  })
+
+  test('project plugins with distinct names are concatenated under profile plugins', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(
+      join(sandbox.userConfigDir, 'credentials.json'),
+      JSON.stringify({ access_token: 'abc', base_url: 'https://x' }),
+    )
+    writeFileSync(
+      join(sandbox.cwd, 'clickhouse.config.ts'),
+      `export default {
+        schema: ['./schema/*.ts'],
+        plugins: [{ plugin: { manifest: { name: 'codegen', apiVersion: 1 } }, name: 'codegen' }],
+      }`,
+    )
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.config.plugins).toHaveLength(2)
+    const names = result.config.plugins.map((p) => (p as { name?: string }).name)
+    expect(names).toEqual(['obsessiondb', 'codegen'])
+    sandbox.cleanup()
+  })
+
+  test('project config alone (no profile, no credentials) does not layer', async () => {
+    const sandbox = createSandbox()
+    writeFileSync(join(sandbox.cwd, 'clickhouse.config.ts'), PROJECT_CONFIG)
+
+    const result = await loadConfig(
+      undefined,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('project')
+    expect(result.profileLayered).toBe(false)
+    expect(result.config.plugins).toHaveLength(0)
+    sandbox.cleanup()
+  })
+
+  test('explicit --config also gets the profile layered underneath', async () => {
+    const sandbox = createSandbox()
+    const explicit = join(sandbox.root, 'custom.config.ts')
+    writeFileSync(explicit, `export default { schema: ['./schema/*.ts'] }`)
+    writeFileSync(
+      join(sandbox.userConfigDir, 'credentials.json'),
+      JSON.stringify({ access_token: 'abc', base_url: 'https://x' }),
+    )
+
+    const result = await loadConfig(
+      explicit,
+      {},
+      { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
+    )
+
+    expect(result.source).toBe('project')
+    expect(result.profileLayered).toBe(true)
+    expect(result.config.plugins).toHaveLength(1)
     sandbox.cleanup()
   })
 })

--- a/packages/cli/src/test/runtime/config-fallback.test.ts
+++ b/packages/cli/src/test/runtime/config-fallback.test.ts
@@ -96,7 +96,7 @@ describe('loadConfig fallback', () => {
       { cwd: sandbox.cwd, userConfigDir: sandbox.userConfigDir },
     )
 
-    expect(result.source).toBe('synthesized')
+    expect(result.source).toBe('profile')
     expect(result.path).toBe('<default:obsessiondb>')
     expect(result.config.plugins).toHaveLength(1)
     expect(result.config.schema).toEqual([])
@@ -138,7 +138,7 @@ describe('loadConfig fallback', () => {
       },
     )
 
-    expect(result.source).toBe('synthesized')
+    expect(result.source).toBe('profile')
     expect(result.path).toBe('<default:obsessiondb>')
     expect(result.config.plugins).toHaveLength(1)
     expect(result.config.schema).toEqual([])

--- a/packages/cli/src/test/runtime/config-merge.test.ts
+++ b/packages/cli/src/test/runtime/config-merge.test.ts
@@ -109,15 +109,7 @@ describe('pluginNameOf', () => {
     expect(pluginNameOf({ plugin: { manifest: { name: 'codegen' } } })).toBe('codegen')
   })
 
-  test('reads explicit name from legacy registration', () => {
-    expect(pluginNameOf({ resolve: './foo.js', name: 'mine' })).toBe('mine')
-  })
-
-  test('falls back to basename for legacy registration', () => {
-    expect(pluginNameOf({ resolve: '/abs/pkg/dist/index.js' })).toBe('index')
-  })
-
-  test('returns basename for string registration', () => {
-    expect(pluginNameOf('./plugins/my-plugin.js')).toBe('my-plugin')
+  test('returns undefined when neither name nor manifest is present', () => {
+    expect(pluginNameOf({ plugin: {} })).toBeUndefined()
   })
 })

--- a/packages/cli/src/test/runtime/config-merge.test.ts
+++ b/packages/cli/src/test/runtime/config-merge.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ChxUserConfig } from '@chkit/core'
+
+import { mergeUserConfig, pluginNameOf } from '../../runtime/config-merge.js'
+
+const profile: ChxUserConfig = {
+  schema: [],
+  outDir: './from-profile',
+  plugins: [
+    { plugin: { manifest: { name: 'obsessiondb' } }, name: 'obsessiondb', options: { service: 'from-profile' } },
+  ],
+  clickhouse: {
+    url: 'https://profile.example/clickhouse',
+    username: 'profile-user',
+    database: 'profile_db',
+  },
+  check: { failOnDrift: false },
+  safety: { allowDestructive: true },
+}
+
+describe('mergeUserConfig', () => {
+  test('overlay scalar fields beat base', () => {
+    const merged = mergeUserConfig(profile, {
+      schema: ['./schema/*.ts'],
+      outDir: './from-project',
+    })
+    expect(merged.schema).toEqual(['./schema/*.ts'])
+    expect(merged.outDir).toBe('./from-project')
+  })
+
+  test('falls back to base when overlay field is missing', () => {
+    const merged = mergeUserConfig(profile, { schema: ['./schema/*.ts'] })
+    expect(merged.outDir).toBe('./from-profile')
+  })
+
+  test('plugins from base are kept when overlay has no plugins field', () => {
+    const merged = mergeUserConfig(profile, { schema: [] })
+    expect(merged.plugins).toHaveLength(1)
+    expect((merged.plugins ?? []).map(pluginNameOf)).toEqual(['obsessiondb'])
+  })
+
+  test('plugins concatenate when names differ', () => {
+    const merged = mergeUserConfig(profile, {
+      schema: [],
+      plugins: [{ plugin: { manifest: { name: 'codegen' } }, name: 'codegen' }],
+    })
+    expect(merged.plugins).toHaveLength(2)
+    expect((merged.plugins ?? []).map(pluginNameOf)).toEqual(['obsessiondb', 'codegen'])
+  })
+
+  test('overlay plugin with same name replaces base plugin', () => {
+    const merged = mergeUserConfig(profile, {
+      schema: [],
+      plugins: [
+        { plugin: { manifest: { name: 'obsessiondb' } }, name: 'obsessiondb', options: { service: 'from-project' } },
+      ],
+    })
+    expect(merged.plugins).toHaveLength(1)
+    const reg = (merged.plugins ?? [])[0] as { options?: { service?: string } }
+    expect(reg.options?.service).toBe('from-project')
+  })
+
+  test('explicit empty plugins array in overlay still concatenates (overlay contributes nothing)', () => {
+    const merged = mergeUserConfig(profile, { schema: [], plugins: [] })
+    expect(merged.plugins).toHaveLength(1)
+    expect((merged.plugins ?? []).map(pluginNameOf)).toEqual(['obsessiondb'])
+  })
+
+  test('clickhouse is field-by-field merged with overlay winning', () => {
+    const merged = mergeUserConfig(profile, {
+      schema: [],
+      clickhouse: { url: 'https://project.example/clickhouse', password: 'secret' },
+    })
+    expect(merged.clickhouse).toEqual({
+      url: 'https://project.example/clickhouse',
+      username: 'profile-user',
+      database: 'profile_db',
+      password: 'secret',
+    })
+  })
+
+  test('check and safety fields merge shallowly', () => {
+    const merged = mergeUserConfig(profile, {
+      schema: [],
+      check: { failOnPending: false },
+    })
+    expect(merged.check).toEqual({ failOnDrift: false, failOnPending: false })
+    expect(merged.safety).toEqual({ allowDestructive: true })
+  })
+
+  test('handles base without optional fields', () => {
+    const merged = mergeUserConfig(
+      { schema: [] },
+      { schema: ['./a.ts'], outDir: './out' },
+    )
+    expect(merged.outDir).toBe('./out')
+    expect(merged.plugins).toBeUndefined()
+    expect(merged.clickhouse).toBeUndefined()
+  })
+})
+
+describe('pluginNameOf', () => {
+  test('reads explicit name from inline registration', () => {
+    expect(pluginNameOf({ plugin: {}, name: 'mine' })).toBe('mine')
+  })
+
+  test('falls back to manifest.name on inline registration', () => {
+    expect(pluginNameOf({ plugin: { manifest: { name: 'codegen' } } })).toBe('codegen')
+  })
+
+  test('reads explicit name from legacy registration', () => {
+    expect(pluginNameOf({ resolve: './foo.js', name: 'mine' })).toBe('mine')
+  })
+
+  test('falls back to basename for legacy registration', () => {
+    expect(pluginNameOf({ resolve: '/abs/pkg/dist/index.js' })).toBe('index')
+  })
+
+  test('returns basename for string registration', () => {
+    expect(pluginNameOf('./plugins/my-plugin.js')).toBe('my-plugin')
+  })
+})

--- a/packages/cli/src/test/runtime/extract-config-path.test.ts
+++ b/packages/cli/src/test/runtime/extract-config-path.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+
+import { extractConfigPath } from '../../runtime/extract-config-path.js'
+
+describe('extractConfigPath', () => {
+  test('returns undefined when --config is absent', () => {
+    expect(extractConfigPath(['generate'])).toBeUndefined()
+  })
+
+  test('reads --config followed by a separate value', () => {
+    expect(extractConfigPath(['generate', '--config', 'a.ts'])).toBe('a.ts')
+  })
+
+  test('reads --config=value equals form', () => {
+    expect(extractConfigPath(['generate', '--config=a.ts'])).toBe('a.ts')
+  })
+
+  test('reads --config when it appears after the command name', () => {
+    expect(extractConfigPath(['migrate', 'apply', '--config', 'a.ts'])).toBe('a.ts')
+  })
+
+  test('stops scanning at "--" so trailing values are not picked up', () => {
+    expect(extractConfigPath(['query', '--', '--config', 'a.ts'])).toBeUndefined()
+  })
+
+  test('first --config wins when multiple are present', () => {
+    expect(extractConfigPath(['--config', 'first.ts', '--config', 'second.ts'])).toBe('first.ts')
+  })
+
+  test('returns empty string when --config=  (empty value) is given', () => {
+    expect(extractConfigPath(['--config='])).toBe('')
+  })
+})

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -225,8 +225,8 @@ function parseIndexType(value: string): ParsedIndexShape {
 		case 'minmax':
 			return { type: 'minmax' }
 		case 'bloom_filter':
-			return args.length > 0
-				? { type: 'bloom_filter', falsePositiveRate: args[0]! }
+			return args[0] !== undefined
+				? { type: 'bloom_filter', falsePositiveRate: args[0] }
 				: { type: 'bloom_filter' }
 		case 'tokenbf_v1':
 			return {
@@ -602,8 +602,8 @@ export function createExecutorWithClient(
 					written_bytes: string
 					elapsed: string
 				}>()
-				if (runningRows.length > 0) {
-					const proc = runningRows[0]!
+				const [proc] = runningRows
+				if (proc) {
 					return {
 						status: 'running',
 						readRows: Number(proc.read_rows),
@@ -641,7 +641,10 @@ SETTINGS skip_unavailable_shards = 1`,
 					return { status: 'unknown' }
 				}
 
-				const row = logRows[0]!
+				const [row] = logRows
+				if (!row) {
+					return { status: 'unknown' }
+				}
 				if (row.type === 'QueryFinish') {
 					return {
 						status: 'finished',

--- a/packages/core/src/codec.test.ts
+++ b/packages/core/src/codec.test.ts
@@ -100,8 +100,8 @@ describe('parseCodec', () => {
 
   test('raw fallback round-trips through renderCodec', () => {
     const parsed = parseCodec('CODEC(SomeNewCodec(42))')
-    expect(parsed).toBeDefined()
-    expect(renderCodec(parsed!)).toBe('CODEC(SomeNewCodec(42))')
+    if (!parsed) throw new Error('expected parsed codec')
+    expect(renderCodec(parsed)).toBe('CODEC(SomeNewCodec(42))')
   })
 
   test('falls back to raw when known codec has unexpected extra args', () => {

--- a/packages/core/src/codec.ts
+++ b/packages/core/src/codec.ts
@@ -113,8 +113,7 @@ function splitTopLevelCommas(input: string): string[] {
   const out: string[] = []
   let depth = 0
   let current = ''
-  for (let i = 0; i < input.length; i++) {
-    const ch = input[i]!
+  for (const ch of input) {
     if (ch === '(') depth += 1
     else if (ch === ')') depth = Math.max(0, depth - 1)
     if (ch === ',' && depth === 0) {

--- a/packages/core/src/config-path.ts
+++ b/packages/core/src/config-path.ts
@@ -1,0 +1,5 @@
+export const SYNTHESIZED_CONFIG_PATH = '<default:obsessiondb>'
+
+export function isSynthesizedConfigPath(path: string): boolean {
+  return path === SYNTHESIZED_CONFIG_PATH
+}

--- a/packages/core/src/flags.test.ts
+++ b/packages/core/src/flags.test.ts
@@ -76,6 +76,25 @@ describe('parseFlags', () => {
     expect(result['--name']).toBe('second')
   })
 
+  it('parses --name=value equals form for string flags', () => {
+    const result = parseFlags(['--name=my-migration'], defs)
+    expect(result['--name']).toBe('my-migration')
+  })
+
+  it('accepts empty value for --name= form', () => {
+    const result = parseFlags(['--name='], defs)
+    expect(result['--name']).toBe('')
+  })
+
+  it('parses --name=value for string[] flags', () => {
+    const result = parseFlags(['--database=db1,db2'], defs)
+    expect(result['--database']).toEqual(['db1', 'db2'])
+  })
+
+  it('rejects equals form on boolean flags', () => {
+    expect(() => parseFlags(['--json=true'], defs)).toThrow(UnknownFlagError)
+  })
+
   it('infers typed record from defineFlags', () => {
     const typedDefs = defineFlags([
       { name: '--out', type: 'string', description: 'Output' },

--- a/packages/core/src/flags.ts
+++ b/packages/core/src/flags.ts
@@ -81,19 +81,18 @@ export interface SafeParseable<T> {
 }
 
 /**
- * Three-layer option resolution: pluginConfig → runtimeOptions → CLI flags.
+ * Two-layer option resolution: registration options → CLI flags.
  * Merges sources, validates through a schema, and throws ErrorClass on failure.
  */
 export function resolveOptions<T>(
   schema: SafeParseable<T>,
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
+  options: Record<string, unknown>,
   flags: ParsedFlags,
   flagMapping: FlagMapping,
   ErrorClass: new (message: string) => Error = Error
 ): T {
   const cliOverrides = mapFlags(flags, flagMapping)
-  const merged = { ...pluginConfig, ...runtimeOptions, ...cliOverrides }
+  const merged = { ...options, ...cliOverrides }
   const result = schema.safeParse(merged)
   if (!result.success) {
     const issue = result.error.issues[0]

--- a/packages/core/src/flags.ts
+++ b/packages/core/src/flags.ts
@@ -121,45 +121,62 @@ export function parseFlags<const T extends readonly FlagDef[]>(argv: string[], f
 
   const flags: ParsedFlags = {}
 
+  const addArrayValue = (key: string, raw: string): void => {
+    const values = raw.split(',').map((v) => v.trim()).filter((v) => v.length > 0)
+    const existing = flags[key]
+    if (Array.isArray(existing)) {
+      existing.push(...values)
+    } else {
+      flags[key] = values
+    }
+  }
+
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i]
     if (!token || !token.startsWith('--')) continue
 
-    if (negationMap.has(token)) {
-      const originalName = negationMap.get(token) as string
+    const eqIdx = token.indexOf('=')
+    const name = eqIdx === -1 ? token : token.slice(0, eqIdx)
+    const inlineValue = eqIdx === -1 ? undefined : token.slice(eqIdx + 1)
+
+    if (eqIdx === -1 && negationMap.has(name)) {
+      const originalName = negationMap.get(name) as string
       flags[originalName] = false
       continue
     }
 
-    const def = lookup.get(token)
+    const def = lookup.get(name)
     if (!def) {
-      throw new UnknownFlagError(token)
+      throw new UnknownFlagError(name)
     }
 
     if (def.type === 'boolean') {
+      if (inlineValue !== undefined) {
+        throw new UnknownFlagError(token)
+      }
       flags[def.name] = true
       continue
     }
 
-    const nextToken = argv[i + 1]
-    if (nextToken === undefined || nextToken.startsWith('--')) {
-      throw new MissingFlagValueError(def.name)
+    let value: string
+    if (inlineValue !== undefined) {
+      value = inlineValue
+    } else {
+      const nextToken = argv[i + 1]
+      if (nextToken === undefined || nextToken.startsWith('--')) {
+        throw new MissingFlagValueError(def.name)
+      }
+      value = nextToken
+      i += 1
     }
-    i += 1
 
     if (def.type === 'string') {
-      flags[def.name] = nextToken
+      flags[def.name] = value
       continue
     }
 
     if (def.type === 'string[]') {
-      const values = nextToken.split(',').map((v) => v.trim()).filter((v) => v.length > 0)
-      const existing = flags[def.name]
-      if (Array.isArray(existing)) {
-        existing.push(...values)
-      } else {
-        flags[def.name] = values
-      }
+      addArrayValue(def.name, value)
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './flags.js'
 export * from './model.js'
+export { SYNTHESIZED_CONFIG_PATH, isSynthesizedConfigPath } from './config-path.js'
 export {
   canonicalizeDefinition,
   canonicalizeDefinitions,

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -184,13 +184,6 @@ export interface ChxResolvedClickHouseConfig {
   secure: boolean
 }
 
-export interface ChxLegacyPluginRegistration {
-  resolve: string
-  name?: string
-  enabled?: boolean
-  options?: Record<string, unknown>
-}
-
 export interface ChxInlinePluginRegistration<
   TPlugin = unknown,
   TOptions extends object = Record<string, unknown>,
@@ -201,10 +194,7 @@ export interface ChxInlinePluginRegistration<
   options?: TOptions
 }
 
-export type ChxPluginRegistration =
-  | string
-  | ChxLegacyPluginRegistration
-  | ChxInlinePluginRegistration
+export type ChxPluginRegistration = ChxInlinePluginRegistration
 
 export interface ChxUserConfig {
   schema: string | string[]

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -45,8 +45,7 @@ function validateColumnCodec(
   }
   let generalCount = 0
   let generalIndex = -1
-  for (let i = 0; i < steps.length; i++) {
-    const step = steps[i]!
+  for (const [i, step] of steps.entries()) {
     if (isRawCodec(step)) continue
     if (isGeneralCodec(step)) {
       generalCount += 1

--- a/packages/plugin-backfill/src/options.test.ts
+++ b/packages/plugin-backfill/src/options.test.ts
@@ -102,10 +102,9 @@ describe('ResumeSchema', () => {
 })
 
 describe('resolveOptions', () => {
-  test('CLI flags override plugin config and runtime options', () => {
+  test('CLI flags override registration options', () => {
     const opts = resolveOptions(
       PlanSchema,
-      { maxChunkBytes: 5 * 1024 ** 3 },
       { maxChunkBytes: 8 * 1024 ** 3 },
       { '--target': 'app.events', '--max-chunk-bytes': '20G' },
       {
@@ -121,10 +120,9 @@ describe('resolveOptions', () => {
     expect(opts.maxChunkBytes).toBe(20 * 1024 ** 3)
   })
 
-  test('runtime options override plugin config', () => {
+  test('registration options apply when no CLI override', () => {
     const opts = resolveOptions(
       RunSchema,
-      { concurrency: 2 },
       { concurrency: 5 },
       { '--plan-id': 'abc123def456789a' },
       { '--plan-id': { key: 'planId', coerce: (v: string) => v } }
@@ -137,7 +135,6 @@ describe('resolveOptions', () => {
     const opts = resolveOptions(
       RunSchema,
       {},
-      {},
       { '--plan-id': 'abc123def456789a' },
       { '--plan-id': { key: 'planId', coerce: (v: string) => v } }
     )
@@ -149,7 +146,7 @@ describe('resolveOptions', () => {
 
   test('throws on invalid options', () => {
     expect(() =>
-      resolveOptions(PlanSchema, {}, {}, {}, {})
+      resolveOptions(PlanSchema, {}, {}, {})
     ).toThrow()
   })
 })

--- a/packages/plugin-backfill/src/options.ts
+++ b/packages/plugin-backfill/src/options.ts
@@ -129,7 +129,6 @@ export const CheckSchema = z.object({
   stateDir: z.string().min(1).optional(),
   failCheckOnRequiredPendingBackfill: z.boolean().default(true),
 })
-export type CheckOptions = z.infer<typeof CheckSchema>
 
 // ───── CLI flag definitions ─────
 

--- a/packages/plugin-backfill/src/options.ts
+++ b/packages/plugin-backfill/src/options.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { defineFlags, resolveOptions, type FlagMapping } from '@chkit/core'
+import { defineFlags, type FlagMapping } from '@chkit/core'
 
 import { BackfillConfigError } from './errors.js'
 
@@ -112,24 +112,24 @@ export const RunSchema = z.object({
   pollIntervalMs: z.number().nonnegative().default(5000),
   stateDir: z.string().min(1).optional(),
 })
-type RunOptions = z.infer<typeof RunSchema>
+export type RunOptions = z.infer<typeof RunSchema>
 
 export const ResumeSchema = RunSchema.extend({
   replayFailed: z.boolean().default(false),
 })
-type ResumeOptions = z.infer<typeof ResumeSchema>
+export type ResumeOptions = z.infer<typeof ResumeSchema>
 
-const StatusSchema = z.object({
+export const StatusSchema = z.object({
   planId: z.string(),
   stateDir: z.string().min(1).optional(),
 })
-type StatusOptions = z.infer<typeof StatusSchema>
+export type StatusOptions = z.infer<typeof StatusSchema>
 
 export const CheckSchema = z.object({
   stateDir: z.string().min(1).optional(),
   failCheckOnRequiredPendingBackfill: z.boolean().default(true),
 })
-type CheckOptions = z.infer<typeof CheckSchema>
+export type CheckOptions = z.infer<typeof CheckSchema>
 
 // ───── CLI flag definitions ─────
 
@@ -161,7 +161,7 @@ export const PLAN_ID_FLAGS = defineFlags([
 
 // ───── Flag mappings ─────
 
-const PLAN_FLAG_MAP: FlagMapping = {
+export const PLAN_FLAG_MAP: FlagMapping = {
   '--target': { key: 'target', coerce: normalizeTarget },
   '--from': { key: 'from', coerce: (v) => normalizeTimestamp(v, '--from') },
   '--to': { key: 'to', coerce: (v) => normalizeTimestamp(v, '--to') },
@@ -176,14 +176,14 @@ function coercePositiveInt(v: string, flag: string): number {
   return n
 }
 
-const RUN_FLAG_MAP: FlagMapping = {
+export const RUN_FLAG_MAP: FlagMapping = {
   '--plan-id': { key: 'planId', coerce: normalizePlanId },
   '--force-environment': { key: 'forceEnvironment' },
   '--concurrency': { key: 'concurrency', coerce: (v) => coercePositiveInt(v, '--concurrency') },
   '--poll-interval': { key: 'pollIntervalMs', coerce: (v) => coercePositiveInt(v, '--poll-interval') },
 }
 
-const RESUME_FLAG_MAP: FlagMapping = {
+export const RESUME_FLAG_MAP: FlagMapping = {
   '--plan-id': { key: 'planId', coerce: normalizePlanId },
   '--force-environment': { key: 'forceEnvironment' },
   '--concurrency': { key: 'concurrency', coerce: (v) => coercePositiveInt(v, '--concurrency') },
@@ -191,47 +191,6 @@ const RESUME_FLAG_MAP: FlagMapping = {
   '--replay-failed': { key: 'replayFailed' },
 }
 
-const PLAN_ID_FLAG_MAP: FlagMapping = {
+export const PLAN_ID_FLAG_MAP: FlagMapping = {
   '--plan-id': { key: 'planId', coerce: normalizePlanId },
-}
-
-// ───── Per-command resolvers ─────
-
-export function resolvePlanOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
-  flags: Record<string, string | string[] | boolean | undefined>
-): PlanOptions {
-  return resolveOptions(PlanSchema, pluginConfig, runtimeOptions, flags, PLAN_FLAG_MAP, BackfillConfigError)
-}
-
-export function resolveRunOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
-  flags: Record<string, string | string[] | boolean | undefined>
-): RunOptions {
-  return resolveOptions(RunSchema, pluginConfig, runtimeOptions, flags, RUN_FLAG_MAP, BackfillConfigError)
-}
-
-export function resolveResumeOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
-  flags: Record<string, string | string[] | boolean | undefined>
-): ResumeOptions {
-  return resolveOptions(ResumeSchema, pluginConfig, runtimeOptions, flags, RESUME_FLAG_MAP, BackfillConfigError)
-}
-
-export function resolveStatusOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
-  flags: Record<string, string | string[] | boolean | undefined>
-): StatusOptions {
-  return resolveOptions(StatusSchema, pluginConfig, runtimeOptions, flags, PLAN_ID_FLAG_MAP, BackfillConfigError)
-}
-
-export function resolveCheckOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>
-): CheckOptions {
-  return resolveOptions(CheckSchema, pluginConfig, runtimeOptions, {}, {}, BackfillConfigError)
 }

--- a/packages/plugin-backfill/src/plugin.test.ts
+++ b/packages/plugin-backfill/src/plugin.test.ts
@@ -31,6 +31,28 @@ describe('@chkit/plugin-backfill plugin surface', () => {
     expect(registration.options?.maxParallelChunks).toBe(4)
   })
 
+  test('createBackfillPlugin carries factory options into runtime schemas', () => {
+    const plugin = createBackfillPlugin({
+      maxParallelChunks: 4,
+      stateDir: './state',
+    })
+    const plan = plugin.commands.find((command) => command.name === 'plan')
+    const run = plugin.commands.find((command) => command.name === 'run')
+
+    const pluginResult = plugin.optionsSchema?.safeParse({})
+    const planResult = plan?.optionsSchema?.safeParse({ target: 'app.events' })
+    const runResult = run?.optionsSchema?.safeParse({ planId: '0123456789abcdef' })
+
+    expect(pluginResult?.success).toBe(true)
+    expect(planResult?.success).toBe(true)
+    expect(runResult?.success).toBe(true)
+    if (!pluginResult?.success || !planResult?.success || !runResult?.success) return
+    expect(pluginResult.data.maxParallelChunks).toBe(4)
+    expect(planResult.data.maxParallelChunks).toBe(4)
+    expect(planResult.data.stateDir).toBe('./state')
+    expect(runResult.data.stateDir).toBe('./state')
+  })
+
   test('keeps internals off the package root and exposes them via sdk', () => {
     expect(root).not.toHaveProperty('analyzeAndChunk')
     expect(root).not.toHaveProperty('executeBackfill')

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -1,5 +1,5 @@
 import { createClickHouseExecutor } from '@chkit/clickhouse'
-import { wrapPluginRun } from '@chkit/core'
+import { wrapPluginRun, type SafeParseable } from '@chkit/core'
 
 import { executeBackfill, type BackfillProgress } from './async-backfill.js'
 import { buildChunkExecutionSql } from './chunking/sql.js'
@@ -20,7 +20,6 @@ import {
   RUN_FLAG_MAP,
   RunSchema,
   StatusSchema,
-  type CheckOptions,
   type PlanOptions,
   type PluginConfig,
   type ResumeOptions,
@@ -190,19 +189,40 @@ async function runBackfill(input: {
   }
 }
 
-export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugin {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function withFactoryDefaults<T>(
+  schema: SafeParseable<T>,
+  defaults: Record<string, unknown>,
+): SafeParseable<T> {
+  return {
+    safeParse(data) {
+      return schema.safeParse({ ...defaults, ...(isRecord(data) ? data : {}) })
+    },
+  }
+}
+
+export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin {
+  const factoryOptions = options as Record<string, unknown>
+  const planOptionsSchema = withFactoryDefaults(PlanSchema, factoryOptions)
+  const runOptionsSchema = withFactoryDefaults(RunSchema, factoryOptions)
+  const resumeOptionsSchema = withFactoryDefaults(ResumeSchema, factoryOptions)
+  const statusOptionsSchema = withFactoryDefaults(StatusSchema, factoryOptions)
+
   return {
     manifest: {
       name: 'backfill',
       apiVersion: 1,
     },
-    optionsSchema: PluginConfigSchema,
+    optionsSchema: withFactoryDefaults(PluginConfigSchema, factoryOptions),
     commands: [
       {
         name: 'plan',
         description: 'Build a deterministic backfill plan and persist immutable plan state',
         flags: PLAN_FLAGS,
-        optionsSchema: PlanSchema,
+        optionsSchema: planOptionsSchema,
         flagMapping: PLAN_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
@@ -264,7 +284,7 @@ export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugi
         name: 'run',
         description: 'Execute a planned backfill with async query submission and polling',
         flags: RUN_FLAGS,
-        optionsSchema: RunSchema,
+        optionsSchema: runOptionsSchema,
         flagMapping: RUN_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
@@ -301,7 +321,7 @@ export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugi
         name: 'resume',
         description: 'Resume a backfill run from last checkpoint',
         flags: RESUME_FLAGS,
-        optionsSchema: ResumeSchema,
+        optionsSchema: resumeOptionsSchema,
         flagMapping: RESUME_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
@@ -362,7 +382,7 @@ export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugi
         name: 'status',
         description: 'Show checkpoint and chunk progress for a backfill run',
         flags: PLAN_ID_FLAGS,
-        optionsSchema: StatusSchema,
+        optionsSchema: statusOptionsSchema,
         flagMapping: PLAN_ID_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
@@ -400,7 +420,7 @@ export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugi
         name: 'cancel',
         description: 'Cancel an in-progress backfill run and prevent further chunk execution',
         flags: PLAN_ID_FLAGS,
-        optionsSchema: StatusSchema,
+        optionsSchema: statusOptionsSchema,
         flagMapping: PLAN_ID_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
@@ -433,7 +453,7 @@ export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugi
         name: 'doctor',
         description: 'Provide actionable remediation steps for failed or pending backfill runs',
         flags: PLAN_ID_FLAGS,
-        optionsSchema: StatusSchema,
+        optionsSchema: statusOptionsSchema,
         flagMapping: PLAN_ID_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -6,17 +6,26 @@ import { buildChunkExecutionSql } from './chunking/sql.js'
 import { generateIdempotencyToken } from './chunking/utils/ids.js'
 import { BackfillConfigError } from './errors.js'
 import {
+  CheckSchema,
   PLAN_FLAGS,
+  PLAN_FLAG_MAP,
   PLAN_ID_FLAGS,
-  RESUME_FLAGS,
-  RUN_FLAGS,
+  PLAN_ID_FLAG_MAP,
+  PlanSchema,
   PluginConfigSchema,
-  resolveCheckOptions,
-  resolvePlanOptions,
-  resolveResumeOptions,
-  resolveRunOptions,
-  resolveStatusOptions,
+  RESUME_FLAGS,
+  RESUME_FLAG_MAP,
+  ResumeSchema,
+  RUN_FLAGS,
+  RUN_FLAG_MAP,
+  RunSchema,
+  StatusSchema,
+  type CheckOptions,
+  type PlanOptions,
   type PluginConfig,
+  type ResumeOptions,
+  type RunOptions,
+  type StatusOptions,
 } from './options.js'
 import { planPayload, statusPayload, cancelPayload, doctorPayload } from './payload.js'
 import { buildBackfillPlan } from './planner.js'
@@ -181,19 +190,20 @@ async function runBackfill(input: {
   }
 }
 
-export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin {
-  const config = PluginConfigSchema.parse(options)
-
+export function createBackfillPlugin(_options: PluginConfig = {}): BackfillPlugin {
   return {
     manifest: {
       name: 'backfill',
       apiVersion: 1,
     },
+    optionsSchema: PluginConfigSchema,
     commands: [
       {
         name: 'plan',
         description: 'Build a deterministic backfill plan and persist immutable plan state',
         flags: PLAN_FLAGS,
+        optionsSchema: PlanSchema,
+        flagMapping: PLAN_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
             command: 'plan',
@@ -202,7 +212,7 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
             print: context.print,
             configErrorClass: BackfillConfigError,
             fn: async () => {
-              const opts = resolvePlanOptions(config, context.options, context.flags)
+              const opts = context.options as PlanOptions
 
               if (!context.config.clickhouse) {
                 throw new BackfillConfigError(
@@ -254,6 +264,8 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         name: 'run',
         description: 'Execute a planned backfill with async query submission and polling',
         flags: RUN_FLAGS,
+        optionsSchema: RunSchema,
+        flagMapping: RUN_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
             command: 'run',
@@ -262,7 +274,7 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
             print: context.print,
             configErrorClass: BackfillConfigError,
             fn: async () => {
-              const opts = resolveRunOptions(config, context.options, context.flags)
+              const opts = context.options as RunOptions
 
               if (!context.config.clickhouse) {
                 throw new BackfillConfigError(
@@ -289,6 +301,8 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         name: 'resume',
         description: 'Resume a backfill run from last checkpoint',
         flags: RESUME_FLAGS,
+        optionsSchema: ResumeSchema,
+        flagMapping: RESUME_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
             command: 'resume',
@@ -297,7 +311,7 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
             print: context.print,
             configErrorClass: BackfillConfigError,
             fn: async () => {
-              const opts = resolveResumeOptions(config, context.options, context.flags)
+              const opts = context.options as ResumeOptions
 
               if (!context.config.clickhouse) {
                 throw new BackfillConfigError(
@@ -348,6 +362,8 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         name: 'status',
         description: 'Show checkpoint and chunk progress for a backfill run',
         flags: PLAN_ID_FLAGS,
+        optionsSchema: StatusSchema,
+        flagMapping: PLAN_ID_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
             command: 'status',
@@ -356,7 +372,7 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
             print: context.print,
             configErrorClass: BackfillConfigError,
             fn: async () => {
-              const opts = resolveStatusOptions(config, context.options, context.flags)
+              const opts = context.options as StatusOptions
               const summary = await getBackfillStatus({
                 planId: opts.planId,
                 config: context.config,
@@ -384,6 +400,8 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         name: 'cancel',
         description: 'Cancel an in-progress backfill run and prevent further chunk execution',
         flags: PLAN_ID_FLAGS,
+        optionsSchema: StatusSchema,
+        flagMapping: PLAN_ID_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
             command: 'cancel',
@@ -392,7 +410,7 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
             print: context.print,
             configErrorClass: BackfillConfigError,
             fn: async () => {
-              const opts = resolveStatusOptions(config, context.options, context.flags)
+              const opts = context.options as StatusOptions
               const summary = await cancelBackfillRun({
                 planId: opts.planId,
                 config: context.config,
@@ -415,6 +433,8 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         name: 'doctor',
         description: 'Provide actionable remediation steps for failed or pending backfill runs',
         flags: PLAN_ID_FLAGS,
+        optionsSchema: StatusSchema,
+        flagMapping: PLAN_ID_FLAG_MAP,
         run: async (context) =>
           wrapPluginRun({
             command: 'doctor',
@@ -423,7 +443,7 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
             print: context.print,
             configErrorClass: BackfillConfigError,
             fn: async () => {
-              const opts = resolveStatusOptions(config, context.options, context.flags)
+              const opts = context.options as StatusOptions
               const report = await getBackfillDoctorReport({
                 planId: opts.planId,
                 config: context.config,
@@ -447,11 +467,11 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
       },
     ],
     hooks: {
-      onConfigLoaded({ options: runtimeOptions }) {
-        resolveCheckOptions(config, runtimeOptions)
+      onConfigLoaded() {
+        // Plugin-level options validated softly at load time via PluginConfigSchema.
       },
-      async onCheck({ config: appConfig, configPath, options: runtimeOptions }) {
-        const opts = resolveCheckOptions(config, runtimeOptions)
+      async onCheck({ config: appConfig, configPath, options }) {
+        const opts = CheckSchema.parse(options)
         return evaluateBackfillCheck({
           configPath,
           config: appConfig,

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -1,4 +1,9 @@
-import type { ChxInlinePluginRegistration, ResolvedChxConfig } from '@chkit/core'
+import type {
+  ChxInlinePluginRegistration,
+  FlagMapping,
+  ResolvedChxConfig,
+  SafeParseable,
+} from '@chkit/core'
 
 import type { BackfillProgress } from './async-backfill.js'
 import type {
@@ -137,11 +142,12 @@ export interface BackfillDoctorReport {
   failedChunkIds: string[]
 }
 
-interface BackfillPluginCommandContext {
+interface BackfillPluginCommandContext<TOptions = Record<string, unknown>> {
   args: string[]
   flags: Record<string, string | string[] | boolean | undefined>
   jsonMode: boolean
-  options: Record<string, unknown>
+  options: TOptions
+  rawOptions: Record<string, unknown>
   config: ResolvedChxConfig
   configPath: string
   print: (value: unknown) => void
@@ -153,6 +159,7 @@ export interface BackfillPlugin {
     apiVersion: 1
     version?: string
   }
+  optionsSchema?: SafeParseable<Record<string, unknown>>
   commands: Array<{
     name: 'plan' | 'run' | 'resume' | 'status' | 'cancel' | 'doctor'
     description: string
@@ -163,6 +170,8 @@ export interface BackfillPlugin {
       placeholder?: string
       negation?: boolean
     }>
+    optionsSchema?: SafeParseable<Record<string, unknown>>
+    flagMapping?: FlagMapping
     run: (context: BackfillPluginCommandContext) => undefined | number | Promise<undefined | number>
   }>
   hooks?: {

--- a/packages/plugin-codegen/src/index.test.ts
+++ b/packages/plugin-codegen/src/index.test.ts
@@ -51,6 +51,21 @@ describe('@chkit/plugin-codegen options', () => {
     expect(registration.options?.emitZod).toBe(true)
     expect(registration.plugin.manifest.name).toBe('codegen')
   })
+
+  test('createCodegenPlugin carries factory options into runtime schemas', () => {
+    const plugin = createCodegenPlugin({ outFile: './types.ts', emitZod: true })
+    const command = plugin.commands[0]
+
+    const pluginResult = plugin.optionsSchema?.safeParse({})
+    const commandResult = command?.optionsSchema?.safeParse({})
+
+    expect(pluginResult?.success).toBe(true)
+    expect(commandResult?.success).toBe(true)
+    if (!pluginResult?.success || !commandResult?.success) return
+    expect(pluginResult.data.outFile).toBe('./types.ts')
+    expect(commandResult.data.outFile).toBe('./types.ts')
+    expect(commandResult.data.emitZod).toBe(true)
+  })
 })
 
 describe('@chkit/plugin-codegen mapping', () => {

--- a/packages/plugin-codegen/src/index.test.ts
+++ b/packages/plugin-codegen/src/index.test.ts
@@ -8,6 +8,7 @@ import { resolveConfig, schema, table } from '@chkit/core'
 
 import {
   createCodegenPlugin,
+  CodegenSchema,
   generateTypeArtifacts,
   generateIngestArtifacts,
   mapColumnType,
@@ -519,16 +520,17 @@ describe('@chkit/plugin-codegen check hook', () => {
         'utf8'
       )
 
-      const plugin = createCodegenPlugin({ outFile: './generated/chkit-types.ts' })
+      const plugin = createCodegenPlugin()
       const onCheck = plugin.hooks?.onCheck
       expect(onCheck).toBeTruthy()
+      const resolvedOptions = CodegenSchema.parse({ outFile: './generated/chkit-types.ts' })
 
       const first = await onCheck?.({
         command: 'check',
         config: resolveConfig({ schema: schemaPath }),
         configPath,
         jsonMode: true,
-        options: {},
+        options: resolvedOptions,
       })
       expect(first?.ok).toBe(false)
       expect(first?.findings[0]?.code).toBe('codegen_missing_output')
@@ -539,7 +541,8 @@ describe('@chkit/plugin-codegen check hook', () => {
         args: [],
         flags: {},
         jsonMode: true,
-        options: {},
+        options: resolvedOptions,
+        rawOptions: { outFile: './generated/chkit-types.ts' },
         config: resolveConfig({ schema: schemaPath }),
         configPath,
         print() {},
@@ -551,7 +554,7 @@ describe('@chkit/plugin-codegen check hook', () => {
         config: resolveConfig({ schema: schemaPath }),
         configPath,
         jsonMode: true,
-        options: {},
+        options: resolvedOptions,
       })
       expect(second?.ok).toBe(true)
       expect(second?.findings).toEqual([])

--- a/packages/plugin-codegen/src/index.ts
+++ b/packages/plugin-codegen/src/index.ts
@@ -1,6 +1,6 @@
 export { createCodegenPlugin, codegen } from './plugin.js'
-export { normalizeCodegenOptions, isRunOnGenerateEnabled } from './options.js'
-export type { PluginConfig } from './options.js'
+export { normalizeCodegenOptions, CodegenSchema } from './options.js'
+export type { PluginConfig, CodegenOptions } from './options.js'
 export { mapColumnType, generateTypeArtifacts } from './generators/type-artifacts.js'
 export { generateIngestArtifacts } from './generators/ingest-artifacts.js'
 export { generateMigrationArtifacts } from './generators/migration-artifacts.js'

--- a/packages/plugin-codegen/src/options.ts
+++ b/packages/plugin-codegen/src/options.ts
@@ -3,7 +3,7 @@ import { defineFlags, type FlagMapping } from '@chkit/core'
 
 // ───── Plugin config schema (what codegen({...}) accepts) ─────
 
-export const PluginConfigSchema = z.object({
+const PluginConfigSchema = z.object({
   outFile: z.string().min(1).optional(),
   emitZod: z.boolean().optional(),
   tableNameStyle: z.enum(['pascal', 'camel', 'raw']).optional(),

--- a/packages/plugin-codegen/src/options.ts
+++ b/packages/plugin-codegen/src/options.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod'
-import { defineFlags, resolveOptions, type FlagMapping } from '@chkit/core'
-
-import { CodegenConfigError } from './errors.js'
+import { defineFlags, type FlagMapping } from '@chkit/core'
 
 // ───── Plugin config schema (what codegen({...}) accepts) ─────
 
@@ -23,7 +21,7 @@ export type PluginConfig = z.input<typeof PluginConfigSchema>
 
 // ───── Codegen command schema ─────
 
-const CodegenSchema = z.object({
+export const CodegenSchema = z.object({
   outFile: z.string().min(1).default('./src/generated/chkit-types.ts'),
   emitZod: z.boolean().default(false),
   tableNameStyle: z.enum(['pascal', 'camel', 'raw']).default('pascal'),
@@ -36,7 +34,7 @@ const CodegenSchema = z.object({
   emitMigrations: z.boolean().default(false),
   migrationsOutFile: z.string().min(1).default('./src/generated/chkit-migrations.ts'),
 })
-type CodegenOptions = z.infer<typeof CodegenSchema>
+export type CodegenOptions = z.infer<typeof CodegenSchema>
 
 // ───── CLI flag definitions ─────
 
@@ -54,7 +52,7 @@ export const CODEGEN_FLAGS = defineFlags([
 
 // ───── Flag mapping ─────
 
-const CODEGEN_FLAG_MAP: FlagMapping = {
+export const CODEGEN_FLAG_MAP: FlagMapping = {
   '--out-file': { key: 'outFile' },
   '--emit-zod': { key: 'emitZod' },
   '--emit-ingest': { key: 'emitIngest' },
@@ -65,24 +63,7 @@ const CODEGEN_FLAG_MAP: FlagMapping = {
   '--migrations-out-file': { key: 'migrationsOutFile' },
 }
 
-// ───── Resolvers ─────
-
-export function resolveCodegenOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
-  flags: Record<string, string | string[] | boolean | undefined>
-): CodegenOptions {
-  return resolveOptions(CodegenSchema, pluginConfig, runtimeOptions, flags, CODEGEN_FLAG_MAP, CodegenConfigError)
-}
-
 /** Fill defaults for partial options. Used by generators. */
 export function normalizeCodegenOptions(options: PluginConfig = {}): CodegenOptions {
   return CodegenSchema.parse(options)
-}
-
-export function isRunOnGenerateEnabled(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>
-): boolean {
-  return resolveOptions(CodegenSchema, pluginConfig, runtimeOptions, {}, {}, CodegenConfigError).runOnGenerate
 }

--- a/packages/plugin-codegen/src/plugin.ts
+++ b/packages/plugin-codegen/src/plugin.ts
@@ -13,7 +13,7 @@ import type {
   GenerateMigrationArtifactsOutput,
 } from './types.js'
 import { CodegenConfigError } from './errors.js'
-import { CODEGEN_FLAGS, PluginConfigSchema, resolveCodegenOptions } from './options.js'
+import { CODEGEN_FLAGS, CODEGEN_FLAG_MAP, CodegenSchema } from './options.js'
 import { generateTypeArtifacts } from './generators/type-artifacts.js'
 import { generateIngestArtifacts } from './generators/ingest-artifacts.js'
 import { generateMigrationArtifacts } from './generators/migration-artifacts.js'
@@ -102,27 +102,21 @@ function mergeCheckResults(results: CodegenPluginCheckResult[]): CodegenPluginCh
   }
 }
 
-export function createCodegenPlugin(options: CodegenPluginOptions = {}): CodegenPlugin {
-  const pluginConfig = PluginConfigSchema.parse(options)
-
+export function createCodegenPlugin(_options: CodegenPluginOptions = {}): CodegenPlugin {
   return {
     manifest: {
       name: 'codegen',
       apiVersion: 1,
     },
+    optionsSchema: CodegenSchema,
     commands: [
       {
         name: 'codegen',
         description: 'Generate TypeScript artifacts from chkit schema definitions',
         flags: CODEGEN_FLAGS,
-        async run({
-          flags,
-          jsonMode,
-          print,
-          options: runtimeOptions,
-          config,
-          configPath,
-        }): Promise<undefined | number> {
+        optionsSchema: CodegenSchema,
+        flagMapping: CODEGEN_FLAG_MAP,
+        async run({ flags, jsonMode, print, options: effectiveOptions, config, configPath }): Promise<undefined | number> {
           return wrapPluginRun({
             command: 'codegen',
             label: 'Codegen',
@@ -130,7 +124,6 @@ export function createCodegenPlugin(options: CodegenPluginOptions = {}): Codegen
             print,
             configErrorClass: CodegenConfigError,
             fn: async () => {
-              const effectiveOptions = resolveCodegenOptions(pluginConfig, runtimeOptions, flags)
               const checkMode = flags['--check'] === true
               const configDir = resolve(configPath, '..')
               const outFile = resolve(configDir, effectiveOptions.outFile)
@@ -249,11 +242,10 @@ export function createCodegenPlugin(options: CodegenPluginOptions = {}): Codegen
       },
     ],
     hooks: {
-      onConfigLoaded({ options: runtimeOptions }) {
-        resolveCodegenOptions(pluginConfig, runtimeOptions, {})
+      onConfigLoaded() {
+        // Validation happens at command dispatch via command.optionsSchema.
       },
-      async onCheck({ config: appConfig, configPath, options: runtimeOptions }) {
-        const effectiveOptions = resolveCodegenOptions(pluginConfig, runtimeOptions, {})
+      async onCheck({ config: appConfig, configPath, options: effectiveOptions }) {
         const configDir = resolve(configPath, '..')
         const outFile = resolve(configDir, effectiveOptions.outFile)
         const definitions = await loadSchemaDefinitions(appConfig.schema, { cwd: configDir })
@@ -324,7 +316,7 @@ export function createCodegenPlugin(options: CodegenPluginOptions = {}): Codegen
 
 export function codegen(options: CodegenPluginOptions = {}): CodegenPluginRegistration {
   return {
-    plugin: createCodegenPlugin(),
+    plugin: createCodegenPlugin(options),
     name: 'codegen',
     enabled: true,
     options,

--- a/packages/plugin-codegen/src/plugin.ts
+++ b/packages/plugin-codegen/src/plugin.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
-import { wrapPluginRun } from '@chkit/core'
+import { wrapPluginRun, type SafeParseable } from '@chkit/core'
 import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 
 import type {
@@ -102,19 +102,37 @@ function mergeCheckResults(results: CodegenPluginCheckResult[]): CodegenPluginCh
   }
 }
 
-export function createCodegenPlugin(_options: CodegenPluginOptions = {}): CodegenPlugin {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function withFactoryDefaults<T>(
+  schema: SafeParseable<T>,
+  defaults: Record<string, unknown>,
+): SafeParseable<T> {
+  return {
+    safeParse(data) {
+      return schema.safeParse({ ...defaults, ...(isRecord(data) ? data : {}) })
+    },
+  }
+}
+
+export function createCodegenPlugin(options: CodegenPluginOptions = {}): CodegenPlugin {
+  const factoryOptions = options as Record<string, unknown>
+  const optionsSchema = withFactoryDefaults(CodegenSchema, factoryOptions)
+
   return {
     manifest: {
       name: 'codegen',
       apiVersion: 1,
     },
-    optionsSchema: CodegenSchema,
+    optionsSchema,
     commands: [
       {
         name: 'codegen',
         description: 'Generate TypeScript artifacts from chkit schema definitions',
         flags: CODEGEN_FLAGS,
-        optionsSchema: CodegenSchema,
+        optionsSchema,
         flagMapping: CODEGEN_FLAG_MAP,
         async run({ flags, jsonMode, print, options: effectiveOptions, config, configPath }): Promise<undefined | number> {
           return wrapPluginRun({

--- a/packages/plugin-codegen/src/types.ts
+++ b/packages/plugin-codegen/src/types.ts
@@ -1,14 +1,16 @@
 import type {
   ChxInlinePluginRegistration,
   FlagDef,
+  FlagMapping,
   MaterializedViewDefinition,
   ParsedFlags,
   ResolvedChxConfig,
+  SafeParseable,
   TableDefinition,
   ViewDefinition,
 } from '@chkit/core'
 
-import type { PluginConfig } from './options.js'
+import type { CodegenOptions, PluginConfig } from './options.js'
 
 export type CodegenPluginOptions = PluginConfig
 
@@ -16,7 +18,8 @@ export interface CodegenPluginCommandContext {
   args: string[]
   flags: ParsedFlags
   jsonMode: boolean
-  options: Record<string, unknown>
+  options: CodegenOptions
+  rawOptions: Record<string, unknown>
   config: ResolvedChxConfig
   configPath: string
   print: (value: unknown) => void
@@ -28,14 +31,17 @@ export interface CodegenPlugin {
     apiVersion: 1
     version?: string
   }
+  optionsSchema?: SafeParseable<CodegenOptions>
   commands: Array<{
     name: 'codegen'
     description: string
     flags?: readonly FlagDef[]
+    optionsSchema?: SafeParseable<CodegenOptions>
+    flagMapping?: FlagMapping
     run: (context: CodegenPluginCommandContext) => undefined | number | Promise<undefined | number>
   }>
   hooks?: {
-    onConfigLoaded?: (context: { command: string; configPath: string; options: Record<string, unknown> }) => void
+    onConfigLoaded?: (context: { command: string; configPath: string; options: CodegenOptions }) => void
     onCheck?: (
       context: CodegenPluginCheckContext
     ) => CodegenPluginCheckResult | undefined | Promise<CodegenPluginCheckResult | undefined>
@@ -107,7 +113,7 @@ export interface CodegenPluginCheckContext {
   config: ResolvedChxConfig
   configPath: string
   jsonMode: boolean
-  options: Record<string, unknown>
+  options: CodegenOptions
 }
 
 export type CodegenPluginRegistration = ChxInlinePluginRegistration<CodegenPlugin, CodegenPluginOptions>

--- a/packages/plugin-obsessiondb/src/auth/credentials.ts
+++ b/packages/plugin-obsessiondb/src/auth/credentials.ts
@@ -37,7 +37,7 @@ export async function saveCredentials(creds: Credentials): Promise<void> {
   const filePath = getCredentialsPath()
   const dir = dirname(filePath)
   await mkdir(dir, { recursive: true, mode: 0o700 })
-  await writeFile(filePath, JSON.stringify(creds, null, 2) + '\n', { mode: 0o600 })
+  await writeFile(filePath, `${JSON.stringify(creds, null, 2)}\n`, { mode: 0o600 })
   // Ensure permissions even if file existed
   await chmod(filePath, 0o600)
 }

--- a/packages/plugin-obsessiondb/src/backfill/handler.ts
+++ b/packages/plugin-obsessiondb/src/backfill/handler.ts
@@ -27,6 +27,10 @@ export async function handleBackfillCommand(context: BeforePluginCommandContext)
 
   if (!REMOTE_SUBCOMMANDS.has(context.command)) return { handled: false }
 
+  // A local backfill plugin status/cancel command uses --plan-id. Do not let the
+  // remote ObsessionDB hook shadow project-local backfill state commands.
+  if (typeof context.flags['--plan-id'] === 'string') return { handled: false }
+
   const creds = await loadCredentials()
   if (!creds) {
     context.print('Not logged in. Run `chkit obsessiondb login` to authenticate.')

--- a/packages/plugin-obsessiondb/src/index.test.ts
+++ b/packages/plugin-obsessiondb/src/index.test.ts
@@ -445,6 +445,47 @@ describe('obsessiondb onInit', () => {
 	})
 })
 
+describe('obsessiondb getContext', () => {
+	let tempDir: string
+	let originalXdg: string | undefined
+
+	afterEach(async () => {
+		if (originalXdg !== undefined) {
+			process.env.XDG_CONFIG_HOME = originalXdg
+		} else {
+			delete process.env.XDG_CONFIG_HOME
+		}
+		if (tempDir) {
+			await rm(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	async function setupAuth() {
+		tempDir = await mkdtemp(join(tmpdir(), 'chkit-obd-'))
+		originalXdg = process.env.XDG_CONFIG_HOME
+		process.env.XDG_CONFIG_HOME = tempDir
+		await saveCredentials({
+			access_token: 'test-tok',
+			base_url: 'https://api.test.com',
+		})
+	}
+
+	test('query reports an actionable error when authenticated without selected service', async () => {
+		await setupAuth()
+
+		const plugin = obsessiondb().plugin
+		await expect(
+			plugin.hooks.getContext({
+				config: makeConfig(),
+				configPath: join(tempDir, 'chkit', 'clickhouse.config.ts'),
+				command: 'query',
+				flags: {},
+				defaults: {},
+			}),
+		).rejects.toThrow(/select-service/)
+	})
+})
+
 describe('onBeforePluginCommand — backfill interception', () => {
 	let tempDir: string
 	let originalXdg: string | undefined

--- a/packages/plugin-obsessiondb/src/index.ts
+++ b/packages/plugin-obsessiondb/src/index.ts
@@ -83,6 +83,7 @@ interface ObsessionDBPlugin {
 		onSchemaLoaded(context: {
 			config: ResolvedChxConfig
 			flags: Record<string, string | string[] | boolean | undefined>
+			jsonMode?: boolean
 			definitions: SchemaDefinition[]
 		}): SchemaDefinition[] | undefined
 		onBeforePluginCommand(
@@ -294,12 +295,12 @@ function createObsessionDBPlugin(
 				if (!shouldStrip) return
 
 				const rewritten = rewriteSharedEngines(context.definitions)
-				if (rewritten.count > 0) {
+				if (!context.jsonMode && rewritten.count > 0) {
 					console.log(
 						`obsessiondb: Rewrote ${rewritten.count} Shared engine(s) to standard ClickHouse equivalents.`,
 					)
 				}
-				if (rewritten.strippedSettings.length > 0) {
+				if (!context.jsonMode && rewritten.strippedSettings.length > 0) {
 					const unique = [...new Set(rewritten.strippedSettings)]
 					console.log(
 						`obsessiondb: Stripped cloud-only setting(s): ${unique.join(', ')}`,

--- a/packages/plugin-obsessiondb/src/index.ts
+++ b/packages/plugin-obsessiondb/src/index.ts
@@ -216,7 +216,7 @@ function createObsessionDBPlugin(
 			...BACKFILL_EXTEND_COMMANDS,
 		],
 		hooks: {
-			async getContext({ configPath, flags }) {
+			async getContext({ config, configPath, command, flags }) {
 				const creds = await loadCredentials()
 				if (!creds) return
 				const effectiveCreds = {
@@ -242,7 +242,14 @@ function createObsessionDBPlugin(
 				} else {
 					service = await loadSelectedService(configPath)
 				}
-				if (!service) return
+				if (!service) {
+					if (command === 'query' && !config.clickhouse) {
+						throw new Error(
+							'authenticated but no ObsessionDB service is selected. Run `chkit obsessiondb select-service` or pass `--service <name>`.',
+						)
+					}
+					return
+				}
 
 				return {
 					executor: createRemoteExecutor({
@@ -274,9 +281,11 @@ function createObsessionDBPlugin(
 				}
 				if (service) {
 					console.log(`obsessiondb: using service "${service.service_name}"\n`)
+				} else if (context.command === 'query') {
+					return
 				} else {
 					console.log(
-						'obsessiondb: authenticated but no service selected (run `chkit obsessiondb select-service`)',
+						'obsessiondb: authenticated but no service selected (run `chkit obsessiondb select-service` or pass `--service <name>`)',
 					)
 				}
 			},

--- a/packages/plugin-obsessiondb/src/query/remote-executor.ts
+++ b/packages/plugin-obsessiondb/src/query/remote-executor.ts
@@ -89,7 +89,9 @@ export function createRemoteExecutor(deps: {
 			compressed?: boolean
 		}) {
 			if (params.values.length === 0) return
-			const columns = Object.keys(params.values[0]!)
+			const [firstValue] = params.values
+			if (!firstValue) return
+			const columns = Object.keys(firstValue)
 			const rows = params.values
 				.map(
 					(row) =>
@@ -145,8 +147,8 @@ ORDER BY event_time DESC
 LIMIT 1`,
 			)
 
-			if (log.length === 0) return { status: 'unknown' as const }
-			const row = log[0]!
+			const [row] = log
+			if (!row) return { status: 'unknown' as const }
 
 			if (row.type === 'QueryFinish') {
 				return {

--- a/packages/plugin-obsessiondb/src/service/select.ts
+++ b/packages/plugin-obsessiondb/src/service/select.ts
@@ -11,8 +11,9 @@ export async function selectServiceInteractive(
     return null
   }
 
-  if (services.length === 1) {
-    const service = services[0]!
+  const [onlyService] = services
+  if (services.length === 1 && onlyService) {
+    const service = onlyService
     print(`Auto-selected service: ${service.name} (${service.status})`)
     return service
   }
@@ -26,11 +27,12 @@ export async function selectServiceInteractive(
   try {
     const answer = await rl.question(`\nSelect service [1-${services.length}]: `)
     const index = parseInt(answer.trim(), 10) - 1
-    if (isNaN(index) || index < 0 || index >= services.length) {
+    const service = services[index]
+    if (Number.isNaN(index) || !service) {
       print('Invalid selection.')
       return null
     }
-    return services[index]!
+    return service
   } finally {
     rl.close()
   }

--- a/packages/plugin-obsessiondb/src/service/storage.ts
+++ b/packages/plugin-obsessiondb/src/service/storage.ts
@@ -1,9 +1,26 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
+import process from 'node:process'
 
 import type { SelectedService } from './types.js'
 
-function getServicePath(configPath: string): string {
+export function getUserConfigDir(): string {
+  const xdgConfig = process.env.XDG_CONFIG_HOME
+  const configDir = xdgConfig && xdgConfig.length > 0 ? xdgConfig : join(homedir(), '.config')
+  return join(configDir, 'chkit')
+}
+
+function isUnderUserConfigDir(path: string, userDir: string): boolean {
+  const target = resolve(path)
+  const dir = resolve(userDir)
+  return target === dir || target.startsWith(`${dir}/`)
+}
+
+export function getServicePath(configPath: string, userDir: string = getUserConfigDir()): string {
+  if (isUnderUserConfigDir(configPath, userDir)) {
+    return join(userDir, 'obsessiondb.json')
+  }
   const configDir = resolve(configPath, '..')
   return join(configDir, '.chkit', 'obsessiondb.json')
 }

--- a/packages/plugin-obsessiondb/src/service/storage.ts
+++ b/packages/plugin-obsessiondb/src/service/storage.ts
@@ -7,7 +7,7 @@ import { isSynthesizedConfigPath } from '@chkit/core'
 
 import type { SelectedService } from './types.js'
 
-export function getUserConfigDir(): string {
+function getUserConfigDir(): string {
   const xdgConfig = process.env.XDG_CONFIG_HOME
   const configDir = xdgConfig && xdgConfig.length > 0 ? xdgConfig : join(homedir(), '.config')
   return join(configDir, 'chkit')

--- a/packages/plugin-obsessiondb/src/service/storage.ts
+++ b/packages/plugin-obsessiondb/src/service/storage.ts
@@ -3,6 +3,8 @@ import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 
+import { isSynthesizedConfigPath } from '@chkit/core'
+
 import type { SelectedService } from './types.js'
 
 export function getUserConfigDir(): string {
@@ -18,7 +20,7 @@ function isUnderUserConfigDir(path: string, userDir: string): boolean {
 }
 
 export function getServicePath(configPath: string, userDir: string = getUserConfigDir()): string {
-  if (isUnderUserConfigDir(configPath, userDir)) {
+  if (isSynthesizedConfigPath(configPath) || isUnderUserConfigDir(configPath, userDir)) {
     return join(userDir, 'obsessiondb.json')
   }
   const configDir = resolve(configPath, '..')

--- a/packages/plugin-obsessiondb/src/service/storage.ts
+++ b/packages/plugin-obsessiondb/src/service/storage.ts
@@ -50,5 +50,5 @@ export async function loadSelectedService(configPath: string): Promise<SelectedS
 export async function saveSelectedService(configPath: string, service: SelectedService): Promise<void> {
   const filePath = getServicePath(configPath)
   await mkdir(dirname(filePath), { recursive: true })
-  await writeFile(filePath, JSON.stringify(service, null, 2) + '\n')
+  await writeFile(filePath, `${JSON.stringify(service, null, 2)}\n`)
 }

--- a/packages/plugin-obsessiondb/src/test/service-storage.test.ts
+++ b/packages/plugin-obsessiondb/src/test/service-storage.test.ts
@@ -58,4 +58,13 @@ describe('getServicePath', () => {
     expect(path).toBe(join(sandbox.userConfigDir, 'obsessiondb.json'))
     sandbox.cleanup()
   })
+
+  test('resolves to user dir when config is the synthesized sentinel path', () => {
+    const sandbox = createSandbox()
+
+    const path = getServicePath('<default:obsessiondb>', sandbox.userConfigDir)
+
+    expect(path).toBe(join(sandbox.userConfigDir, 'obsessiondb.json'))
+    sandbox.cleanup()
+  })
 })

--- a/packages/plugin-obsessiondb/src/test/service-storage.test.ts
+++ b/packages/plugin-obsessiondb/src/test/service-storage.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { getServicePath } from '../service/storage.js'
+
+interface Sandbox {
+  root: string
+  project: string
+  userConfigDir: string
+  cleanup: () => void
+}
+
+function createSandbox(): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), 'chkit-service-'))
+  const project = join(root, 'project')
+  const userConfigDir = join(root, 'xdg', 'chkit')
+  mkdirSync(project, { recursive: true })
+  mkdirSync(userConfigDir, { recursive: true })
+  return {
+    root,
+    project,
+    userConfigDir,
+    cleanup() {
+      rmSync(root, { recursive: true, force: true })
+    },
+  }
+}
+
+describe('getServicePath', () => {
+  test('resolves to project .chkit/obsessiondb.json when config sits in a project dir', () => {
+    const sandbox = createSandbox()
+    const configPath = join(sandbox.project, 'clickhouse.config.ts')
+
+    const path = getServicePath(configPath, sandbox.userConfigDir)
+
+    expect(path).toBe(join(sandbox.project, '.chkit', 'obsessiondb.json'))
+    sandbox.cleanup()
+  })
+
+  test('resolves to user dir directly when config sits under user config dir', () => {
+    const sandbox = createSandbox()
+    const configPath = join(sandbox.userConfigDir, 'clickhouse.config.ts')
+
+    const path = getServicePath(configPath, sandbox.userConfigDir)
+
+    expect(path).toBe(join(sandbox.userConfigDir, 'obsessiondb.json'))
+    sandbox.cleanup()
+  })
+
+  test('resolves to user dir for any nested path under user config dir', () => {
+    const sandbox = createSandbox()
+    const configPath = join(sandbox.userConfigDir, 'subdir', 'clickhouse.config.ts')
+
+    const path = getServicePath(configPath, sandbox.userConfigDir)
+
+    expect(path).toBe(join(sandbox.userConfigDir, 'obsessiondb.json'))
+    sandbox.cleanup()
+  })
+})

--- a/packages/plugin-pull/src/index.test.ts
+++ b/packages/plugin-pull/src/index.test.ts
@@ -5,6 +5,28 @@ import { tmpdir } from 'node:os'
 
 import { __testUtils, createPullPlugin, PullSchema, renderSchemaFile } from './index.js'
 
+describe('@chkit/plugin-pull options', () => {
+  test('createPullPlugin carries factory options into runtime schemas', () => {
+    const plugin = createPullPlugin({
+      outFile: './schema.ts',
+      databases: ['app'],
+      overwrite: true,
+      introspect: async () => [],
+    })
+    const command = plugin.commands[0]
+
+    const pluginResult = plugin.optionsSchema?.safeParse({})
+    const commandResult = command?.optionsSchema?.safeParse({})
+
+    expect(pluginResult?.success).toBe(true)
+    expect(commandResult?.success).toBe(true)
+    if (!pluginResult?.success || !commandResult?.success) return
+    expect(pluginResult.data.outFile).toBe('./schema.ts')
+    expect(commandResult.data.databases).toEqual(['app'])
+    expect(commandResult.data.overwrite).toBe(true)
+  })
+})
+
 describe('@chkit/plugin-pull renderSchemaFile', () => {
   test('renders deterministic table definitions', () => {
     const content = renderSchemaFile([

--- a/packages/plugin-pull/src/index.test.ts
+++ b/packages/plugin-pull/src/index.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-import { __testUtils, createPullPlugin, renderSchemaFile } from './index.js'
+import { __testUtils, createPullPlugin, PullSchema, renderSchemaFile } from './index.js'
 
 describe('@chkit/plugin-pull renderSchemaFile', () => {
   test('renders deterministic table definitions', () => {
@@ -176,7 +176,8 @@ describe('@chkit/plugin-pull schema command', () => {
       args: [],
       flags: { '--dryrun': true },
       jsonMode: true,
-      options: {},
+      options: PullSchema.parse({ databases: ['app'] }),
+      rawOptions: { databases: ['app'] },
       configPath: '/tmp/clickhouse.config.ts',
       config: {
         schema: ['./schema.ts'],
@@ -257,7 +258,8 @@ describe('@chkit/plugin-pull schema command', () => {
       args: [],
       flags: { '--dryrun': true },
       jsonMode: true,
-      options: {},
+      options: PullSchema.parse({ databases: ['app'] }),
+      rawOptions: { databases: ['app'] },
       configPath: '/tmp/clickhouse.config.ts',
       config: {
         schema: ['./schema.ts'],
@@ -320,11 +322,13 @@ describe('@chkit/plugin-pull schema command', () => {
 
     const run = async (flags: Record<string, string | string[] | boolean | undefined> = {}): Promise<{ code: undefined | number; output: unknown[] }> => {
       const output: unknown[] = []
+      const overwrite = flags['--force'] === true || flags['--overwrite'] === true
       const code = await command.run({
         args: [],
         flags,
         jsonMode: true,
-        options: {},
+        options: PullSchema.parse({ databases: ['app'], outFile, overwrite }),
+        rawOptions: { databases: ['app'], outFile },
         configPath: '/tmp/clickhouse.config.ts',
         config: {
           schema: ['./schema.ts'],

--- a/packages/plugin-pull/src/index.ts
+++ b/packages/plugin-pull/src/index.ts
@@ -13,8 +13,8 @@ import {
   defineFlags,
   type FlagMapping,
   normalizeEngine,
-  resolveOptions,
   type ResolvedChxConfig,
+  type SafeParseable,
   type SchemaDefinition,
   splitTopLevelComma,
   type TableDefinition,
@@ -31,17 +31,9 @@ import {
   type SystemTableRow,
 } from './view-parser.js'
 
-// ───── Plugin config schema (what pull({...}) accepts) ─────
-
-const PluginConfigSchema = z.object({
-  outFile: z.string().min(1).optional(),
-  databases: z.array(z.string()).optional(),
-  overwrite: z.boolean().optional(),
-})
-
 // ───── Pull command schema ─────
 
-const PullSchema = z.object({
+export const PullSchema = z.object({
   outFile: z.string().min(1).default('./src/db/schema/pulled.ts'),
   databases: z.array(z.string()).default([]).transform((arr) =>
     [...new Set(arr.map((s) => s.trim()).filter((s) => s.length > 0))].sort()
@@ -63,7 +55,8 @@ export interface PullPluginCommandContext {
   args: string[]
   flags: Record<string, string | string[] | boolean | undefined>
   jsonMode: boolean
-  options: Record<string, unknown>
+  options: PullOptions
+  rawOptions: Record<string, unknown>
   config: ResolvedChxConfig
   configPath: string
   print: (value: unknown) => void
@@ -75,6 +68,7 @@ export interface PullPlugin {
     apiVersion: 1
     version?: string
   }
+  optionsSchema?: SafeParseable<PullOptions>
   commands: Array<{
     name: 'schema'
     description: string
@@ -85,6 +79,8 @@ export interface PullPlugin {
       placeholder?: string
       negation?: boolean
     }>
+    optionsSchema?: SafeParseable<PullOptions>
+    flagMapping?: FlagMapping
     run: (context: PullPluginCommandContext) => undefined | number | Promise<undefined | number>
   }>
 }
@@ -115,21 +111,13 @@ const PULL_FLAG_MAP: FlagMapping = {
   '--database': { key: 'databases' },
 }
 
-// ───── Resolver ─────
+// ───── Errors ─────
 
 class PullConfigError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'PullConfigError'
   }
-}
-
-function resolvePullOptions(
-  pluginConfig: Record<string, unknown>,
-  runtimeOptions: Record<string, unknown>,
-  flags: Record<string, string | string[] | boolean | undefined>
-): PullOptions {
-  return resolveOptions(PullSchema, pluginConfig, runtimeOptions, flags, PULL_FLAG_MAP, PullConfigError)
 }
 
 // ───── Plugin ─────
@@ -144,7 +132,6 @@ interface PullSchemaResult {
 }
 
 export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
-  const pluginConfig = PluginConfigSchema.parse(options)
   const introspector = options.introspect
 
   return {
@@ -152,12 +139,15 @@ export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
       name: 'pull',
       apiVersion: 1,
     },
+    optionsSchema: PullSchema,
     commands: [
       {
         name: 'schema',
         description: 'Pull live ClickHouse table schema and write chkit schema file',
         flags: PULL_SCHEMA_FLAGS,
-        async run({ flags, jsonMode, print, options: runtimeOptions, config }) {
+        optionsSchema: PullSchema,
+        flagMapping: PULL_FLAG_MAP,
+        async run({ flags, jsonMode, print, options: opts, config }) {
           return wrapPluginRun({
             command: 'schema',
             label: 'Pull schema',
@@ -165,7 +155,6 @@ export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
             print,
             configErrorClass: PullConfigError,
             fn: async () => {
-              const opts = resolvePullOptions(pluginConfig, runtimeOptions, flags)
               const dryrun = flags['--dryrun'] === true
               const pulled = await pullSchema({
                 config,

--- a/packages/plugin-pull/src/index.ts
+++ b/packages/plugin-pull/src/index.ts
@@ -131,21 +131,43 @@ interface PullSchemaResult {
   content: string
 }
 
+function stringArrayFlag(value: string | string[] | boolean | undefined): string[] | undefined {
+  if (Array.isArray(value)) return value
+  if (typeof value === 'string') return [value]
+  return undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function withFactoryDefaults<T>(
+  schema: SafeParseable<T>,
+  defaults: Record<string, unknown>,
+): SafeParseable<T> {
+  return {
+    safeParse(data) {
+      return schema.safeParse({ ...defaults, ...(isRecord(data) ? data : {}) })
+    },
+  }
+}
+
 export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
-  const introspector = options.introspect
+  const { introspect: introspector, ...factoryOptions } = options
+  const optionsSchema = withFactoryDefaults(PullSchema, factoryOptions)
 
   return {
     manifest: {
       name: 'pull',
       apiVersion: 1,
     },
-    optionsSchema: PullSchema,
+    optionsSchema,
     commands: [
       {
         name: 'schema',
         description: 'Pull live ClickHouse table schema and write chkit schema file',
         flags: PULL_SCHEMA_FLAGS,
-        optionsSchema: PullSchema,
+        optionsSchema,
         flagMapping: PULL_FLAG_MAP,
         async run({ flags, jsonMode, print, options: opts, config }) {
           return wrapPluginRun({
@@ -155,17 +177,31 @@ export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
             print,
             configErrorClass: PullConfigError,
             fn: async () => {
+              const flagOptions = {
+                ...(typeof flags['--out-file'] === 'string' ? { outFile: flags['--out-file'] } : {}),
+                ...(flags['--force'] === true || flags['--overwrite'] === true
+                  ? { overwrite: true }
+                  : {}),
+                ...(stringArrayFlag(flags['--database'])
+                  ? { databases: stringArrayFlag(flags['--database']) }
+                  : {}),
+              }
+              const effectiveOptions = PullSchema.parse({
+                ...factoryOptions,
+                ...(isRecord(opts) ? opts : {}),
+                ...flagOptions,
+              })
               const dryrun = flags['--dryrun'] === true
               const pulled = await pullSchema({
                 config,
-                options: { ...opts, introspect: introspector },
+                options: { ...effectiveOptions, introspect: introspector },
               })
 
               if (!dryrun) {
                 await writeSchemaFile({
                   outFile: pulled.outFile,
                   content: pulled.content,
-                  overwrite: opts.overwrite,
+                  overwrite: effectiveOptions.overwrite,
                 })
               }
 

--- a/packages/plugin-pull/src/render-schema.ts
+++ b/packages/plugin-pull/src/render-schema.ts
@@ -239,6 +239,7 @@ function renderCodecStepSource(step: ColumnCodec): string {
 
 function renderCodecSource(spec: ColumnCodecSpec): string {
   const steps = Array.isArray(spec) ? spec : [spec]
-  if (steps.length === 1) return renderCodecStepSource(steps[0]!)
+  const [first] = steps
+  if (steps.length === 1 && first) return renderCodecStepSource(first)
   return `[${steps.map(renderCodecStepSource).join(', ')}]`
 }


### PR DESCRIPTION
Adds a user-profile config fallback so `chkit query` can run from any directory by loading `~/.config/chkit/config.ts` or synthesizing an ObsessionDB-only config from stored credentials. ObsessionDB bootstrap commands like `chkit obsessiondb login` now work before credentials exist, while project-only commands still require a local `clickhouse.config.ts`. The ObsessionDB plugin now stores selected services in profile mode, reports clearer login/service-selection guidance, and the CLI loads the ObsessionDB plugin through an optional runtime import. Validated with focused config and ObsessionDB tests, CLI/plugin typechecks, lint, and manual empty-directory command checks.
