### PR TITLE
[codex] Add docs link to CLI help

### DIFF
--- a/packages/cli/src/runtime/help.ts
+++ b/packages/cli/src/runtime/help.ts
@@ -1,6 +1,8 @@
 import type { FlagDef } from '../plugins.js'
 import type { CommandRegistry, RegisteredCommand } from './command-registry.js'
 
+const DOCS_URL = 'https://chkit.obsessiondb.com/'
+
 export function formatGlobalHelp(registry: CommandRegistry, version: string): string {
   const lines: string[] = []
   lines.push(`chkit v${version} - ClickHouse toolkit`)
@@ -41,6 +43,8 @@ export function formatGlobalHelp(registry: CommandRegistry, version: string): st
   }
   lines.push(formatFlagLine({ name: '-h, --help', type: 'boolean', description: 'Show help' }))
   lines.push(formatFlagLine({ name: '-v, --version', type: 'boolean', description: 'Show version' }))
+
+  appendDocsHelp(lines)
 
   return lines.join('\n')
 }
@@ -83,7 +87,16 @@ export function formatCommandHelp(command: RegisteredCommand, globalFlags: reado
     lines.push(formatFlagLine(flag))
   }
 
+  appendDocsHelp(lines)
+
   return lines.join('\n')
+}
+
+function appendDocsHelp(lines: string[]): void {
+  lines.push('')
+  lines.push('Documentation:')
+  lines.push(`  Full documentation: ${DOCS_URL}`)
+  lines.push('  Agent-readable markdown: fetch any docs page with Accept: text/markdown')
 }
 
 function formatFlagLine(flag: FlagDef & { name?: string }): string {

--- a/packages/cli/src/test/runtime/help.test.ts
+++ b/packages/cli/src/test/runtime/help.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { CommandRegistry, RegisteredCommand } from '../../runtime/command-registry.js'
+import { formatCommandHelp, formatGlobalHelp } from '../../runtime/help.js'
+
+const globalFlags = [
+	{
+		name: '--config',
+		type: 'string' as const,
+		description: 'Path to config',
+		placeholder: '<path>',
+	},
+]
+
+const command: RegisteredCommand = {
+	name: 'status',
+	description: 'Show migration status',
+	flags: [],
+	pluginFlags: [],
+	pluginName: 'core',
+}
+
+const registry: CommandRegistry = {
+	commands: [command],
+	globalFlags,
+	get: (name) => (name === command.name ? command : undefined),
+	resolveFlags: () => [...globalFlags],
+}
+
+describe('help formatting', () => {
+	test('global help links to full documentation and markdown fetch hint', () => {
+		const help = formatGlobalHelp(registry, '0.0.0-test')
+
+		expect(help).toContain('Documentation:')
+		expect(help).toContain('Full documentation: https://chkit.obsessiondb.com/')
+		expect(help).toContain(
+			'Agent-readable markdown: fetch any docs page with Accept: text/markdown',
+		)
+	})
+
+	test('command help links to full documentation and markdown fetch hint', () => {
+		const help = formatCommandHelp(command, globalFlags)
+
+		expect(help).toContain('Documentation:')
+		expect(help).toContain('Full documentation: https://chkit.obsessiondb.com/')
+		expect(help).toContain(
+			'Agent-readable markdown: fetch any docs page with Accept: text/markdown',
+		)
+	})
+})


### PR DESCRIPTION
Adds a Documentation section to global and command-specific CLI help output with the full docs URL and a hint that docs pages can be fetched as markdown via the `Accept: text/markdown` header.

This helps agents and other CLI users discover the complete documentation from `--help` output. Coverage includes focused help formatter tests for both top-level and command help.

Validated with `bun test packages/cli/src/test/runtime/help.test.ts`, `bun run --cwd packages/cli typecheck`, and `bun run --cwd packages/cli lint`.