### PR TITLE
fix(plugin-pull): skip ObsessionDB metadata tables

### DIFF
--- a/.changeset/silent-folders-pull.md
+++ b/.changeset/silent-folders-pull.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-pull": patch
+---
+
+Exclude ObsessionDB metadata tables from pulled schema output.

--- a/packages/plugin-pull/src/index.test.ts
+++ b/packages/plugin-pull/src/index.test.ts
@@ -241,6 +241,109 @@ describe('@chkit/plugin-pull schema command', () => {
     expect(payload.content).toContain('default: "fn:\'\'"')
   })
 
+  test('excludes ObsessionDB metadata tables from pulled schema output', async () => {
+    const plugin = createPullPlugin({
+      databases: ['app'],
+      introspect: async () => [
+        {
+          database: 'app',
+          name: 'events',
+          engine: 'MergeTree()',
+          primaryKey: '(id)',
+          orderBy: '(id)',
+          columns: [{ name: 'id', type: 'UInt64' }],
+          settings: {},
+          indexes: [],
+          projections: [],
+        },
+        {
+          database: 'app',
+          name: 'metadata_folder',
+          engine: 'MergeTree()',
+          primaryKey: '(id)',
+          orderBy: '(id)',
+          columns: [{ name: 'id', type: 'UUID' }],
+          settings: {},
+          indexes: [],
+          projections: [],
+        },
+        {
+          database: 'app',
+          name: 'metadata_table_folder',
+          engine: 'MergeTree()',
+          primaryKey: '(table_id, folder_id)',
+          orderBy: '(table_id, folder_id)',
+          columns: [
+            { name: 'table_id', type: 'UUID' },
+            { name: 'folder_id', type: 'UUID' },
+          ],
+          settings: {},
+          indexes: [],
+          projections: [],
+        },
+        {
+          database: 'app',
+          name: 'metadata_table_tag',
+          engine: 'MergeTree()',
+          primaryKey: '(table_id, tag)',
+          orderBy: '(table_id, tag)',
+          columns: [
+            { name: 'table_id', type: 'UUID' },
+            { name: 'tag', type: 'String' },
+          ],
+          settings: {},
+          indexes: [],
+          projections: [],
+        },
+      ],
+    })
+
+    const command = plugin.commands[0]
+    if (!command) throw new Error('missing command')
+
+    const logs: unknown[] = []
+    const code = await command.run({
+      args: [],
+      flags: { '--dryrun': true },
+      jsonMode: true,
+      options: PullSchema.parse({ databases: ['app'] }),
+      rawOptions: { databases: ['app'] },
+      configPath: '/tmp/clickhouse.config.ts',
+      config: {
+        schema: ['./schema.ts'],
+        outDir: './chkit',
+        migrationsDir: './chkit/migrations',
+        metaDir: './chkit/meta',
+        plugins: [],
+        check: { failOnPending: true, failOnChecksumMismatch: true, failOnDrift: true },
+        safety: { allowDestructive: false },
+        clickhouse: {
+          url: 'http://localhost:8123',
+          username: 'default',
+          password: '',
+          database: 'default',
+          secure: false,
+        },
+      },
+      print(value) {
+        logs.push(value)
+      },
+    })
+
+    expect(code).toBe(0)
+    const payload = logs[0] as {
+      definitionCount: number
+      tableCount: number
+      content: string
+    }
+    expect(payload.definitionCount).toBe(1)
+    expect(payload.tableCount).toBe(1)
+    expect(payload.content).toContain('const app_events = table({')
+    expect(payload.content).not.toContain('metadata_folder')
+    expect(payload.content).not.toContain('metadata_table_folder')
+    expect(payload.content).not.toContain('metadata_table_tag')
+  })
+
   test('supports introspected view and materialized_view objects', async () => {
     const plugin = createPullPlugin({
       databases: ['app'],

--- a/packages/plugin-pull/src/index.ts
+++ b/packages/plugin-pull/src/index.ts
@@ -120,6 +120,21 @@ class PullConfigError extends Error {
   }
 }
 
+const OBSESSIONDB_METADATA_TABLE_NAMES = new Set([
+  'metadata_folder',
+  'metadata_table_folder',
+  'metadata_table_tag',
+])
+
+function isObsessionDbMetadataObject(object: IntrospectedObject): boolean {
+  const kind = (object as { kind?: string }).kind ?? 'table'
+  return kind === 'table' && OBSESSIONDB_METADATA_TABLE_NAMES.has(object.name)
+}
+
+function isPullableObject(object: IntrospectedObject): boolean {
+  return !isObsessionDbMetadataObject(object)
+}
+
 // ───── Plugin ─────
 
 interface PullSchemaResult {
@@ -274,10 +289,10 @@ async function pullSchema(input: {
     }
   }
 
-  const introspected = await introspector({
+  const introspected = (await introspector({
     config: input.config.clickhouse,
     databases: selectedDatabases,
-  })
+  })).filter(isPullableObject)
 
   const definitions = canonicalizeDefinitions(introspected.map(mapIntrospectedObjectToDefinition))
   const content = renderSchemaFile(definitions)


### PR DESCRIPTION
## Summary
- filters ObsessionDB metadata tables out of `chkit pull` results before rendering schema definitions
- adds a regression test covering `metadata_folder`, `metadata_table_folder`, and `metadata_table_tag`
- adds a patch changeset for `@chkit/plugin-pull`

## Test Plan
- [x] `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun test packages/plugin-pull/src/index.test.ts`
- [x] `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun run --cwd packages/plugin-pull typecheck`
- [x] `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun run --cwd packages/plugin-pull lint`
- [x] `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun run --cwd packages/plugin-pull build`

Fixes #126
