### PR TITLE
ci: skip Fallow analysis on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,14 @@ jobs:
         run: git diff --exit-code bun.lock
 
       - name: Fallow analysis
+        if: github.event_name == 'pull_request'
         uses: fallow-rs/fallow@v2
         with:
           format: sarif
           fail-on-issues: false
 
       - name: Upload Fallow SARIF
+        if: github.event_name == 'pull_request'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: fallow-results.sarif


### PR DESCRIPTION
## Summary
Fallow is an agentic linter — useful as PR feedback, but not a meaningful gate on `main`. Its SARIF upload step was also failing on every push to main with `Resource not accessible by integration` (missing `security-events: write` permission), which blocked the `deploy` job via `needs: verify`. Gating both Fallow steps to `pull_request` events restores a clean verify on main while keeping the feedback on PRs.

## Test plan
- [ ] CI passes on this PR (Fallow still runs here)
- [ ] After merge, verify the push-to-main CI is green and deploy runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)