### PR TITLE
Detect streamed ClickHouse exceptions

### DIFF
--- a/.changeset/detect-streamed-clickhouse-exceptions.md
+++ b/.changeset/detect-streamed-clickhouse-exceptions.md
@@ -1,0 +1,8 @@
+---
+"@chkit/clickhouse": patch
+"chkit": patch
+---
+
+Detect ClickHouse exceptions that arrive in the `x-clickhouse-exception-code` response header on an HTTP 200 response. When `send_progress_in_http_headers=1` is set (chkit's default for long-running migrations), ClickHouse commits to a 200 status before the query completes; if the query then errors, the exception is reported via response headers rather than as an HTTP error code. `@clickhouse/client` does not surface this as a thrown error, so previously `chkit migrate` could record a failed INSERT migration as applied while the data never landed.
+
+`@chkit/clickhouse` now inspects `result.response_headers` after every `command`/`query`/`queryJson`/`insert` call and throws a new `ClickHouseStreamedException` (with `code`, `exceptionTag`, and `query_id`) when a non-zero exception code is present. Migrations that fail this way now exit with a non-zero status and remain pending so the operator can fix the underlying issue and re-apply.

--- a/packages/clickhouse/src/index.test.ts
+++ b/packages/clickhouse/src/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  assertStreamedQuerySucceeded,
+  ClickHouseStreamedException,
   createClickHouseExecutor,
   createExecutorWithClient,
   createSessionClickHouseClient,
@@ -23,15 +25,28 @@ type InsertCall = {
   values: Array<Record<string, unknown>>
 }
 
-function createMockClient(name: string, calls: InsertCall[]) {
+type MockClientOptions = {
+  commandHeaders?: Record<string, string>
+  queryHeaders?: Record<string, string>
+  insertHeaders?: Record<string, string>
+}
+
+function createMockClient(
+  name: string,
+  calls: InsertCall[],
+  opts: MockClientOptions = {},
+) {
   return {
     async command() {
-      return { query_id: `${name}-command` }
+      return {
+        query_id: `${name}-command`,
+        response_headers: opts.commandHeaders ?? {},
+      }
     },
     async query() {
       return {
         query_id: `${name}-query`,
-        response_headers: {},
+        response_headers: opts.queryHeaders ?? {},
         async json() {
           return []
         },
@@ -39,7 +54,10 @@ function createMockClient(name: string, calls: InsertCall[]) {
     },
     async insert(params: { table: string; values: Array<Record<string, unknown>> }) {
       calls.push({ client: name, table: params.table, values: params.values })
-      return { query_id: `${name}-insert` }
+      return {
+        query_id: `${name}-insert`,
+        response_headers: opts.insertHeaders ?? {},
+      }
     },
     async close() {},
   } as unknown as ReturnType<typeof createStatelessClickHouseClient>
@@ -185,6 +203,156 @@ SETTINGS index_granularity = 8192;`
       'CREATE TABLE app.events (id UInt64) ENGINE = MergeTree() ORDER BY id SETTINGS index_granularity = 8192;'
 
     expect(parseEngineFromCreateTableQuery(query)).toBe('MergeTree()')
+  })
+
+  test('assertStreamedQuerySucceeded throws on non-zero exception code header', () => {
+    const call = () =>
+      assertStreamedQuerySucceeded({
+        response_headers: {
+          'x-clickhouse-exception-code': '241',
+          'x-clickhouse-exception-tag': 'tagvalue',
+        },
+        query_id: 'qid-1',
+        sql: 'INSERT INTO t SELECT 1',
+      })
+
+    expect(call).toThrow(ClickHouseStreamedException)
+    expect(call).toThrow(/241/)
+    expect(call).toThrow(/qid-1/)
+    expect(call).toThrow(/tagvalue/)
+  })
+
+  test('assertStreamedQuerySucceeded carries structured fields', () => {
+    let caught: unknown
+    try {
+      assertStreamedQuerySucceeded({
+        response_headers: {
+          'x-clickhouse-exception-code': '241',
+          'x-clickhouse-exception-tag': 'tagvalue',
+        },
+        query_id: 'qid-1',
+        sql: 'INSERT INTO t SELECT 1',
+      })
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(ClickHouseStreamedException)
+    const err = caught as ClickHouseStreamedException
+    expect(err.code).toBe('241')
+    expect(err.exceptionTag).toBe('tagvalue')
+    expect(err.query_id).toBe('qid-1')
+  })
+
+  test("assertStreamedQuerySucceeded does not throw when code is '0'", () => {
+    assertStreamedQuerySucceeded({
+      response_headers: { 'x-clickhouse-exception-code': '0' },
+      query_id: 'qid',
+      sql: undefined,
+    })
+  })
+
+  test('assertStreamedQuerySucceeded does not throw on missing header', () => {
+    assertStreamedQuerySucceeded({
+      response_headers: { 'content-type': 'text/plain' },
+      query_id: 'qid',
+      sql: undefined,
+    })
+  })
+
+  test('assertStreamedQuerySucceeded does not throw on undefined response_headers', () => {
+    assertStreamedQuerySucceeded({
+      response_headers: undefined,
+      query_id: 'qid',
+      sql: undefined,
+    })
+  })
+
+  test('executor.command throws when streamed exception is reported via headers', async () => {
+    const calls: InsertCall[] = []
+    const executor = createExecutorWithClient(
+      {
+        url: 'http://localhost:8123',
+        username: 'default',
+        password: '',
+        database: 'default',
+        secure: false,
+      },
+      createMockClient('plain', calls, {
+        commandHeaders: {
+          'x-clickhouse-exception-code': '241',
+          'x-clickhouse-exception-tag': 'memlim',
+        },
+      }),
+    )
+
+    await expect(executor.command('INSERT INTO hits SELECT 1')).rejects.toBeInstanceOf(
+      ClickHouseStreamedException,
+    )
+    await expect(executor.command('INSERT INTO hits SELECT 1')).rejects.toThrow(/241/)
+    await executor.close()
+  })
+
+  test('executor.query throws when streamed exception is reported via headers', async () => {
+    const calls: InsertCall[] = []
+    const executor = createExecutorWithClient(
+      {
+        url: 'http://localhost:8123',
+        username: 'default',
+        password: '',
+        database: 'default',
+        secure: false,
+      },
+      createMockClient('plain', calls, {
+        queryHeaders: {
+          'x-clickhouse-exception-code': '159',
+        },
+      }),
+    )
+
+    await expect(executor.query('SELECT 1')).rejects.toBeInstanceOf(
+      ClickHouseStreamedException,
+    )
+    await executor.close()
+  })
+
+  test('executor.insert throws when streamed exception is reported via headers', async () => {
+    const calls: InsertCall[] = []
+    const executor = createExecutorWithClient(
+      {
+        url: 'http://localhost:8123',
+        username: 'default',
+        password: '',
+        database: 'default',
+        secure: false,
+      },
+      createMockClient('plain', calls, {
+        insertHeaders: {
+          'x-clickhouse-exception-code': '60',
+        },
+      }),
+    )
+
+    await expect(
+      executor.insert({ table: 'hits', values: [{ id: 1 }] }),
+    ).rejects.toBeInstanceOf(ClickHouseStreamedException)
+    await executor.close()
+  })
+
+  test('executor.command succeeds when response_headers carry no exception code', async () => {
+    const calls: InsertCall[] = []
+    const executor = createExecutorWithClient(
+      {
+        url: 'http://localhost:8123',
+        username: 'default',
+        password: '',
+        database: 'default',
+        secure: false,
+      },
+      createMockClient('plain', calls),
+    )
+
+    await executor.command('CREATE TABLE noop (x UInt64) ENGINE = Memory')
+    await executor.close()
   })
 
   test('parses projection definitions from create table query', () => {

--- a/packages/clickhouse/src/index.test.ts
+++ b/packages/clickhouse/src/index.test.ts
@@ -315,6 +315,54 @@ SETTINGS index_granularity = 8192;`
     await executor.close()
   })
 
+  test('executor.query checks exception headers before decoding the response body', async () => {
+    // With send_progress_in_http_headers=1, ClickHouse can return HTTP 200,
+    // set x-clickhouse-exception-code, then append a plain-text exception
+    // block to the body. If we decoded the body first, JSON parsing would
+    // throw before the header check ran and the streamed exception would be
+    // silently bypassed.
+    let jsonCalled = false
+    const failingJsonClient = {
+      async query() {
+        return {
+          query_id: 'q-1',
+          response_headers: {
+            'x-clickhouse-exception-code': '241',
+            'x-clickhouse-exception-tag': 'memlim',
+          },
+          async json() {
+            jsonCalled = true
+            throw new Error('invalid JSON: trailing exception block')
+          },
+        }
+      },
+      async command() {
+        return { query_id: 'c-1', response_headers: {} }
+      },
+      async insert() {
+        return { query_id: 'i-1', response_headers: {} }
+      },
+      async close() {},
+    } as unknown as ReturnType<typeof createStatelessClickHouseClient>
+
+    const executor = createExecutorWithClient(
+      {
+        url: 'http://localhost:8123',
+        username: 'default',
+        password: '',
+        database: 'default',
+        secure: false,
+      },
+      failingJsonClient,
+    )
+
+    await expect(executor.query('SELECT 1')).rejects.toBeInstanceOf(
+      ClickHouseStreamedException,
+    )
+    expect(jsonCalled).toBe(false)
+    await executor.close()
+  })
+
   test('executor.insert throws when streamed exception is reported via headers', async () => {
     const calls: InsertCall[] = []
     const executor = createExecutorWithClient(

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -353,6 +353,64 @@ export function isUnknownDatabaseError(error: unknown): boolean {
 	return String(error.code) === '81'
 }
 
+/**
+ * Thrown when a ClickHouse query failed mid-flight after the server already
+ * committed an HTTP 200 response by emitting progress headers. In that
+ * scenario the error is reported via the `x-clickhouse-exception-code`
+ * response header rather than as an HTTP error — @clickhouse/client does not
+ * surface it as a thrown error, so we must detect it ourselves and throw.
+ */
+export class ClickHouseStreamedException extends Error {
+	readonly code: string
+	readonly exceptionTag: string | undefined
+	readonly query_id: string | undefined
+	constructor(input: {
+		code: string
+		exceptionTag: string | undefined
+		query_id: string | undefined
+		sql: string | undefined
+	}) {
+		const idPart = input.query_id ? ` (query_id ${input.query_id})` : ''
+		const tagPart = input.exceptionTag ? `, exception_tag ${input.exceptionTag}` : ''
+		const sqlPreview = input.sql
+			? `\n  SQL: ${input.sql.length > 200 ? `${input.sql.slice(0, 200)}…` : input.sql}`
+			: ''
+		super(
+			`ClickHouse query failed with exception code ${input.code}${tagPart}${idPart}.${sqlPreview}`,
+		)
+		this.name = 'ClickHouseStreamedException'
+		this.code = input.code
+		this.exceptionTag = input.exceptionTag
+		this.query_id = input.query_id
+	}
+}
+
+/**
+ * Throws if the response carries a non-zero `x-clickhouse-exception-code`
+ * header. This happens when ClickHouse sends progress headers (committing
+ * HTTP 200) and then the query errors out — the error is reported in
+ * headers, not by HTTP status, and @clickhouse/client does not raise it.
+ */
+export function assertStreamedQuerySucceeded(input: {
+	response_headers: Record<string, string | string[] | undefined> | undefined
+	query_id: string
+	sql: string | undefined
+}): void {
+	const headers = input.response_headers
+	if (!headers) return
+	const rawCode = headers['x-clickhouse-exception-code']
+	const code = Array.isArray(rawCode) ? rawCode[0] : rawCode
+	if (!code || code === '0') return
+	const rawTag = headers['x-clickhouse-exception-tag']
+	const tag = Array.isArray(rawTag) ? rawTag[0] : rawTag
+	throw new ClickHouseStreamedException({
+		code,
+		exceptionTag: tag,
+		query_id: input.query_id,
+		sql: input.sql,
+	})
+}
+
 export {
 	waitForColumn,
 	waitForDDLPropagation,
@@ -484,6 +542,11 @@ export function createExecutorWithClient(
 					query: sql,
 					http_headers: { 'X-DDL': '1' },
 				})
+				assertStreamedQuerySucceeded({
+					response_headers: result.response_headers,
+					query_id: result.query_id,
+					sql,
+				})
 				logProfiling(profiler, sql, result.query_id, result.summary)
 			} catch (error) {
 				if (isUnknownDatabaseError(error)) {
@@ -496,9 +559,14 @@ export function createExecutorWithClient(
 						clickhouse_settings: { wait_end_of_query: 1, async_insert: 0 },
 					})
 					try {
-						await fallback.command({
+						const fallbackResult = await fallback.command({
 							query: sql,
 							http_headers: { 'X-DDL': '1' },
+						})
+						assertStreamedQuerySucceeded({
+							response_headers: fallbackResult.response_headers,
+							query_id: fallbackResult.query_id,
+							sql,
 						})
 					} finally {
 						await fallback.close()
@@ -517,6 +585,11 @@ export function createExecutorWithClient(
 					...(settings ? { clickhouse_settings: settings } : {}),
 				})
 				const rows = await result.json<T>()
+				assertStreamedQuerySucceeded({
+					response_headers: result.response_headers,
+					query_id: result.query_id,
+					sql,
+				})
 				logProfiling(
 					profiler,
 					sql,
@@ -539,7 +612,12 @@ export function createExecutorWithClient(
 					http_headers: { 'X-DDL': '1' },
 					...(settings ? { clickhouse_settings: settings } : {}),
 				})
-        const payload = (await result.json<T>()) as ClickHouseJsonQueryResult<T>
+				const payload = (await result.json<T>()) as ClickHouseJsonQueryResult<T>
+				assertStreamedQuerySucceeded({
+					response_headers: result.response_headers,
+					query_id: result.query_id,
+					sql,
+				})
 				logProfiling(
 					profiler,
 					sql,
@@ -575,6 +653,11 @@ export function createExecutorWithClient(
 					table: params.table,
 					values: params.values,
 					format: 'JSONEachRow',
+				})
+				assertStreamedQuerySucceeded({
+					response_headers: result.response_headers,
+					query_id: result.query_id,
+					sql: `INSERT INTO ${params.table}`,
 				})
 				logProfiling(
 					profiler,

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -584,12 +584,17 @@ export function createExecutorWithClient(
 					http_headers: { 'X-DDL': '1' },
 					...(settings ? { clickhouse_settings: settings } : {}),
 				})
-				const rows = await result.json<T>()
+				// Check headers before decoding the body. With
+				// send_progress_in_http_headers=1, ClickHouse can return HTTP 200
+				// then append a plain-text exception block after partial JSON
+				// rows — JSON parsing would throw before we ever read the
+				// exception-code header.
 				assertStreamedQuerySucceeded({
 					response_headers: result.response_headers,
 					query_id: result.query_id,
 					sql,
 				})
+				const rows = await result.json<T>()
 				logProfiling(
 					profiler,
 					sql,
@@ -612,12 +617,12 @@ export function createExecutorWithClient(
 					http_headers: { 'X-DDL': '1' },
 					...(settings ? { clickhouse_settings: settings } : {}),
 				})
-				const payload = (await result.json<T>()) as ClickHouseJsonQueryResult<T>
 				assertStreamedQuerySucceeded({
 					response_headers: result.response_headers,
 					query_id: result.query_id,
 					sql,
 				})
+				const payload = (await result.json<T>()) as ClickHouseJsonQueryResult<T>
 				logProfiling(
 					profiler,
 					sql,


### PR DESCRIPTION
## Summary
- add ClickHouseStreamedException for non-zero x-clickhouse-exception-code response headers
- check streamed exception headers after command/query/queryJson/insert calls
- cover command, query, insert, and structured error behavior with tests

## Verification
- bun test packages/clickhouse/src/index.test.ts