### PR TITLE
docs: fix journal-in-ClickHouse references (status/migrate/configuration)

### DIFF
--- a/apps/docs/src/content/docs/cli/migrate.md
+++ b/apps/docs/src/content/docs/cli/migrate.md
@@ -63,13 +63,13 @@ Before applying, the CLI verifies SHA-256 checksums of all previously-applied mi
 
 ### Journal
 
-Each applied migration is recorded in `journal.json` (in `metaDir`) with:
+Each applied migration is recorded in the `_chkit_migrations` journal table in ClickHouse with:
 
 - `name` — the migration filename
 - `appliedAt` — ISO 8601 timestamp
 - `checksum` — SHA-256 hash of the file content
 
-The journal is written after each migration, not batched.
+The journal is written after each migration, not batched. The table name can be overridden with the `CHKIT_JOURNAL_TABLE` environment variable.
 
 ### Table scoping
 
@@ -137,8 +137,7 @@ chkit migrate --apply --table analytics.events
   "scope": { "enabled": false },
   "applied": [
     { "name": "0004_add_column.sql", "appliedAt": "2025-06-15T10:30:00.000Z", "checksum": "a1b2c3..." }
-  ],
-  "journalFile": "./chkit/meta/journal.json"
+  ]
 }
 ```
 

--- a/apps/docs/src/content/docs/cli/migrate.md
+++ b/apps/docs/src/content/docs/cli/migrate.md
@@ -69,7 +69,7 @@ Each applied migration is recorded in the `_chkit_migrations` journal table in C
 - `appliedAt` — ISO 8601 timestamp
 - `checksum` — SHA-256 hash of the file content
 
-The journal is written after each migration, not batched. The table name can be overridden with the `CHKIT_JOURNAL_TABLE` environment variable.
+The journal is written after each migration, not batched. The table is created in the database configured in `clickhouse.database` (it is not qualified with a database name, so on a shared/default-database setup it lives in `default._chkit_migrations`). The table name can be overridden with the `CHKIT_JOURNAL_TABLE` environment variable.
 
 ### Table scoping
 

--- a/apps/docs/src/content/docs/cli/status.md
+++ b/apps/docs/src/content/docs/cli/status.md
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-Reports the current migration state by comparing migration files on disk against the journal. Does not connect to ClickHouse.
+Reports the current migration state by comparing migration files on disk against the migration journal stored in ClickHouse. Requires a ClickHouse connection.
 
 ## Synopsis
 
@@ -19,14 +19,14 @@ No command-specific flags. See [global flags](/cli/overview/#global-flags).
 
 ## Behavior
 
-`chkit status` reads the migrations directory and `journal.json` to compute:
+`chkit status` reads the migrations directory and the `_chkit_migrations` journal table in ClickHouse to compute:
 
 - **Total** migration files (`.sql` files in `migrationsDir`, sorted alphabetically)
-- **Applied** migrations (entries recorded in the journal)
+- **Applied** migrations (entries recorded in the journal table)
 - **Pending** migrations (on disk but not yet applied)
 - **Checksum mismatches** (applied migrations whose SHA-256 checksum no longer matches the file on disk)
 
-This command is read-only and does not require a ClickHouse connection.
+This command is read-only, but it requires a ClickHouse connection to read the journal table. It fails if no `clickhouse` connection is configured.
 
 ## Examples
 
@@ -47,7 +47,8 @@ chkit status --json
 
 | Code | Meaning |
 |------|---------|
-| 0 | Always succeeds |
+| 0 | Success |
+| 1 | Error (e.g. no ClickHouse connection configured) |
 
 ## JSON output
 

--- a/apps/docs/src/content/docs/configuration/overview.md
+++ b/apps/docs/src/content/docs/configuration/overview.md
@@ -10,11 +10,13 @@ description: "clickhouse.config.ts structure and defaults."
 - `schema`: glob path to [schema files](/schema/dsl-reference/)
 - `outDir`: root folder for generated artifacts
 - `migrationsDir`: SQL migration file folder
-- `metaDir`: state folder (`snapshot.json`, `journal.json`)
+- `metaDir`: state folder (`snapshot.json`)
 - `plugins`: plugin registrations
 - `clickhouse`: live connection options
 - `check`: CI gate behavior
 - `safety`: destructive migration safety behavior
+
+Migration state (the journal of applied migrations) is not stored in `metaDir`. It lives in the `_chkit_migrations` table in ClickHouse, so `status`, `migrate`, and `check` require a ClickHouse connection.
 
 ## Example
 

--- a/apps/docs/src/content/docs/configuration/overview.md
+++ b/apps/docs/src/content/docs/configuration/overview.md
@@ -16,7 +16,7 @@ description: "clickhouse.config.ts structure and defaults."
 - `check`: CI gate behavior
 - `safety`: destructive migration safety behavior
 
-Migration state (the journal of applied migrations) is not stored in `metaDir`. It lives in the `_chkit_migrations` table in ClickHouse, so `status`, `migrate`, and `check` require a ClickHouse connection.
+Migration state (the journal of applied migrations) is not stored in `metaDir`. It lives in the `_chkit_migrations` table in your configured `clickhouse.database`, so `status`, `migrate`, and `check` require a ClickHouse connection.
 
 ## Example
 


### PR DESCRIPTION
## Summary
The migration journal moved from a `journal.json` file in `metaDir` into the `_chkit_migrations` ClickHouse table, but the docs were never updated — leaving a cold user following the docs at a guaranteed wall. This fixes findings **#3 (blocker)** and **#17** from the chkit prod-ready audit (NUM-7276 / NUM-7294).

- **`cli/status.md`** — remove the false "does not connect to ClickHouse / does not require a ClickHouse connection" claims (`status` now reads the journal table and hard-fails without an executor); document reading the `_chkit_migrations` table; fix the exit-codes table (no longer "always succeeds").
- **`cli/migrate.md`** — rewrite the Journal section to describe the `_chkit_migrations` table and the `CHKIT_JOURNAL_TABLE` override; drop the dead `journalFile` field from the success JSON example.
- **`configuration/overview.md`** — drop `journal.json` from the `metaDir` description; add a note that migration state lives in ClickHouse and `status`/`migrate`/`check` require a connection.

All claims were verified against the current CLI source (`status.ts` throws without an executor; `journal-store.ts` defines `_chkit_migrations`; migrate emits `{mode, scope, applied}` with no `journalFile`). Docs-only change — no changeset required.

## Test plan
- [x] `cd apps/docs && bun run build` succeeds (29 pages, raw-markdown sitemap regenerated)
- [x] Grep sweep confirms no remaining `journal.json` / `journalFile` / "does not require a ClickHouse" references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)