### PR TITLE
feat: load .ts config and schema files under plain Node (not just Bun)

### DIFF
--- a/.changeset/ts-config-loader-under-node.md
+++ b/.changeset/ts-config-loader-under-node.md
@@ -1,0 +1,6 @@
+---
+"@chkit/core": patch
+"chkit": patch
+---
+
+Load `.ts` config and schema files under plain Node, not only Bun. Previously every database command (`status`, `generate`, `migrate`, `check`, `drift`, `query`) failed on Node with `Unknown file extension ".ts"`, despite the docs advertising Node.js 20+. Config and schema modules now load through jiti on Node (and continue to use Bun's native importer under Bun). Also improves the cold-start error when a config can't resolve its dependencies: instead of a raw module-resolution error, chkit now reports which package is missing and tells you to run `bun install` (or `npm`/`pnpm install`).

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "chkit",
@@ -19,7 +18,7 @@
     },
     "apps/docs": {
       "name": "@chkit/docs",
-      "version": "0.0.2-beta.15",
+      "version": "0.0.2-beta.17",
       "dependencies": {
         "@astrojs/starlight": "^0.37.6",
         "astro": "^5.6.1",
@@ -45,7 +44,7 @@
     },
     "packages/cli": {
       "name": "chkit",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "bin": {
         "chkit": "./dist/bin/chkit.js",
       },
@@ -62,7 +61,7 @@
     },
     "packages/clickhouse": {
       "name": "@chkit/clickhouse",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "@clickhouse/client": "^1.11.0",
@@ -72,16 +71,17 @@
     },
     "packages/codegen": {
       "name": "@chkit/codegen",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/core": "0.1.0-beta.26",
       },
     },
     "packages/core": {
       "name": "@chkit/core",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "fast-glob": "^3.3.2",
+        "jiti": "^2.7.0",
       },
       "devDependencies": {
         "@clickhouse/client": "^1.11.0",
@@ -89,7 +89,7 @@
     },
     "packages/create-chkit": {
       "name": "create-chkit",
-      "version": "0.1.0-beta.25",
+      "version": "0.1.0-beta.27",
       "bin": {
         "create-chkit": "./dist/bin/create-chkit.js",
       },
@@ -105,7 +105,7 @@
     },
     "packages/plugin-backfill": {
       "name": "@chkit/plugin-backfill",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -116,7 +116,7 @@
     },
     "packages/plugin-codegen": {
       "name": "@chkit/plugin-codegen",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/core": "workspace:*",
         "zod": "^4.3.6",
@@ -124,7 +124,7 @@
     },
     "packages/plugin-obsessiondb": {
       "name": "@chkit/plugin-obsessiondb",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -135,7 +135,7 @@
     },
     "packages/plugin-pull": {
       "name": "@chkit/plugin-pull",
-      "version": "0.1.0-beta.26",
+      "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
@@ -935,6 +935,8 @@
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/packages/cli/src/runtime/config.ts
+++ b/packages/cli/src/runtime/config.ts
@@ -2,9 +2,9 @@ import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
 
 import {
+  importModuleFile,
   resolveConfig,
   SYNTHESIZED_CONFIG_PATH,
   type ChxConfig,
@@ -108,7 +108,12 @@ export async function loadConfig(
 }
 
 async function readRawConfig(configPath: string, env: ChxConfigEnv): Promise<RawConfig> {
-  const mod = await import(pathToFileURL(configPath).href)
+  let mod: Record<string, unknown>
+  try {
+    mod = await importModuleFile(configPath)
+  } catch (error) {
+    throw enrichConfigLoadError(error, configPath)
+  }
   const candidate = (mod.default ?? mod.config) as ChxConfigInput | undefined
   if (!candidate) {
     throw new Error(
@@ -120,6 +125,26 @@ async function readRawConfig(configPath: string, env: ChxConfigEnv): Promise<Raw
   debug('config', `config export is ${isFn ? 'function' : 'object'} (path=${configPath})`)
   const raw = isFn ? await candidate(env) : (candidate as ChxConfig)
   return { raw, path: configPath }
+}
+
+export function parseMissingModule(message: string): string | undefined {
+  const match =
+    message.match(/cannot find (?:module|package) ['"]([^'"]+)['"]/i) ??
+    message.match(/cannot resolve ['"]([^'"]+)['"]/i)
+  return match?.[1]
+}
+
+function enrichConfigLoadError(error: unknown, configPath: string): Error {
+  const message = error instanceof Error ? error.message : String(error)
+  const missing = parseMissingModule(message)
+  if (missing) {
+    return new Error(
+      `Config at ${configPath} could not load its dependencies: cannot find "${missing}".\n` +
+        `Install dependencies in this project first: bun install (or npm install / pnpm install).`,
+      { cause: error },
+    )
+  }
+  return error instanceof Error ? error : new Error(message)
 }
 
 async function readProfileLayer(

--- a/packages/cli/src/test/runtime/config.test.ts
+++ b/packages/cli/src/test/runtime/config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseMissingModule } from '../../runtime/config.js'
+
+describe('parseMissingModule', () => {
+  test('extracts the package from a jiti / Node CJS error', () => {
+    expect(parseMissingModule("Cannot find module '@chkit/core'")).toBe('@chkit/core')
+  })
+
+  test('extracts the package from a Node ESM error', () => {
+    expect(parseMissingModule("Cannot find package 'zod' imported from /app/clickhouse.config.ts")).toBe('zod')
+  })
+
+  test('extracts the package from a Bun-style error', () => {
+    expect(parseMissingModule(`Cannot find package "@chkit/plugin-codegen" from "/app"`)).toBe(
+      '@chkit/plugin-codegen',
+    )
+  })
+
+  test('returns undefined for unrelated errors', () => {
+    expect(parseMissingModule('SyntaxError: Unexpected token')).toBeUndefined()
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "fast-glob": "^3.3.2"
+    "fast-glob": "^3.3.2",
+    "jiti": "^2.7.0"
   },
   "devDependencies": {
     "@clickhouse/client": "^1.11.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,3 +24,4 @@ export {
 export { assertValidDefinitions, validateDefinitions } from './validate.js'
 export { wrapPluginRun } from './plugin-error.js'
 export { splitSqlStatements, extractExecutableStatements } from './sql-splitter.js'
+export { importModuleFile } from './ts-import.js'

--- a/packages/core/src/schema-loader.ts
+++ b/packages/core/src/schema-loader.ts
@@ -1,10 +1,10 @@
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
 
 import fg from 'fast-glob'
 
 import { canonicalizeDefinitions, collectDefinitionsFromModule } from './canonical.js'
 import type { SchemaDefinition } from './model.js'
+import { importModuleFile } from './ts-import.js'
 
 export interface SchemaLoaderOptions {
   cwd?: string
@@ -26,7 +26,7 @@ export async function loadSchemaDefinitions(
 
   const all: SchemaDefinition[] = []
   for (const file of files) {
-    const mod = (await import(pathToFileURL(file).href)) as Record<string, unknown>
+    const mod = await importModuleFile(file)
     all.push(...collectDefinitionsFromModule(mod))
   }
 

--- a/packages/core/src/ts-import.test.ts
+++ b/packages/core/src/ts-import.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+
+import { importModuleFile } from './ts-import.js'
+
+function makeFixtureDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'chkit-ts-import-'))
+  // A type annotation ensures we exercise TypeScript-specific syntax, not just ESM.
+  writeFileSync(join(dir, 'sample.ts'), `export const value: number = 42\nexport default { name: 'sample' }\n`)
+  writeFileSync(join(dir, 'sample.mjs'), `export const value = 7\nexport default { name: 'mjs' }\n`)
+  return dir
+}
+
+describe('importModuleFile', () => {
+  test('loads a .ts module with named and default exports under the current runtime', async () => {
+    const dir = makeFixtureDir()
+    const mod = await importModuleFile(join(dir, 'sample.ts'))
+    expect(mod.value).toBe(42)
+    expect((mod.default as { name: string }).name).toBe('sample')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('loads a plain .mjs module', async () => {
+    const dir = makeFixtureDir()
+    const mod = await importModuleFile(join(dir, 'sample.mjs'))
+    expect(mod.value).toBe(7)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // Regression guard for finding #1: plain Node cannot natively import a .ts file
+  // (ERR_UNKNOWN_FILE_EXTENSION). importModuleFile must load it via jiti under Node.
+  test('loads a .ts module under plain Node', () => {
+    const dir = makeFixtureDir()
+    const tsImportSource = join(import.meta.dir, 'ts-import.ts')
+    const script = [
+      `const { createJiti } = await import('jiti')`,
+      `const jiti = createJiti(import.meta.url)`,
+      `const mod = await jiti.import(${JSON.stringify(tsImportSource)})`,
+      `const out = await mod.importModuleFile(${JSON.stringify(join(dir, 'sample.ts'))})`,
+      `process.stdout.write(JSON.stringify({ value: out.value, name: out.default.name }))`,
+    ].join('\n')
+    const result = spawnSync('node', ['--input-type=module', '-e', script], {
+      cwd: import.meta.dir,
+      encoding: 'utf8',
+    })
+    rmSync(dir, { recursive: true, force: true })
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual({ value: 42, name: 'sample' })
+  })
+})

--- a/packages/core/src/ts-import.test.ts
+++ b/packages/core/src/ts-import.test.ts
@@ -1,16 +1,18 @@
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, test } from 'bun:test'
 
 import { importModuleFile } from './ts-import.js'
 
+const TS_FIXTURE = `export const value: number = 42\nexport default { name: 'sample' }\n`
+
 function makeFixtureDir(): string {
   const dir = mkdtempSync(join(tmpdir(), 'chkit-ts-import-'))
   // A type annotation ensures we exercise TypeScript-specific syntax, not just ESM.
-  writeFileSync(join(dir, 'sample.ts'), `export const value: number = 42\nexport default { name: 'sample' }\n`)
+  writeFileSync(join(dir, 'sample.ts'), TS_FIXTURE)
   writeFileSync(join(dir, 'sample.mjs'), `export const value = 7\nexport default { name: 'mjs' }\n`)
   return dir
 }
@@ -33,22 +35,33 @@ describe('importModuleFile', () => {
 
   // Regression guard for finding #1: plain Node cannot natively import a .ts file
   // (ERR_UNKNOWN_FILE_EXTENSION). importModuleFile must load it via jiti under Node.
-  test('loads a .ts module under plain Node', () => {
-    const dir = makeFixtureDir()
-    const tsImportSource = join(import.meta.dir, 'ts-import.ts')
+  //
+  // We transpile ts-import.ts to plain JS and run THAT under Node, rather than
+  // loading the .ts source through jiti — otherwise jiti's transform would also
+  // intercept importModuleFile's own dynamic import() and mask a native-import
+  // regression. The temp dir lives under the repo root so the compiled module's
+  // `import('jiti')` resolves against the workspace node_modules.
+  test('loads a .ts module under plain Node (compiled, no jiti wrapper)', () => {
+    const repoRoot = resolve(import.meta.dir, '../../..')
+    const dir = mkdtempSync(join(repoRoot, '.tmp-node-loader-'))
+    const sourceTs = readFileSync(join(import.meta.dir, 'ts-import.ts'), 'utf8')
+    const compiledJs = new Bun.Transpiler({ loader: 'ts' }).transformSync(sourceTs)
+    writeFileSync(join(dir, 'ts-import.mjs'), compiledJs)
+    writeFileSync(join(dir, 'sample.ts'), TS_FIXTURE)
+
     const script = [
-      `const { createJiti } = await import('jiti')`,
-      `const jiti = createJiti(import.meta.url)`,
-      `const mod = await jiti.import(${JSON.stringify(tsImportSource)})`,
-      `const out = await mod.importModuleFile(${JSON.stringify(join(dir, 'sample.ts'))})`,
+      `const mod = await import('./ts-import.mjs')`,
+      `const out = await mod.importModuleFile('./sample.ts')`,
       `process.stdout.write(JSON.stringify({ value: out.value, name: out.default.name }))`,
     ].join('\n')
     const result = spawnSync('node', ['--input-type=module', '-e', script], {
-      cwd: import.meta.dir,
+      cwd: dir,
       encoding: 'utf8',
     })
     rmSync(dir, { recursive: true, force: true })
+
     expect(result.status).toBe(0)
+    expect(result.stderr).not.toContain('ERR_UNKNOWN_FILE_EXTENSION')
     expect(JSON.parse(result.stdout)).toEqual({ value: 42, name: 'sample' })
   })
 })

--- a/packages/core/src/ts-import.ts
+++ b/packages/core/src/ts-import.ts
@@ -1,0 +1,34 @@
+import { pathToFileURL } from 'node:url'
+
+type ModuleNamespace = Record<string, unknown>
+type ModuleImporter = (id: string) => Promise<ModuleNamespace>
+
+let cachedNodeImporter: ModuleImporter | null = null
+
+function isBun(): boolean {
+  return typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined'
+}
+
+async function getNodeImporter(): Promise<ModuleImporter> {
+  if (cachedNodeImporter) return cachedNodeImporter
+  const { createJiti } = await import('jiti')
+  const jiti = createJiti(import.meta.url)
+  cachedNodeImporter = (id) => jiti.import(id) as Promise<ModuleNamespace>
+  return cachedNodeImporter
+}
+
+/**
+ * Import a user config or schema module by absolute path.
+ *
+ * Bun transpiles TypeScript natively, so it uses a plain dynamic import. Under
+ * Node, `.ts` files are loaded through jiti so they work without a separate
+ * build step — matching the documented "Node.js 20+" support. Plain `.js`/`.mjs`
+ * modules load the same way under either runtime.
+ */
+export async function importModuleFile(absolutePath: string): Promise<ModuleNamespace> {
+  if (isBun()) {
+    return (await import(pathToFileURL(absolutePath).href)) as ModuleNamespace
+  }
+  const nodeImport = await getNodeImporter()
+  return nodeImport(absolutePath)
+}


### PR DESCRIPTION
## Summary
Every database command (`status`, `generate`, `migrate`, `check`, `drift`, `query`) failed under **Node** with `Unknown file extension ".ts"` because `config.ts` and `schema-loader.ts` did a bare `await import()` of a `.ts` URL — which only Bun can transpile. The docs advertise **Node.js 20+**, so this broke the product for the majority TS-on-Node audience on their first command. Fixes audit **#1 (blocker)** and **#12**, and unblocks **#9** (npm/pnpm/yarn now work).

- New `importModuleFile()` in `@chkit/core`: under Bun it keeps the native importer (byte-identical to today); under Node it loads `.ts`/`.js` through **jiti**, preserving normal `node_modules` resolution (so a schema's `import { table } from '@chkit/core'` keeps type identity — no bundled duplicate).
- Both load sites (core `schema-loader`, cli `config`) route through it.
- **#12**: config-load failures now report the missing package and tell you to run `bun install` (or `npm`/`pnpm install`) instead of leaking a raw module-resolution error.
- Adds `jiti@^2.7.0` to `@chkit/core` deps.

## Runtime decision
Per the prod-ready plan we chose **ship a TS loader** (keeps the "Node 20+ / works anywhere TS does" audience) over going Bun-native — so docs stay accurate and no `engines` guard / `.mjs` scaffolding is needed.

## Test plan
- [x] `bun test` — new `ts-import.test.ts` (Bun load + a **spawned-Node** regression guard that loads a `.ts` via the real loader) and `parseMissingModule` unit tests; 76 cli-runtime + 243 core tests pass.
- [x] **Live**: scaffolded a `.ts` config + schema, ran `status` and `generate --dryrun` under **`node`** against a real ClickHouse cluster — both succeed (previously `ERR_UNKNOWN_FILE_EXTENSION`). Confirmed the Bun path is unchanged and the #12 message fires for a config with no installed deps.
- [x] `typecheck` + `lint` clean on `@chkit/core` and `chkit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)