### PR TITLE
fix: clean one-line message on ClickHouse authentication failure

### DIFF
--- a/.changeset/clean-auth-error-message.md
+++ b/.changeset/clean-auth-error-message.md
@@ -1,0 +1,6 @@
+---
+"@chkit/clickhouse": patch
+"chkit": patch
+---
+
+Replace the leaked ClickHouse server blurb on an authentication failure with a single clear line. A wrong `CLICKHOUSE_PASSWORD` previously dumped ~8 lines of ClickHouse Cloud password-reset instructions and `/etc/clickhouse-server/users.d/` filesystem paths that read as an internal error leak. chkit now detects auth failures (ClickHouse error codes 194/516, `REQUIRED_PASSWORD`/`AUTHENTICATION_FAILED`, or an "Authentication failed" message) and reports: `Authentication failed for user "<user>" at <url>. Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.`

--- a/packages/cli/src/test/auth.e2e.test.ts
+++ b/packages/cli/src/test/auth.e2e.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+
+import { getRequiredEnv, runCli } from './e2e-testkit.js'
+
+describe('@chkit/cli auth error e2e', () => {
+  test('a wrong password yields one clean line, not the raw ClickHouse server blurb (#7)', async () => {
+    const { clickhouseUrl, clickhouseUser, clickhouseDatabase } = getRequiredEnv()
+    const dir = await mkdtemp(join(tmpdir(), 'chkit-auth-e2e-'))
+    const configPath = join(dir, 'clickhouse.config.ts')
+    await writeFile(
+      configPath,
+      `export default {\n` +
+        `  schema: '${join(dir, 'schema.ts')}',\n` +
+        `  outDir: '${join(dir, 'chkit')}',\n` +
+        `  migrationsDir: '${join(dir, 'chkit/migrations')}',\n` +
+        `  metaDir: '${join(dir, 'chkit/meta')}',\n` +
+        `  clickhouse: {\n` +
+        `    url: '${clickhouseUrl}',\n` +
+        `    username: '${clickhouseUser}',\n` +
+        `    password: 'definitely-wrong-password-xyz',\n` +
+        `    database: '${clickhouseDatabase}',\n` +
+        `  },\n}\n`,
+      'utf8',
+    )
+
+    try {
+      // HOME/XDG override isolates the run from any stored ObsessionDB profile,
+      // so the vanilla executor path (and wrapConnectionError) is exercised.
+      const result = runCli(dir, ['status', '--config', configPath, '--json'], {
+        HOME: dir,
+        XDG_CONFIG_HOME: dir,
+      })
+      expect(result.exitCode).toBe(1)
+      const combined = `${result.stdout}\n${result.stderr}`
+      expect(combined).toContain(`Authentication failed for user "${clickhouseUser}"`)
+      expect(combined).toContain('Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD')
+      // The leaked server remediation blurb must be gone.
+      expect(combined).not.toContain('clickhouse.cloud')
+      expect(combined).not.toContain('/etc/clickhouse-server')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/packages/clickhouse/src/index.test.ts
+++ b/packages/clickhouse/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   createSessionClickHouseClient,
   createStatelessClickHouseExecutor,
   createStatelessClickHouseClient,
+  formatConnectionError,
   inferSchemaKindFromEngine,
   parseEngineFromCreateTableQuery,
   parseOrderByFromCreateTableQuery,
@@ -424,5 +425,48 @@ ORDER BY id;`
         query: 'SELECT id ORDER BY id LIMIT 10',
       },
     ])
+  })
+})
+
+describe('formatConnectionError', () => {
+  // The full server blurb chkit must NOT leak (Cloud reset URL + on-disk paths).
+  const rawAuthBlurb =
+    'default: Authentication failed: password is incorrect, or there is no user with such name\n\n' +
+    'If you use ClickHouse Cloud, the password can be reset at https://clickhouse.cloud/\n' +
+    'The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml\n'
+
+  test('replaces a wrong-password error (code 194) with one clean line', () => {
+    const error = Object.assign(new Error(rawAuthBlurb), { code: '194', type: 'REQUIRED_PASSWORD' })
+    const message = formatConnectionError(error, 'https://db.example.com:443', 'default')
+    expect(message).toBe(
+      'Authentication failed for user "default" at https://db.example.com:443. Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.',
+    )
+    expect(message).not.toContain('clickhouse.cloud')
+    expect(message).not.toContain('/etc/clickhouse-server')
+  })
+
+  test('detects AUTHENTICATION_FAILED (code 516) by type', () => {
+    const error = Object.assign(new Error('Authentication failed'), { type: 'AUTHENTICATION_FAILED' })
+    expect(formatConnectionError(error, 'https://x', 'admin')).toBe(
+      'Authentication failed for user "admin" at https://x. Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.',
+    )
+  })
+
+  test('detects auth failure by message alone (no code/type)', () => {
+    const error = new Error('default: Authentication failed: password is incorrect')
+    expect(formatConnectionError(error, 'https://x')).toBe(
+      'Authentication failed for the configured user at https://x. Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.',
+    )
+  })
+
+  test('still formats network errors (regression: ECONNREFUSED path intact)', () => {
+    const error = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' })
+    expect(formatConnectionError(error, 'https://x')).toBe(
+      'Could not connect to ClickHouse at https://x (connection refused)',
+    )
+  })
+
+  test('returns undefined for unrecognized errors (caller rethrows raw)', () => {
+    expect(formatConnectionError(new Error('Unknown data type family: Nope'), 'https://x')).toBeUndefined()
   })
 })

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -327,8 +327,36 @@ const NETWORK_ERROR_LABELS: Record<string, string> = {
 	EHOSTUNREACH: 'host unreachable',
 }
 
-function wrapConnectionError(error: unknown, url: string): never {
-	if (error instanceof Error && 'code' in error) {
+/**
+ * ClickHouse reports a wrong/missing password with server-side error codes 194
+ * (REQUIRED_PASSWORD) or 516 (AUTHENTICATION_FAILED) and a multi-line message
+ * that includes Cloud reset URLs and on-disk users.d/ paths — noise that reads
+ * as a leaked internal error to someone who just fat-fingered a password.
+ */
+function isAuthError(error: Error): boolean {
+	const code = String((error as { code?: unknown }).code ?? '')
+	const type = String((error as { type?: unknown }).type ?? '')
+	if (code === '194' || code === '516') return true
+	if (type === 'REQUIRED_PASSWORD' || type === 'AUTHENTICATION_FAILED') return true
+	return /authentication failed/i.test(error.message)
+}
+
+/**
+ * Builds a clean, user-facing message for a connection-time error, or returns
+ * `undefined` when the error is not one we recognize (caller rethrows as-is).
+ * Pure so it can be unit-tested without catching thrown errors.
+ */
+export function formatConnectionError(
+	error: unknown,
+	url: string,
+	username?: string,
+): string | undefined {
+	if (!(error instanceof Error)) return undefined
+	if (isAuthError(error)) {
+		const who = username ? `user "${username}"` : 'the configured user'
+		return `Authentication failed for ${who} at ${url}. Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.`
+	}
+	if ('code' in error) {
 		const code = (error as NodeJS.ErrnoException).code ?? ''
 		const label = NETWORK_ERROR_LABELS[code]
 		if (label) {
@@ -339,11 +367,15 @@ function wrapConnectionError(error: unknown, url: string): never {
 				isLocalhostDefault && envUnset
 					? '\n  Hint: CLICKHOUSE_URL is not set — chkit fell back to the default localhost endpoint. Set CLICKHOUSE_URL to point at your ClickHouse instance.'
 					: ''
-			throw new Error(
-				`Could not connect to ClickHouse at ${url} (${label})${hint}`,
-			)
+			return `Could not connect to ClickHouse at ${url} (${label})${hint}`
 		}
 	}
+	return undefined
+}
+
+export function wrapConnectionError(error: unknown, url: string, username?: string): never {
+	const message = formatConnectionError(error, url, username)
+	if (message !== undefined) throw new Error(message)
 	throw error
 }
 
@@ -573,7 +605,7 @@ export function createExecutorWithClient(
 					}
 					return
 				}
-				wrapConnectionError(error, config.url)
+				wrapConnectionError(error, config.url, config.username)
 			}
 		},
 		async query<T>(sql: string, settings?: ClickHouseSettings): Promise<T[]> {
@@ -603,7 +635,7 @@ export function createExecutorWithClient(
 				)
 				return rows
 			} catch (error) {
-				wrapConnectionError(error, config.url)
+				wrapConnectionError(error, config.url, config.username)
 			}
 		},
 		async queryJson<T extends Record<string, unknown>>(
@@ -634,7 +666,7 @@ export function createExecutorWithClient(
 					query_id: result.query_id,
 				}
 			} catch (error) {
-				wrapConnectionError(error, config.url)
+				wrapConnectionError(error, config.url, config.username)
 			}
 		},
 		async insert<T extends Record<string, unknown>>(
@@ -671,7 +703,7 @@ export function createExecutorWithClient(
 					result.summary,
 				)
 			} catch (error) {
-				wrapConnectionError(error, config.url)
+				wrapConnectionError(error, config.url, config.username)
 			}
 		},
 		async submit(sql: string, queryId?: string): Promise<string> {
@@ -679,7 +711,7 @@ export function createExecutorWithClient(
 			try {
 				await fireAndForgetClient.command({ query: sql, query_id: id })
 			} catch (error) {
-				wrapConnectionError(error, config.url)
+				wrapConnectionError(error, config.url, config.username)
 			}
 			return id
 		},
@@ -758,7 +790,7 @@ SETTINGS skip_unavailable_shards = 1`,
 					error: row.exception,
 				}
 			} catch (error) {
-				wrapConnectionError(error, config.url)
+				wrapConnectionError(error, config.url, config.username)
 			}
 		},
 		async close(): Promise<void> {


### PR DESCRIPTION
## Summary
A fat-fingered `CLICKHOUSE_PASSWORD` dumped ~8 lines of ClickHouse Cloud password-reset instructions and `/etc/clickhouse-server/users.d/` filesystem paths — noise that reads as a leaked internal error. `wrapConnectionError` only reformatted *network*-error labels and rethrew everything else raw. Fixes audit **#7**.

- Detect auth failures (CH codes `194`/`516`, `REQUIRED_PASSWORD`/`AUTHENTICATION_FAILED`, or an "Authentication failed" message) and report a single line: `Authentication failed for user "<user>" at <url>. Check CLICKHOUSE_USER / CLICKHOUSE_PASSWORD.`
- Pass `config.username` through to all 6 `wrapConnectionError` call sites.
- Extract message-building into a pure `formatConnectionError()` so it's unit-testable without catching throws.

## Test plan
- [x] `bun test` — 5 new `formatConnectionError` cases (wrong-password code 194 → clean line **and** asserts the Cloud-URL / server-path blurb is gone; `AUTHENTICATION_FAILED` by type; message-only detection; ECONNREFUSED regression; unknown error → `undefined`/rethrow). 25 clickhouse tests pass.
- [x] **Live**: wrong `CLICKHOUSE_PASSWORD` against a real cluster now yields the one-liner (no blurb); correct password unaffected (`status` succeeds). Error shape captured from the real server (code `194`, type `REQUIRED_PASSWORD`).
- [x] `typecheck` + `lint` clean on `@chkit/clickhouse` and `chkit`.

Note: the `Plugin "core" failed in command:status:` prefix is the separate finding #20, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)