### PR TITLE
feat: stable JSON error envelope for --json mode

### DIFF
--- a/.changeset/json-error-envelope.md
+++ b/.changeset/json-error-envelope.md
@@ -1,0 +1,5 @@
+---
+"chkit": patch
+---
+
+Emit a stable JSON error envelope in `--json` mode. Previously any failure left stdout empty and printed a multi-line plain-text message to stderr, so any pipe to `jq` broke on the first error. Failures now write `{ "command", "schemaVersion", "ok": false, "error": { "code", "message", "hint?" } }` to stdout (exit code unchanged). Successful `--json` output is unchanged. Commands that already emit a structured JSON payload before failing (e.g. checksum mismatch, blocked destructive migration) are not double-wrapped.

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -11,6 +11,7 @@ import { debug } from '../runtime/debug.js'
 import { extractConfigPath } from '../runtime/extract-config-path.js'
 import { GLOBAL_FLAGS } from '../runtime/global-flags.js'
 import { formatCommandHelp, formatGlobalHelp } from '../runtime/help.js'
+import { emitJsonError, hasEmittedJson, type JsonError } from '../runtime/json-output.js'
 import { configureCliLogging } from '../runtime/logging.js'
 import { loadPluginRuntime } from '../runtime/plugin-runtime/index.js'
 import { CLI_VERSION } from '../runtime/version.js'
@@ -65,6 +66,16 @@ function formatFatalError(error: unknown): string {
     return (error as NodeJS.ErrnoException).code as string
   }
   return String(error) || 'Unknown error'
+}
+
+function toJsonError(error: unknown): JsonError {
+  const code =
+    error instanceof Error &&
+    'code' in error &&
+    typeof (error as NodeJS.ErrnoException).code === 'string'
+      ? ((error as NodeJS.ErrnoException).code as string)
+      : 'error'
+  return { code, message: formatFatalError(error) }
 }
 
 function resolveExitCode(): number {
@@ -268,6 +279,12 @@ run()
           }
         : error,
     )
-    console.error(formatFatalError(error))
+    const argv = process.argv.slice(2)
+    const jsonMode = argv.includes('--json')
+    if (jsonMode && !hasEmittedJson()) {
+      emitJsonError(argv[0] ?? 'chkit', toJsonError(error))
+    } else {
+      console.error(formatFatalError(error))
+    }
     process.exit(1)
   })

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -281,10 +281,13 @@ run()
     )
     const argv = process.argv.slice(2)
     const jsonMode = argv.includes('--json')
+    // In --json mode emit a machine-readable envelope to stdout (so a pipe to
+    // jq doesn't break on the first error) unless a command already wrote a
+    // structured JSON payload. The human-readable message always goes to
+    // stderr — stdout stays parseable, stderr stays diagnostic.
     if (jsonMode && !hasEmittedJson()) {
       emitJsonError(argv[0] ?? 'chkit', toJsonError(error))
-    } else {
-      console.error(formatFatalError(error))
     }
+    console.error(formatFatalError(error))
     process.exit(1)
   })

--- a/packages/cli/src/bin/chkit.ts
+++ b/packages/cli/src/bin/chkit.ts
@@ -78,6 +78,29 @@ function toJsonError(error: unknown): JsonError {
   return { code, message: formatFatalError(error) }
 }
 
+/**
+ * Report a usage error from a non-throwing early-return path (unknown command,
+ * missing project config, plugin not configured). Mirrors the top-level catch:
+ * the human message always goes to stderr; in --json mode a parseable error
+ * envelope goes to stdout (instead of nothing — or, for unknown commands, help
+ * text that would break a `jq` consumer). Sets a failing exit code.
+ */
+function reportUsageError(input: {
+  command: string
+  code: string
+  message: string
+  jsonMode: boolean
+  onText?: () => void
+}): void {
+  console.error(input.message)
+  if (input.jsonMode) {
+    emitJsonError(input.command, { code: input.code, message: input.message })
+  } else {
+    input.onText?.()
+  }
+  process.exitCode = 1
+}
+
 function resolveExitCode(): number {
   if (typeof process.exitCode === 'number') return process.exitCode
   return process.exitCode ? Number(process.exitCode) : 0
@@ -134,11 +157,14 @@ async function run(): Promise<void> {
   })
 
   if (configSource !== 'project' && PROJECT_ONLY_COMMANDS.has(commandName)) {
-    console.error(
-      `Command "${commandName}" requires a project config (clickhouse.config.ts) in the current directory.\n` +
+    reportUsageError({
+      command: commandName,
+      code: 'project_config_required',
+      message:
+        `Command "${commandName}" requires a project config (clickhouse.config.ts) in the current directory.\n` +
         `You are running chkit from a user profile (no local config found).`,
-    )
-    process.exitCode = 1
+      jsonMode: argv.includes('--json'),
+    })
     return
   }
 
@@ -194,14 +220,24 @@ async function run(): Promise<void> {
     if (!resolved) {
       const wellKnown = WELL_KNOWN_PLUGIN_COMMANDS[commandName]
       if (wellKnown) {
-        console.error(`${wellKnown} plugin is not configured. Add it to config.plugins first.`)
-        process.exitCode = 1
+        reportUsageError({
+          command: commandName,
+          code: 'plugin_not_configured',
+          message: `${wellKnown} plugin is not configured. Add it to config.plugins first.`,
+          jsonMode: argv.includes('--json'),
+        })
         return
       }
-      console.error(`Unknown command: ${commandName}`)
-      console.log('')
-      console.log(formatGlobalHelp(registry, CLI_VERSION))
-      process.exitCode = 1
+      reportUsageError({
+        command: commandName,
+        code: 'unknown_command',
+        message: `Unknown command: ${commandName}`,
+        jsonMode: argv.includes('--json'),
+        onText: () => {
+          console.log('')
+          console.log(formatGlobalHelp(registry, CLI_VERSION))
+        },
+      })
       return
     }
 

--- a/packages/cli/src/runtime/json-output.ts
+++ b/packages/cli/src/runtime/json-output.ts
@@ -9,8 +9,16 @@ type Command =
 
 const JSON_CONTRACT_VERSION = 1
 
+let jsonEmitted = false
+
+/** Whether any JSON payload (success or error) has already been written to stdout. */
+export function hasEmittedJson(): boolean {
+  return jsonEmitted
+}
+
 export function printOutput(value: unknown, jsonMode: boolean): void {
   if (jsonMode) {
+    jsonEmitted = true
     console.log(JSON.stringify(value, null, 2))
     return
   }
@@ -32,4 +40,36 @@ function jsonPayload<T extends object>(command: Command, payload: T): T & {
 
 export function emitJson<T extends object>(command: Command, payload: T): void {
   printOutput(jsonPayload(command, payload), true)
+}
+
+export interface JsonError {
+  code: string
+  message: string
+  hint?: string
+}
+
+export interface JsonErrorEnvelope {
+  command: string
+  schemaVersion: number
+  ok: false
+  error: JsonError
+}
+
+export function buildJsonErrorEnvelope(command: string, error: JsonError): JsonErrorEnvelope {
+  return {
+    command,
+    schemaVersion: JSON_CONTRACT_VERSION,
+    ok: false,
+    error,
+  }
+}
+
+/**
+ * Emit a stable machine-readable error envelope to stdout for `--json` consumers.
+ * Without this, a thrown error left stdout empty and printed plain text to
+ * stderr, breaking any pipe to `jq` on the first failure.
+ */
+export function emitJsonError(command: string, error: JsonError): void {
+  jsonEmitted = true
+  console.log(JSON.stringify(buildJsonErrorEnvelope(command, error), null, 2))
 }

--- a/packages/cli/src/test/check.e2e.test.ts
+++ b/packages/cli/src/test/check.e2e.test.ts
@@ -10,6 +10,11 @@ describe('@chkit/cli check e2e', () => {
       const result = runCli(['check', '--config', fixture.configPath, '--json'])
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain('clickhouse config is required for check')
+      // #4: --json emits a parseable error envelope to stdout.
+      const envelope = JSON.parse(result.stdout) as { ok: boolean; command: string; error: { message: string } }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('check')
+      expect(envelope.error.message).toContain('clickhouse config is required for check')
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })
     }

--- a/packages/cli/src/test/drift-command.e2e.test.ts
+++ b/packages/cli/src/test/drift-command.e2e.test.ts
@@ -13,6 +13,15 @@ describe('@chkit/cli drift command e2e', () => {
       const result = runCli(['drift', '--config', fixture.configPath, '--json'])
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain('clickhouse config is required for drift checks')
+      // #4: --json mode also emits a parseable error envelope to stdout.
+      const envelope = JSON.parse(result.stdout) as {
+        ok: boolean
+        command: string
+        error: { message: string }
+      }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('drift')
+      expect(envelope.error.message).toContain('clickhouse config is required for drift checks')
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })
     }

--- a/packages/cli/src/test/migrate.e2e.test.ts
+++ b/packages/cli/src/test/migrate.e2e.test.ts
@@ -11,6 +11,10 @@ describe('@chkit/cli migrate e2e', () => {
       const result = runCli(['migrate', '--config', fixture.configPath, '--json'])
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain('clickhouse config is required for migrate')
+      const envelope = JSON.parse(result.stdout) as { ok: boolean; command: string; error: { message: string } }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('migrate')
+      expect(envelope.error.message).toContain('clickhouse config is required for migrate')
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })
     }
@@ -29,6 +33,10 @@ describe('@chkit/cli migrate e2e', () => {
       const result = runCli(['migrate', '--config', fixture.configPath, '--execute', '--json'])
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain('clickhouse config is required for migrate')
+      const envelope = JSON.parse(result.stdout) as { ok: boolean; command: string; error: { message: string } }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('migrate')
+      expect(envelope.error.message).toContain('clickhouse config is required for migrate')
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })
     }
@@ -54,6 +62,10 @@ describe('@chkit/cli migrate e2e', () => {
       ])
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain('clickhouse config is required for migrate')
+      const envelope = JSON.parse(result.stdout) as { ok: boolean; command: string; error: { message: string } }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('migrate')
+      expect(envelope.error.message).toContain('clickhouse config is required for migrate')
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })
     }

--- a/packages/cli/src/test/runtime/json-output.test.ts
+++ b/packages/cli/src/test/runtime/json-output.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { buildJsonErrorEnvelope } from '../../runtime/json-output.js'
+import { buildJsonErrorEnvelope, emitJson, hasEmittedJson } from '../../runtime/json-output.js'
 
 describe('buildJsonErrorEnvelope', () => {
   test('produces the stable ok:false error envelope', () => {
@@ -27,5 +27,22 @@ describe('buildJsonErrorEnvelope', () => {
     })
     expect(envelope.ok).toBe(false)
     expect(envelope.error.hint).toBe('Run bun install')
+  })
+})
+
+describe('hasEmittedJson (no-double-emit guard)', () => {
+  // The top-level catch only emits an error envelope when `!hasEmittedJson()`.
+  // So once a command has written its own JSON payload, the flag must be set —
+  // otherwise a command that emits JSON and then throws would print two JSON
+  // objects to stdout, breaking the consumer.
+  test('a successful JSON emit marks output as emitted', () => {
+    const original = console.log
+    console.log = () => {}
+    try {
+      emitJson('migrate', { mode: 'execute', applied: [] })
+    } finally {
+      console.log = original
+    }
+    expect(hasEmittedJson()).toBe(true)
   })
 })

--- a/packages/cli/src/test/runtime/json-output.test.ts
+++ b/packages/cli/src/test/runtime/json-output.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildJsonErrorEnvelope } from '../../runtime/json-output.js'
+
+describe('buildJsonErrorEnvelope', () => {
+  test('produces the stable ok:false error envelope', () => {
+    const envelope = buildJsonErrorEnvelope('migrate', {
+      code: 'error',
+      message: 'Authentication failed for user "default" at https://x.',
+    })
+    expect(envelope).toEqual({
+      command: 'migrate',
+      schemaVersion: 1,
+      ok: false,
+      error: {
+        code: 'error',
+        message: 'Authentication failed for user "default" at https://x.',
+      },
+    })
+  })
+
+  test('preserves an optional hint', () => {
+    const envelope = buildJsonErrorEnvelope('status', {
+      code: 'MODULE_NOT_FOUND',
+      message: 'cannot find "@chkit/core"',
+      hint: 'Run bun install',
+    })
+    expect(envelope.ok).toBe(false)
+    expect(envelope.error.hint).toBe('Run bun install')
+  })
+})

--- a/packages/cli/src/test/status.e2e.test.ts
+++ b/packages/cli/src/test/status.e2e.test.ts
@@ -10,6 +10,11 @@ describe('@chkit/cli status e2e', () => {
       const result = runCli(['status', '--config', fixture.configPath, '--json'])
       expect(result.exitCode).toBe(1)
       expect(result.stderr).toContain('clickhouse config is required for status')
+      // #4: --json emits a parseable error envelope to stdout.
+      const envelope = JSON.parse(result.stdout) as { ok: boolean; command: string; error: { message: string } }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('status')
+      expect(envelope.error.message).toContain('clickhouse config is required for status')
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })
     }

--- a/packages/cli/src/test/usage-errors.e2e.test.ts
+++ b/packages/cli/src/test/usage-errors.e2e.test.ts
@@ -1,0 +1,52 @@
+import { rm } from 'node:fs/promises'
+
+import { describe, expect, test } from 'bun:test'
+
+import { createFixture, runCli } from './testkit.test'
+
+type Envelope = { ok: boolean; command: string; error: { code: string; message: string } }
+
+describe('@chkit/cli usage-error --json envelopes (#4)', () => {
+  test('unknown command emits a JSON envelope on stdout (not help text)', async () => {
+    const fixture = await createFixture()
+    try {
+      const result = runCli(['definitely-not-a-command', '--config', fixture.configPath, '--json'])
+      expect(result.exitCode).toBe(1)
+      // A clean parse proves stdout holds ONLY the envelope — no help dump that
+      // would break a `jq` consumer.
+      const envelope = JSON.parse(result.stdout) as Envelope
+      expect(envelope.ok).toBe(false)
+      expect(envelope.command).toBe('definitely-not-a-command')
+      expect(envelope.error.code).toBe('unknown_command')
+      expect(envelope.error.message).toContain('Unknown command')
+    } finally {
+      await rm(fixture.dir, { recursive: true, force: true })
+    }
+  })
+
+  test('unknown command without --json still prints help to stdout (human path intact)', async () => {
+    const fixture = await createFixture()
+    try {
+      const result = runCli(['definitely-not-a-command', '--config', fixture.configPath])
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('Unknown command')
+      // Non-JSON keeps the helpful global help on stdout.
+      expect(result.stdout.length).toBeGreaterThan(0)
+    } finally {
+      await rm(fixture.dir, { recursive: true, force: true })
+    }
+  })
+
+  test('well-known plugin command without the plugin emits a JSON envelope', async () => {
+    const fixture = await createFixture()
+    try {
+      const result = runCli(['codegen', '--config', fixture.configPath, '--json'])
+      expect(result.exitCode).toBe(1)
+      const envelope = JSON.parse(result.stdout) as Envelope
+      expect(envelope.ok).toBe(false)
+      expect(envelope.error.code).toBe('plugin_not_configured')
+    } finally {
+      await rm(fixture.dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
`--json` is the documented machine-readable mode for CI, but on any failure stdout was empty and a multi-line plain-text message went to stderr — so any pipe to `jq` broke on the first error. Fixes audit **#4**.

- `emitJsonError()` writes `{ "command", "schemaVersion", "ok": false, "error": { "code", "message", "hint?" } }` to **stdout**; wired into the top-level catch in `bin/chkit.ts`.
- A `hasEmittedJson()` guard prevents double-emitting when a command already wrote a structured JSON payload before throwing (checksum mismatch, blocked destructive migration).
- Success `--json` output is unchanged — no `ok` field added, backward compatible.

## Test plan
- [x] `bun test` — `buildJsonErrorEnvelope` shape unit tests; 78 cli-runtime tests pass.
- [x] **Live** (built bin, real cluster): wrong-password `status --json` → a single valid envelope on stdout (`ok:false`, parseable, `error.code`/`message`), exit 1; good-password `status --json` → exactly one unchanged payload (no `ok` field). stderr-vs-stdout separation verified.
- [x] `typecheck` + `lint` clean on `chkit`.

Note: the `Plugin "core" failed in command:…` prefix inside `error.message` is the separate finding #20, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)