### PR TITLE
fix: resume partial sync (DDL) migrations instead of replaying from statement 1

### DIFF
--- a/.changeset/idempotent-renames.md
+++ b/.changeset/idempotent-renames.md
@@ -1,0 +1,6 @@
+---
+"@chkit/core": patch
+"chkit": patch
+---
+
+Generate idempotent `RENAME COLUMN` / `RENAME TABLE` statements using `IF EXISTS`. Renames are the one non-idempotent generated DDL: replaying `RENAME COLUMN a TO b` after it already ran fails with "unknown identifier". With `IF EXISTS`, a replay after a partial migration failure (or alongside per-statement resume) is a safe no-op instead of bricking the migration. Applies to both auto-detected rename suggestions and explicit `--rename-column` / `--rename-table` / `renamedFrom` renames.

--- a/.changeset/sync-migration-resume.md
+++ b/.changeset/sync-migration-resume.md
@@ -1,0 +1,5 @@
+---
+"chkit": patch
+---
+
+Resume partially-applied synchronous (DDL) migrations instead of replaying from the first statement. Previously, if a multi-statement migration failed partway (e.g. statement 1 added a column, statement 2 failed), nothing was journaled and re-running replayed statement 1 — which then failed with "column already exists", leaving the migration permanently stuck with the database mutated. Sync statements now record per-statement journal state (`started` → `completed`/`failed`), mirroring the async path: completed statements are skipped on re-run so the migration resumes from where it failed. Resuming across a migration-file edit is refused (checksum guard).

--- a/packages/cli/src/commands/generate/plan-pipeline.ts
+++ b/packages/cli/src/commands/generate/plan-pipeline.ts
@@ -84,7 +84,7 @@ export function applyExplicitTableRenames(
       type: 'alter_table_rename_table',
       key: `table:${mapping.newDatabase}.${mapping.newName}:rename_table`,
       risk: 'caution',
-      sql: `RENAME TABLE ${mapping.oldDatabase}.${mapping.oldName} TO ${mapping.newDatabase}.${mapping.newName};`,
+      sql: `RENAME TABLE IF EXISTS ${mapping.oldDatabase}.${mapping.oldName} TO ${mapping.newDatabase}.${mapping.newName};`,
     })
   }
 
@@ -129,7 +129,7 @@ export function buildExplicitColumnRenameSuggestions(
           : 'Explicitly confirmed by schema metadata (renamedFrom).',
       dropOperationKey,
       addOperationKey,
-      confirmationSQL: `ALTER TABLE ${mapping.database}.${mapping.table} RENAME COLUMN \`${mapping.from}\` TO \`${mapping.to}\`;`,
+      confirmationSQL: `ALTER TABLE ${mapping.database}.${mapping.table} RENAME COLUMN IF EXISTS \`${mapping.from}\` TO \`${mapping.to}\`;`,
     })
   }
 

--- a/packages/cli/src/commands/migrate/apply.ts
+++ b/packages/cli/src/commands/migrate/apply.ts
@@ -6,15 +6,55 @@ import type { ResolvedChxConfig } from '@chkit/core'
 
 import type { ParsedFlags, PluginRuntime, TableScope } from '../../plugins.js'
 import { debug } from '../../runtime/debug.js'
-import type { createJournalStore } from '../../runtime/journal-store.js'
+import type {
+  createJournalStore,
+  MigrationRowState,
+  OperationState,
+  OperationStatus,
+} from '../../runtime/journal-store.js'
 import { checksumSQL, type MigrationJournalEntry } from '../../runtime/migration-store.js'
 import {
   extractExecutableStatements,
   extractMigrationOperationSummaries,
 } from '../../runtime/safety-markers.js'
-import { applyAsyncStatement } from './async-apply.js'
+import {
+  applyAsyncStatement,
+  freshMigrationState,
+  isoWithoutZone,
+  upsertOperation,
+} from './async-apply.js'
 
 type JournalStore = ReturnType<typeof createJournalStore>
+
+function operationIsCompleted(state: MigrationRowState | null, index: number): boolean {
+  return (
+    state?.operations.some((op) => op.operationIndex === index && op.status === 'completed') ?? false
+  )
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function syncOperationState(
+  index: number,
+  operationType: string,
+  operationKey: string,
+  status: OperationStatus,
+  lastError = '',
+): OperationState {
+  const timestamp = isoWithoutZone(new Date())
+  return {
+    operationIndex: index,
+    operationKey,
+    operationType,
+    queryId: '',
+    status,
+    startedAt: timestamp,
+    finishedAt: status === 'started' ? null : timestamp,
+    lastError,
+  }
+}
 
 export async function applyMigration(input: {
   db: ClickHouseExecutor
@@ -46,6 +86,21 @@ export async function applyMigration(input: {
 
   const migrationChecksum = checksumSQL(sql)
 
+  // Resume support (#6): if a prior run left per-statement journal state for
+  // this migration, statements already marked completed are skipped instead of
+  // replayed — so a partial failure no longer bricks the migration on re-run
+  // with "column already exists". Guard against resuming across a file edit.
+  const initialState = await journalStore.readMigrationState(file)
+  if (
+    initialState !== null &&
+    !initialState.migrationCompleted &&
+    initialState.checksum !== migrationChecksum
+  ) {
+    throw new Error(
+      `Migration ${file} has in-progress journal state for checksum ${initialState.checksum}, but the current file checksum is ${migrationChecksum}. Restore the original migration file or clear the in-progress journal state before retrying.`,
+    )
+  }
+
   for (let i = 0; i < statements.length; i++) {
     const statement = statements[i] as string
     const operation = operationSummaries[i]
@@ -65,10 +120,39 @@ export async function applyMigration(input: {
       // Async ops are DML (loads, backfills) — no DDL propagation to wait on.
       continue
     }
-    await db.command(statement)
+    // Sync DDL path with per-statement journaling + resume. Re-read state each
+    // iteration so async ops written above (or in a prior run) are preserved.
+    const stateBefore = await journalStore.readMigrationState(file)
+    if (operationIsCompleted(stateBefore, i)) {
+      debug('migrate', `${file}#${i}: already completed in a prior run — skipping`)
+      continue
+    }
+    const opType = operation?.type ?? 'sql_statement'
+    const opKey = operation?.key ?? `statement:${i}`
+    const baseState = stateBefore ?? freshMigrationState(file, migrationChecksum)
+    await journalStore.writeMigrationState(
+      upsertOperation(baseState, syncOperationState(i, opType, opKey, 'started'), Date.now),
+    )
+    try {
+      await db.command(statement)
+    } catch (error) {
+      const stateOnError = (await journalStore.readMigrationState(file)) ?? baseState
+      await journalStore.writeMigrationState(
+        upsertOperation(
+          stateOnError,
+          syncOperationState(i, opType, opKey, 'failed', errorMessage(error)),
+          Date.now,
+        ),
+      )
+      throw error
+    }
     if (operation) {
       await waitForDDLPropagation(db, operation.type, operation.key)
     }
+    const stateAfter = (await journalStore.readMigrationState(file)) ?? baseState
+    await journalStore.writeMigrationState(
+      upsertOperation(stateAfter, syncOperationState(i, opType, opKey, 'completed'), Date.now),
+    )
   }
 
   const entry: MigrationJournalEntry = {

--- a/packages/cli/src/commands/migrate/apply.ts
+++ b/packages/cli/src/commands/migrate/apply.ts
@@ -146,13 +146,17 @@ export async function applyMigration(input: {
       )
       throw error
     }
-    if (operation) {
-      await waitForDDLPropagation(db, operation.type, operation.key)
-    }
+    // Mark completed as soon as the statement has executed — BEFORE waiting for
+    // DDL propagation. The statement already ran, so if the propagation wait
+    // later times out and throws, a re-run must skip this statement rather than
+    // replay it into an "already exists" error (the brick this fix prevents).
     const stateAfter = (await journalStore.readMigrationState(file)) ?? baseState
     await journalStore.writeMigrationState(
       upsertOperation(stateAfter, syncOperationState(i, opType, opKey, 'completed'), Date.now),
     )
+    if (operation) {
+      await waitForDDLPropagation(db, operation.type, operation.key)
+    }
   }
 
   const entry: MigrationJournalEntry = {

--- a/packages/cli/src/commands/migrate/async-apply.ts
+++ b/packages/cli/src/commands/migrate/async-apply.ts
@@ -298,7 +298,7 @@ async function pollUntilTerminal(input: PollUntilTerminalInput): Promise<AsyncAp
   }
 }
 
-function upsertOperation(
+export function upsertOperation(
   state: MigrationRowState,
   op: OperationState,
   now: () => number,
@@ -318,7 +318,7 @@ function upsertOperation(
   }
 }
 
-function freshMigrationState(
+export function freshMigrationState(
   migrationName: string,
   checksum: string,
 ): MigrationRowState {
@@ -373,7 +373,7 @@ function formatBytes(value: number | undefined): string {
   return `${value} B`
 }
 
-function isoWithoutZone(date: Date): string {
+export function isoWithoutZone(date: Date): string {
   return date.toISOString().replace('Z', '')
 }
 

--- a/packages/cli/src/test/commands/migrate/apply-resume.test.ts
+++ b/packages/cli/src/test/commands/migrate/apply-resume.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+
+import type { ClickHouseExecutor } from '@chkit/clickhouse'
+
+import { applyMigration } from '../../../commands/migrate/apply.js'
+import type { JournalStore, MigrationJournalEntry, MigrationRowState } from '../../../runtime/journal-store.js'
+import type { ParsedFlags, PluginRuntime, TableScope } from '../../../plugins.js'
+
+function createFakeStore() {
+  let current: MigrationRowState | null = null
+  const appended: MigrationJournalEntry[] = []
+  const store: JournalStore = {
+    databaseMissing: false,
+    async readJournal() {
+      return { version: 1, applied: [] }
+    },
+    async readMigrationState() {
+      return current
+    },
+    async writeMigrationState(state) {
+      current = state
+    },
+    async appendEntry(entry) {
+      appended.push(entry)
+      if (current) current = { ...current, migrationCompleted: true }
+    },
+  }
+  return { store, appended, state: () => current }
+}
+
+function fakePluginRuntime(): PluginRuntime {
+  return {
+    async runOnBeforeApply({ statements }: { statements: string[] }) {
+      return statements
+    },
+    async runOnAfterApply() {},
+  } as unknown as PluginRuntime
+}
+
+const CONFIG = {} as never
+const TABLE_SCOPE = { enabled: false } as unknown as TableScope
+const FLAGS = {} as ParsedFlags
+
+describe('applyMigration sync resume (#6)', () => {
+  test('skips a completed statement on re-run after a partial failure', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chkit-apply-resume-'))
+    writeFileSync(
+      join(dir, 'm.sql'),
+      'ALTER TABLE t ADD COLUMN a UInt64;\nALTER TABLE t ADD COLUMN b UInt64;\n',
+    )
+
+    const commandCalls: string[] = []
+    let failSecondStatement = true
+    const db = {
+      async command(sql: string) {
+        commandCalls.push(sql)
+        if (failSecondStatement && sql.includes('COLUMN b')) {
+          throw new Error('boom: statement b failed')
+        }
+      },
+    } as unknown as ClickHouseExecutor
+
+    const { store, appended, state } = createFakeStore()
+    const args = {
+      db,
+      journalStore: store,
+      pluginRuntime: fakePluginRuntime(),
+      config: CONFIG,
+      tableScope: TABLE_SCOPE,
+      flags: FLAGS,
+      migrationsDir: dir,
+      file: 'm.sql',
+    }
+
+    // Run 1: both statements attempted; statement b fails.
+    await expect(applyMigration(args)).rejects.toThrow('boom: statement b failed')
+    expect(commandCalls).toEqual([
+      'ALTER TABLE t ADD COLUMN a UInt64;',
+      'ALTER TABLE t ADD COLUMN b UInt64;',
+    ])
+    const after1 = state()
+    expect(after1?.operations.find((o) => o.operationIndex === 0)?.status).toBe('completed')
+    expect(after1?.operations.find((o) => o.operationIndex === 1)?.status).toBe('failed')
+    expect(appended).toHaveLength(0)
+
+    // Run 2: statement b now succeeds. Statement a must NOT be replayed.
+    failSecondStatement = false
+    commandCalls.length = 0
+    await applyMigration(args)
+    expect(commandCalls).toEqual(['ALTER TABLE t ADD COLUMN b UInt64;'])
+    expect(appended).toHaveLength(1)
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/cli/src/test/commands/migrate/apply-resume.test.ts
+++ b/packages/cli/src/test/commands/migrate/apply-resume.test.ts
@@ -96,4 +96,59 @@ describe('applyMigration sync resume (#6)', () => {
 
     rmSync(dir, { recursive: true, force: true })
   })
+
+  // A statement is marked completed BEFORE the DDL-propagation wait, so a
+  // propagation timeout can't cause the (already-executed) statement to be
+  // replayed into an "already exists" error on re-run.
+  test('marks a sync statement completed before waiting for DDL propagation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chkit-apply-order-'))
+    writeFileSync(
+      join(dir, 'm.sql'),
+      '-- operation: create_table key=table:default.t risk=safe\n' +
+        'CREATE TABLE default.t (id UInt64) ENGINE = MergeTree ORDER BY id;\n',
+    )
+
+    const events: string[] = []
+    const db = {
+      async command() {
+        events.push('command')
+      },
+      async query() {
+        // Used by waitForDDLPropagation → waitForTable; a non-empty row means
+        // the table is already visible, so the wait returns immediately.
+        events.push('propagation-query')
+        return [{ x: 1 }]
+      },
+    } as unknown as ClickHouseExecutor
+
+    let current: MigrationRowState | null = null
+    const store: JournalStore = {
+      databaseMissing: false,
+      async readJournal() {
+        return { version: 1, applied: [] }
+      },
+      async readMigrationState() {
+        return current
+      },
+      async writeMigrationState(state) {
+        current = state
+        if (state.operations.some((op) => op.status === 'completed')) events.push('completed-write')
+      },
+      async appendEntry() {},
+    }
+
+    await applyMigration({
+      db,
+      journalStore: store,
+      pluginRuntime: fakePluginRuntime(),
+      config: CONFIG,
+      tableScope: TABLE_SCOPE,
+      flags: FLAGS,
+      migrationsDir: dir,
+      file: 'm.sql',
+    })
+    rmSync(dir, { recursive: true, force: true })
+
+    expect(events).toEqual(['command', 'completed-write', 'propagation-query'])
+  })
 })

--- a/packages/cli/src/test/migration-scenario.test.ts
+++ b/packages/cli/src/test/migration-scenario.test.ts
@@ -104,11 +104,17 @@ describe('@chkit/cli migration scenario flows', () => {
       const plan = runCli(['generate', '--config', fixture.configPath, '--dryrun', '--json'])
       expect(plan.exitCode).toBe(0)
       const payload = JSON.parse(plan.stdout) as {
-        operations: Array<{ type: string }>
+        operations: Array<{ type: string; sql: string }>
         renameSuggestions: Array<{ from: string; to: string }>
       }
-      expect(payload.operations.some((operation) => operation.type === 'alter_table_rename_table')).toBe(true)
-      expect(payload.operations.some((operation) => operation.type === 'alter_table_rename_column')).toBe(true)
+      const renameTable = payload.operations.find((op) => op.type === 'alter_table_rename_table')
+      const renameColumn = payload.operations.find((op) => op.type === 'alter_table_rename_column')
+      expect(renameTable).toBeTruthy()
+      expect(renameColumn).toBeTruthy()
+      // Renames are idempotent (IF EXISTS) so a replay after a partial failure
+      // is a safe no-op rather than an "unknown identifier" brick.
+      expect(renameTable?.sql).toContain('RENAME TABLE IF EXISTS')
+      expect(renameColumn?.sql).toContain('RENAME COLUMN IF EXISTS')
       expect(payload.renameSuggestions.some((s) => s.from === 'source' && s.to === 'event_source')).toBe(true)
     } finally {
       await rm(fixture.dir, { recursive: true, force: true })

--- a/packages/cli/src/test/runtime/rename-idempotency.test.ts
+++ b/packages/cli/src/test/runtime/rename-idempotency.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { MigrationPlan } from '@chkit/core'
+
+import {
+  applyExplicitTableRenames,
+  buildExplicitColumnRenameSuggestions,
+} from '../../commands/generate/plan-pipeline.js'
+
+const EMPTY_RISK = { safe: 0, caution: 0, danger: 0 }
+
+// Renames are made idempotent (IF EXISTS) so that, after a partial migration
+// failure, a replay is a safe no-op instead of an "unknown identifier" brick.
+describe('rename SQL idempotency', () => {
+  test('explicit table rename emits RENAME TABLE IF EXISTS', () => {
+    const plan: MigrationPlan = { operations: [], riskSummary: EMPTY_RISK, renameSuggestions: [] }
+    const result = applyExplicitTableRenames(plan, [
+      { oldDatabase: 'app', oldName: 'users', newDatabase: 'app', newName: 'customers', source: 'cli' },
+    ])
+    const op = result.operations.find((o) => o.type === 'alter_table_rename_table')
+    expect(op?.sql).toBe('RENAME TABLE IF EXISTS app.users TO app.customers;')
+  })
+
+  test('explicit column rename suggestion emits RENAME COLUMN IF EXISTS', () => {
+    const plan: MigrationPlan = {
+      operations: [
+        { type: 'alter_table_drop_column', key: 'table:app.t:column:a', risk: 'danger', sql: '' },
+        { type: 'alter_table_add_column', key: 'table:app.t:column:b', risk: 'safe', sql: '' },
+      ],
+      riskSummary: EMPTY_RISK,
+      renameSuggestions: [],
+    }
+    const suggestions = buildExplicitColumnRenameSuggestions(plan, [
+      { database: 'app', table: 't', from: 'a', to: 'b', source: 'cli' },
+    ])
+    expect(suggestions[0]?.confirmationSQL).toBe('ALTER TABLE app.t RENAME COLUMN IF EXISTS `a` TO `b`;')
+  })
+})

--- a/packages/cli/src/test/sync-resume.e2e.test.ts
+++ b/packages/cli/src/test/sync-resume.e2e.test.ts
@@ -1,0 +1,99 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  createJournalTableName,
+  createLiveExecutor,
+  createPrefix,
+  getRequiredEnv,
+  quoteIdent,
+  runCli,
+  waitForColumn,
+  waitForTable,
+} from './e2e-testkit.js'
+
+describe('@chkit/cli sync migration resume e2e (#6)', () => {
+  test('a partial failure resumes on re-run instead of replaying statement 1', async () => {
+    const liveEnv = getRequiredEnv()
+    const executor = createLiveExecutor(liveEnv)
+    const database = liveEnv.clickhouseDatabase
+    const journalTable = createJournalTableName('resume')
+    const prefix = createPrefix('resume')
+    const tableA = `${prefix}a`
+    const tableB = `${prefix}b`
+    const dir = await mkdtemp(join(tmpdir(), 'chkit-resume-e2e-'))
+    const migrationsDir = join(dir, 'chkit/migrations')
+    const configPath = join(dir, 'clickhouse.config.ts')
+    const migrationName = '20990101000000_resume.sql'
+
+    try {
+      await mkdir(migrationsDir, { recursive: true })
+      await writeFile(
+        configPath,
+        `export default {\n` +
+          `  schema: '${join(dir, 'schema.ts')}',\n` +
+          `  outDir: '${join(dir, 'chkit')}',\n` +
+          `  migrationsDir: '${migrationsDir}',\n` +
+          `  metaDir: '${join(dir, 'chkit/meta')}',\n` +
+          `  clickhouse: {\n` +
+          `    url: '${liveEnv.clickhouseUrl}',\n` +
+          `    username: '${liveEnv.clickhouseUser}',\n` +
+          `    password: '${liveEnv.clickhousePassword}',\n` +
+          `    database: '${database}',\n` +
+          `  },\n}\n`,
+        'utf8',
+      )
+
+      await executor.command(
+        `CREATE TABLE ${quoteIdent(database)}.${quoteIdent(tableA)} (id UInt64) ENGINE = MergeTree ORDER BY id`,
+      )
+      await waitForTable(executor, database, tableA)
+
+      // Statement 1 succeeds (ADD COLUMN); statement 2 fails until table B exists.
+      await writeFile(
+        join(migrationsDir, migrationName),
+        `ALTER TABLE ${database}.${tableA} ADD COLUMN newcol UInt64;\n` +
+          `INSERT INTO ${database}.${tableB} SELECT 1;\n`,
+        'utf8',
+      )
+
+      const cliEnv = { CHKIT_JOURNAL_TABLE: journalTable, CI: '1' }
+      const migrate = () => runCli(dir, ['migrate', '--config', configPath, '--execute', '--json'], cliEnv)
+
+      // Run 1: stmt1 applies, stmt2 fails (table B missing).
+      const run1 = migrate()
+      expect(run1.exitCode).not.toBe(0)
+      await waitForColumn(executor, database, tableA, 'newcol')
+
+      // Run 2: same file, cause still present. Must fail on stmt2 again — NOT on
+      // "column already exists", which would mean statement 1 was replayed.
+      const run2 = migrate()
+      expect(run2.exitCode).not.toBe(0)
+      expect(`${run2.stdout}\n${run2.stderr}`.toLowerCase()).not.toContain('already exists')
+
+      // Resolve the transient cause, then resume.
+      await executor.command(
+        `CREATE TABLE ${quoteIdent(database)}.${quoteIdent(tableB)} (v UInt64) ENGINE = MergeTree ORDER BY v`,
+      )
+      await waitForTable(executor, database, tableB)
+
+      const run3 = migrate()
+      expect(run3.exitCode).toBe(0)
+
+      const completed = await executor.query<{ n: number }>(
+        `SELECT count() AS n FROM ${quoteIdent(database)}.${quoteIdent(journalTable)} FINAL ` +
+          `WHERE name = '${migrationName}' AND migration_completed = 1`,
+      )
+      expect(Number(completed[0]?.n ?? 0)).toBe(1)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+      await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(tableA)}`)
+      await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(tableB)}`)
+      await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+      await executor.close()
+    }
+  }, 180_000)
+})

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -364,7 +364,7 @@ describe('@chkit/core planner v1', () => {
           'Dropped and added columns have an identical non-name definition (type, nullability, default, comment).',
         dropOperationKey: 'table:app.events:column:source',
         addOperationKey: 'table:app.events:column:origin',
-        confirmationSQL: 'ALTER TABLE app.events RENAME COLUMN `source` TO `origin`;',
+        confirmationSQL: 'ALTER TABLE app.events RENAME COLUMN IF EXISTS `source` TO `origin`;',
       },
     ])
   })

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -156,7 +156,10 @@ function isCodecRemoval(oldCol: ColumnDefinition, newCol: ColumnDefinition): boo
 }
 
 function renderRenameColumnSuggestionSQL(table: TableDefinition, from: string, to: string): string {
-  return `ALTER TABLE ${table.database}.${table.name} RENAME COLUMN \`${from}\` TO \`${to}\`;`
+  // IF EXISTS makes the rename idempotent: once it has run (the `from` column is
+  // gone), a replay after a partial migration failure is a safe no-op rather
+  // than an "unknown identifier" brick. ClickHouse supports the clause.
+  return `ALTER TABLE ${table.database}.${table.name} RENAME COLUMN IF EXISTS \`${from}\` TO \`${to}\`;`
 }
 
 function inferColumnRenameSuggestions(


### PR DESCRIPTION
## Summary
`apply.ts` only appended the journal entry after **all** statements succeeded, so a partial failure (stmt1 OK, stmt2 fails) recorded nothing. Re-running replayed stmt1 and got **permanently stuck** on "column already exists" with the database already mutated. Fixes audit **#6**.

- Mirror the async path's per-operation journaling for **sync** statements: write `OperationState` `started` before `db.command`, `completed` after success, `failed` (with the error) on throw.
- On re-run, statements already `completed` are **skipped** — the migration resumes from the failed statement.
- Re-read journal state each iteration so async-written ops are preserved; a checksum guard refuses to resume across a migration-file edit.
- Exported `upsertOperation`/`freshMigrationState`/`isoWithoutZone` from `async-apply` for reuse — no behavior change to the async path.

## Test plan
- [x] `bun test` — unit test (mocked db + journal store): run 1 fails on stmt2, run 2 calls **only** stmt2 (stmt1 skipped) and appends the entry; 86 migrate/runtime tests pass (async path unchanged).
- [x] **Live** (built bin, real cluster), the audit's exact scenario: 2-statement migration where stmt1 `ADD COLUMN` succeeds and stmt2 fails transiently. Re-run with the cause still present fails on **stmt2's** error (not `newcol already exists`) → stmt1 skipped; after resolving the cause, re-run completes and is recorded. Before the fix this bricked permanently.
- [x] `typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)