### PR TITLE
fix: don't report unmanaged tables as drift by default

### DIFF
--- a/.changeset/drift-scope-managed-objects.md
+++ b/.changeset/drift-scope-managed-objects.md
@@ -1,0 +1,6 @@
+---
+"@chkit/core": patch
+"chkit": patch
+---
+
+Stop reporting unmanaged tables as drift by default. On a shared database, every object chkit doesn't manage was emitted as `extra_object` and set `drifted = true`, so `drift` always reported drift and `check` (which defaults to `failOnDrift: true`) failed the CI gate permanently for unrelated reasons. Objects that exist in ClickHouse but are not in your schema are now reported for visibility but no longer count as drift. A new `check.failOnExtraObjects` option (default `false`) opts back into treating them as drift, for when chkit owns the entire database.

--- a/apps/docs/src/content/docs/cli/check.md
+++ b/apps/docs/src/content/docs/cli/check.md
@@ -25,15 +25,16 @@ Global flags documented on [CLI Overview](/cli/overview/#global-flags).
 
 ### Built-in policies
 
-Three policies are evaluated, each defaulting to `true`:
+| Policy | Config key | Default | What it checks |
+|--------|-----------|---------|----------------|
+| Fail on pending | `check.failOnPending` | `true` | Pending migrations exist |
+| Fail on checksum mismatch | `check.failOnChecksumMismatch` | `true` | Applied migration files have been modified |
+| Fail on drift | `check.failOnDrift` | `true` | Live ClickHouse schema differs from snapshot |
+| Fail on extra objects | `check.failOnExtraObjects` | `false` | Objects exist in ClickHouse that are not in your schema |
 
-| Policy | Config key | What it checks |
-|--------|-----------|----------------|
-| Fail on pending | `check.failOnPending` | Pending migrations exist |
-| Fail on checksum mismatch | `check.failOnChecksumMismatch` | Applied migration files have been modified |
-| Fail on drift | `check.failOnDrift` | Live ClickHouse schema differs from snapshot |
+By default, objects that exist in ClickHouse but are not in your schema (`extra_object`) are **not** treated as drift — so chkit coexists with unmanaged tables on a shared database without breaking the CI gate. They are still reported by [`chkit drift`](/cli/drift/) for visibility. Set `check.failOnExtraObjects: true` only when chkit owns the entire database and any unmanaged object should fail the check.
 
-Policies can be disabled in config. The `--strict` flag forces all three on regardless of config values.
+Policies can be disabled in config. The `--strict` flag forces `failOnPending`, `failOnChecksumMismatch`, and `failOnDrift` on regardless of config values.
 
 ### Drift evaluation
 

--- a/apps/docs/src/content/docs/guides/ci-cd.md
+++ b/apps/docs/src/content/docs/guides/ci-cd.md
@@ -69,8 +69,9 @@ The `chkit check` command evaluates three policies:
 | `failOnPending` | `true` | Fail if unapplied migrations exist |
 | `failOnChecksumMismatch` | `true` | Fail if applied migration files were modified |
 | `failOnDrift` | `true` | Fail if live schema drifts from snapshot |
+| `failOnExtraObjects` | `false` | Fail if ClickHouse has objects not in your schema (off by default so chkit coexists with unmanaged tables on a shared database) |
 
-All three default to `true`, so checks are strict out of the box. Override them in `clickhouse.config.ts`:
+The first three default to `true`, so checks are strict out of the box. `failOnExtraObjects` defaults to `false` — enable it only when chkit owns the entire database. Override them in `clickhouse.config.ts`:
 
 ```ts
 export default defineConfig({

--- a/packages/cli/src/commands/drift/payload.ts
+++ b/packages/cli/src/commands/drift/payload.ts
@@ -27,6 +27,28 @@ export interface DriftPayload {
   tableDrift: TableDriftDetail[]
 }
 
+/**
+ * Decide whether a schema has drifted. Objects that exist in ClickHouse but are
+ * not in the schema (`extra_object` → `extraCount`) are NOT drift by default:
+ * on a shared database every unmanaged table would otherwise break the CI gate.
+ * Opt in with `check.failOnExtraObjects` to treat them as drift (e.g. when chkit
+ * owns the whole database).
+ */
+export function computeDrifted(input: {
+  missingCount: number
+  kindMismatchCount: number
+  tableDriftCount: number
+  extraCount: number
+  failOnExtraObjects: boolean
+}): boolean {
+  return (
+    input.missingCount > 0 ||
+    input.kindMismatchCount > 0 ||
+    input.tableDriftCount > 0 ||
+    (input.failOnExtraObjects && input.extraCount > 0)
+  )
+}
+
 export async function buildDriftPayload(
   config: ChxConfig,
   metaDir: string,
@@ -108,12 +130,13 @@ export async function buildDriftPayload(
 
   debug('drift', `comparison: missing=${missing.length}, extra=${extra.length}, kindMismatches=${kindMismatches.length}, objectDrift=${objectDrift.length}, tableDrift=${tableDrift.length}`)
 
-  const drifted =
-    missing.length > 0 ||
-    extra.length > 0 ||
-    kindMismatches.length > 0 ||
-    objectDrift.length > 0 ||
-    tableDrift.length > 0
+  const drifted = computeDrifted({
+    missingCount: missing.length,
+    kindMismatchCount: kindMismatches.length,
+    tableDriftCount: tableDrift.length,
+    extraCount: extra.length,
+    failOnExtraObjects: config.check?.failOnExtraObjects === true,
+  })
   return {
     scope,
     snapshotFile: join(metaDir, 'snapshot.json'),

--- a/packages/cli/src/test/commands/drift/compute-drifted.test.ts
+++ b/packages/cli/src/test/commands/drift/compute-drifted.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+
+import { computeDrifted } from '../../../commands/drift/payload.js'
+
+const NONE = {
+  missingCount: 0,
+  kindMismatchCount: 0,
+  tableDriftCount: 0,
+  extraCount: 0,
+  failOnExtraObjects: false,
+}
+
+describe('computeDrifted (#5)', () => {
+  test('unmanaged extra objects are NOT drift by default', () => {
+    expect(computeDrifted({ ...NONE, extraCount: 20 })).toBe(false)
+  })
+
+  test('extra objects ARE drift when failOnExtraObjects is opted in', () => {
+    expect(computeDrifted({ ...NONE, extraCount: 20, failOnExtraObjects: true })).toBe(true)
+  })
+
+  test('missing managed objects always drift', () => {
+    expect(computeDrifted({ ...NONE, missingCount: 1 })).toBe(true)
+  })
+
+  test('kind mismatches always drift', () => {
+    expect(computeDrifted({ ...NONE, kindMismatchCount: 1 })).toBe(true)
+  })
+
+  test('table-shape drift on managed tables always drifts', () => {
+    expect(computeDrifted({ ...NONE, tableDriftCount: 1 })).toBe(true)
+  })
+
+  test('a clean schema with no findings is not drifted', () => {
+    expect(computeDrifted(NONE)).toBe(false)
+  })
+})

--- a/packages/cli/src/test/drift-extra-objects.e2e.test.ts
+++ b/packages/cli/src/test/drift-extra-objects.e2e.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  CORE_ENTRY,
+  createJournalTableName,
+  createLiveExecutor,
+  createPrefix,
+  getRequiredEnv,
+  quoteIdent,
+  runCli,
+  runCliWithRetry,
+  waitForTable,
+} from './e2e-testkit.js'
+
+function renderConfig(dir: string, env: ReturnType<typeof getRequiredEnv>, database: string, extra: string): string {
+  return (
+    `export default {\n` +
+    `  schema: '${join(dir, 'schema.ts')}',\n` +
+    `  outDir: '${join(dir, 'chkit')}',\n` +
+    `  migrationsDir: '${join(dir, 'chkit/migrations')}',\n` +
+    `  metaDir: '${join(dir, 'chkit/meta')}',\n` +
+    `  check: {${extra}},\n` +
+    `  clickhouse: {\n` +
+    `    url: '${env.clickhouseUrl}',\n` +
+    `    username: '${env.clickhouseUser}',\n` +
+    `    password: '${env.clickhousePassword}',\n` +
+    `    database: '${database}',\n` +
+    `  },\n}\n`
+  )
+}
+
+describe('@chkit/cli drift extra-objects e2e (#5)', () => {
+  test('unmanaged tables are reported but do not fail drift/check by default; opt-in flips it', async () => {
+    const env = getRequiredEnv()
+    const executor = createLiveExecutor(env)
+    const database = env.clickhouseDatabase
+    const journalTable = createJournalTableName('drift_extra')
+    const prefix = createPrefix('drift_extra')
+    const managed = `${prefix}managed`
+    const unmanaged = `${prefix}unmanaged`
+    const dir = await mkdtemp(join(tmpdir(), 'chkit-drift-extra-e2e-'))
+    const defaultConfig = join(dir, 'clickhouse.config.ts')
+    const strictConfig = join(dir, 'clickhouse.strict.config.ts')
+    const cliEnv = { CHKIT_JOURNAL_TABLE: journalTable }
+
+    try {
+      await writeFile(
+        join(dir, 'schema.ts'),
+        `import { schema, table } from '${CORE_ENTRY}'\n\n` +
+          `const managed = table({\n` +
+          `  database: '${database}',\n  name: '${managed}',\n` +
+          `  columns: [{ name: 'id', type: 'UInt64' }],\n` +
+          `  engine: 'MergeTree()',\n  primaryKey: ['id'],\n  orderBy: ['id'],\n})\n\n` +
+          `export default schema(managed)\n`,
+        'utf8',
+      )
+      await writeFile(defaultConfig, renderConfig(dir, env, database, ''), 'utf8')
+      await writeFile(strictConfig, renderConfig(dir, env, database, ' failOnExtraObjects: true '), 'utf8')
+
+      // Create the managed table via chkit, then an UNMANAGED table directly.
+      expect(runCli(dir, ['generate', '--config', defaultConfig, '--json'], cliEnv).exitCode).toBe(0)
+      const migrated = await runCliWithRetry(dir, ['migrate', '--config', defaultConfig, '--execute', '--json'], {
+        extraEnv: cliEnv,
+      })
+      expect(migrated.exitCode).toBe(0)
+      await waitForTable(executor, database, managed)
+      await executor.command(
+        `CREATE TABLE ${quoteIdent(database)}.${quoteIdent(unmanaged)} (x UInt64) ENGINE = MergeTree ORDER BY x`,
+      )
+      await waitForTable(executor, database, unmanaged)
+
+      // Default: the unmanaged table is reported as extra_object but does NOT drift.
+      const drift = runCli(dir, ['drift', '--config', defaultConfig, '--json'], cliEnv)
+      expect(drift.exitCode).toBe(0)
+      const driftPayload = JSON.parse(drift.stdout) as {
+        drifted: boolean
+        missing: string[]
+        objectDrift: Array<{ code: string; object: string }>
+      }
+      expect(driftPayload.missing).toEqual([])
+      expect(driftPayload.drifted).toBe(false)
+      expect(
+        driftPayload.objectDrift.some((d) => d.code === 'extra_object' && d.object.includes(unmanaged)),
+      ).toBe(true)
+
+      // check passes (the CI gate is not broken by unmanaged tables).
+      const check = runCli(dir, ['check', '--config', defaultConfig, '--json'], cliEnv)
+      expect(check.exitCode).toBe(0)
+      const checkPayload = JSON.parse(check.stdout) as { ok: boolean; failedChecks: string[] }
+      expect(checkPayload.ok).toBe(true)
+      expect(checkPayload.failedChecks).not.toContain('schema_drift')
+
+      // Opt-in: failOnExtraObjects makes the same state drift.
+      const strictDrift = runCli(dir, ['drift', '--config', strictConfig, '--json'], cliEnv)
+      const strictPayload = JSON.parse(strictDrift.stdout) as { drifted: boolean }
+      expect(strictPayload.drifted).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+      await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(managed)}`)
+      await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(unmanaged)}`)
+      await executor.command(`DROP TABLE IF EXISTS ${quoteIdent(database)}.${quoteIdent(journalTable)}`)
+      await executor.close()
+    }
+  }, 180_000)
+})

--- a/packages/core/src/model-types.ts
+++ b/packages/core/src/model-types.ts
@@ -162,6 +162,13 @@ export interface ChxCheckConfig {
   failOnPending?: boolean
   failOnChecksumMismatch?: boolean
   failOnDrift?: boolean
+  /**
+   * Treat objects that exist in ClickHouse but are not in your schema
+   * (`extra_object`) as drift. Defaults to `false` so chkit coexists with
+   * unmanaged tables on a shared database — only opt in when chkit is expected
+   * to own the entire database.
+   */
+  failOnExtraObjects?: boolean
 }
 
 export interface ChxSafetyConfig {

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -47,6 +47,7 @@ export function resolveConfig(config: ChxUserConfig): ChxResolvedConfig {
       failOnPending: config.check?.failOnPending ?? true,
       failOnChecksumMismatch: config.check?.failOnChecksumMismatch ?? true,
       failOnDrift: config.check?.failOnDrift ?? true,
+      failOnExtraObjects: config.check?.failOnExtraObjects ?? false,
     },
     safety: {
       allowDestructive: config.safety?.allowDestructive ?? false,


### PR DESCRIPTION
## Summary
On a shared database, every object chkit doesn't manage was emitted as `extra_object` and set `drifted = true`, so `drift` always reported drift and `check` (which defaults to `failOnDrift: true`) **failed the CI gate permanently** for unrelated reasons. Fixes audit **#5**.

- `extra_object` no longer contributes to `drifted` by default; unmanaged objects are still **reported** (for visibility via `drift`) but don't fail the gate.
- New `check.failOnExtraObjects` (default `false`) opts back into treating them as drift, for when chkit owns the whole database.
- Extracted the decision into a pure `computeDrifted()` and unit-tested it.
- Documented in `cli/check.md` and `guides/ci-cd.md`.

## Test plan
- [x] `bun test` — `computeDrifted` unit tests (extra alone ≠ drift; opt-in flips it; missing/kind/table drift always drift); drift unit + **drift e2e against real CH** still pass (managed-drift detection unbroken).
- [x] **Live** on the shared `default` database (26 tables, 24 unmanaged): `drift --json` → `drifted: false` with the 24 still listed under `extra`; `check --json` → `ok: true`. With `check.failOnExtraObjects: true` → `drifted: true`.
- [x] `typecheck` + `lint` clean; `apps/docs` build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)