### PR TITLE
fix: ship @chkit/clickhouse/e2e-testkit from dist, not unshipped src

### DIFF
--- a/.changeset/fix-published-exports.md
+++ b/.changeset/fix-published-exports.md
@@ -1,0 +1,5 @@
+---
+"@chkit/clickhouse": patch
+---
+
+Fix the `@chkit/clickhouse/e2e-testkit` subpath export. Both conditions pointed at `./src/e2e-testkit.ts`, which `files: ["dist"]` excludes from the published tarball, so importing the subpath from the published package hit a hard module-not-found. Build it to `dist` and point the export there (keeping a `source` condition for in-repo type resolution).

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -28,8 +28,9 @@
       "default": "./dist/index.js"
     },
     "./e2e-testkit": {
-      "bun": "./src/e2e-testkit.ts",
-      "default": "./src/e2e-testkit.ts"
+      "source": "./src/e2e-testkit.ts",
+      "types": "./dist/e2e-testkit.d.ts",
+      "default": "./dist/e2e-testkit.js"
     }
   },
   "files": [

--- a/packages/clickhouse/tsconfig.json
+++ b/packages/clickhouse/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts", "src/e2e-testkit.ts"]
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
Fixes the broken `@chkit/clickhouse/e2e-testkit` published export (#28). Scoped down from the original three-finding PR after CI surfaced that one of them was load-bearing.

- **#28** — `@chkit/clickhouse/e2e-testkit` exported `./src/e2e-testkit.ts` under both conditions, but `src` is excluded from the published tarball (`files: ["dist"]`) — a hard module-not-found from the published package. Built it to `dist` (dropped the tsconfig exclude) and pointed the export at `dist`, keeping a `source` condition for in-repo type resolution.
- **#27** — already resolved upstream; `@chkit/codegen` now declares `@chkit/core: workspace:*`. No change.
- **#42** (drop the `source` export condition) — **investigated and deferred.** The repo relies on `source` so `tsc` can type-check sibling packages from source without a build (`typecheck` depends on `^typecheck`, not `^build`), and a plugin-backfill test asserts its presence. Removing it broke CI. Doing #42 correctly requires stripping `source` at publish time — a separate change.

## Test plan
- [x] `bun run typecheck` with **all `dist/` wiped** (CI's exact condition) — passes via `source` resolution.
- [x] `turbo run build lint test` green; plugin-backfill exports test passes.
- [x] `@chkit/clickhouse/e2e-testkit` resolves to `dist/e2e-testkit.js` under Node (`require.resolve`) and Bun.
- [x] `patch` changeset for `@chkit/clickhouse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)