### PR TITLE
chkit versioning & release: policy docs, lockstep versions, Zod 4, source guard

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,19 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "chkit",
+      "create-chkit",
+      "@chkit/core",
+      "@chkit/clickhouse",
+      "@chkit/codegen",
+      "@chkit/plugin-codegen",
+      "@chkit/plugin-pull",
+      "@chkit/plugin-backfill",
+      "@chkit/plugin-obsessiondb"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/versioning-policy-lockstep.md
+++ b/.changeset/versioning-policy-lockstep.md
@@ -1,0 +1,5 @@
+---
+"chkit": patch
+---
+
+Document the pre-1.0 versioning, channel, and support policy in the chkit README, and lock-step all publishable packages into a single changesets fixed group so versions never skew across packages.

--- a/.changeset/zod-major-consolidation.md
+++ b/.changeset/zod-major-consolidation.md
@@ -1,0 +1,6 @@
+---
+"@chkit/plugin-obsessiondb": patch
+"@chkit/plugin-codegen": patch
+---
+
+Consolidate all publishable packages on Zod 4. `@chkit/plugin-obsessiondb` was pinned to `zod@3.25.76` while the rest of the toolkit used Zod 4, pulling two major versions into the dependency tree; it now uses `zod@^4.3.6`. Its oRPC contracts are unaffected — `@orpc/contract` validates through the Standard Schema interface, which both Zod majors implement. `@chkit/plugin-codegen` now declares `zod` as a peer dependency (`^4.0.0`) instead of a direct dependency, so generated Zod schemas resolve against the consumer's own `zod` install rather than a bundled copy.

--- a/apps/docs/src/content/docs/plugins/codegen.md
+++ b/apps/docs/src/content/docs/plugins/codegen.md
@@ -31,6 +31,14 @@ The plugin is designed so your existing chkit workflow can stay the same.
 
 In `clickhouse.config.ts`, register `codegen(...)` from `@chkit/plugin-codegen`.
 
+:::note
+`zod` is a peer dependency (`^4.0.0`). Install it alongside the plugin — generated Zod schemas (`emitZod: true`) import `zod` from your project, so they resolve against your own copy rather than a bundled one.
+
+```sh
+bun add -d @chkit/plugin-codegen zod
+```
+:::
+
 Recommended typed setup:
 
 ```ts

--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,12 @@
       "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/core": "workspace:*",
+      },
+      "devDependencies": {
         "zod": "^4.3.6",
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0",
       },
     },
     "packages/plugin-obsessiondb": {
@@ -130,7 +135,7 @@
         "@chkit/core": "workspace:*",
         "@orpc/client": "1.13.4",
         "@orpc/contract": "1.13.4",
-        "zod": "3.25.76",
+        "zod": "^4.3.6",
       },
     },
     "packages/plugin-pull": {
@@ -1467,6 +1472,8 @@
     "@chkit/plugin-backfill/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@chkit/plugin-codegen/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@chkit/plugin-obsessiondb/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@chkit/plugin-pull/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,6 +74,27 @@ npx skills add obsessiondb/chkit
 
 See the [chkit documentation](https://chkit.obsessiondb.com).
 
+## Versioning & releases
+
+chkit is **pre-1.0**. While the version is `0.x`, the public API is still
+stabilizing and **any release may contain breaking changes** — this is the
+standard [SemVer](https://semver.org/#spec-item-4) `0.x` contract. Pin an exact
+version (or a tight range) if you need reproducible installs.
+
+- **`latest` tracks the current beta line.** Until 1.0 ships, installing
+  `chkit` with no tag (`bun add -d chkit`) gives you the latest `0.1.0-beta.x`
+  build. This is intentional for the pre-1.0 period.
+- **All publishable packages release in lockstep.** `chkit`, `create-chkit`,
+  and every `@chkit/*` package share a single version, so a given chkit version
+  always lines up with matching plugin and core versions — there is no
+  cross-package version skew.
+- **Public vs. internal surface.** The supported public API is the `chkit` CLI,
+  `@chkit/core`, and the `@chkit/plugin-*` packages. `@chkit/clickhouse` and
+  `@chkit/codegen` are internal and not meant to be installed directly.
+- **At 1.0** chkit will commit to real SemVer (breaking changes only in major
+  bumps) and a deprecation policy. Until then, treat minor/patch bumps as
+  potentially breaking.
+
 ## License
 
 [MIT](../../LICENSE)

--- a/packages/plugin-codegen/README.md
+++ b/packages/plugin-codegen/README.md
@@ -7,8 +7,12 @@ Part of the [chkit](https://github.com/obsessiondb/chkit) monorepo. This plugin 
 ## Install
 
 ```bash
-bun add -d @chkit/plugin-codegen
+bun add -d @chkit/plugin-codegen zod
 ```
+
+`zod` is a peer dependency (`^4.0.0`): the plugin uses it at runtime, and any
+generated Zod schemas (`emitZod: true`) import `zod` from your project. Install
+the same `zod` your project already uses to avoid duplicate copies.
 
 ## Usage
 

--- a/packages/plugin-codegen/package.json
+++ b/packages/plugin-codegen/package.json
@@ -42,8 +42,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@chkit/core": "workspace:*",
-    "zod": "^4.3.6"
+    "@chkit/core": "workspace:*"
   },
-  "devDependencies": {}
+  "peerDependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "zod": "^4.3.6"
+  }
 }

--- a/packages/plugin-obsessiondb/package.json
+++ b/packages/plugin-obsessiondb/package.json
@@ -45,6 +45,6 @@
     "@chkit/core": "workspace:*",
     "@orpc/client": "1.13.4",
     "@orpc/contract": "1.13.4",
-    "zod": "3.25.76"
+    "zod": "^4.3.6"
   }
 }

--- a/scripts/check-packed-deps.ts
+++ b/scripts/check-packed-deps.ts
@@ -13,6 +13,13 @@
  * (check-workspace-deps) proves the inputs are right; this proves the packed
  * OUTPUT is right, exercising the real pack path.
  *
+ * It also asserts that no `source` export condition (`./src/*.ts`, load-bearing
+ * for in-repo typecheck against unbuilt siblings) is actually shipped in the
+ * tarball. The `source` condition stays in the published package.json — Node,
+ * Bun, and tsc all ignore it and fall through to `types`/`default` (dist) — but
+ * the file it points at must never ship, or a bundler that honors `source`
+ * would load untranspiled TypeScript. This is the guard for that invariant.
+ *
  * Run after `build`, before publish.
  *
  * Follow-up (out of scope here, needs a live service + credentials): an
@@ -27,6 +34,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
 	buildWorkspaceVersions,
+	type ExportsField,
 	isWorkspaceSpecifier,
 	type PackageJson,
 	readWorkspacePackages,
@@ -46,13 +54,17 @@ function main(): void {
 		if (wsPkg.pkg.private) continue
 		checked++
 
-		const manifest = packAndReadManifest(wsPkg, workspaceVersions)
+		const { manifest, entries } = packAndReadManifest(wsPkg, workspaceVersions)
 
 		for (const issue of findStaleInternalDeps(
 			manifest,
 			internalNames,
 			workspaceVersions,
 		)) {
+			failures.push(`${wsPkg.pkg.name}: ${issue}`)
+		}
+
+		for (const issue of findShippedSourceExports(manifest, entries)) {
 			failures.push(`${wsPkg.pkg.name}: ${issue}`)
 		}
 	}
@@ -79,9 +91,16 @@ function main(): void {
 	)
 }
 
+/** A packed tarball: its published package.json plus the files it ships. */
+interface PackedTarball {
+	manifest: PackageJson
+	/** Paths relative to the package root, e.g. `dist/index.js`, `package.json`. */
+	entries: string[]
+}
+
 /**
  * Packs a package exactly as the release script publishes it and returns the
- * package.json inside the tarball.
+ * package.json inside the tarball along with the list of shipped files.
  *
  * Mirrors scripts/manual-release.ts: resolve every `workspace:` specifier to
  * the current workspace version on disk, pack, then restore the original
@@ -93,7 +112,7 @@ function main(): void {
 function packAndReadManifest(
 	wsPkg: WorkspacePackage,
 	workspaceVersions: Map<string, string>,
-): PackageJson {
+): PackedTarball {
 	const originalContent = readFileSync(wsPkg.pkgJsonPath, 'utf8')
 	const resolved = resolveWorkspaceDeps(wsPkg.pkg, workspaceVersions)
 
@@ -112,8 +131,8 @@ function packAndReadManifest(
 	}
 }
 
-/** Packs the package as-is on disk and returns the tarball's package.json. */
-function packAndExtract(wsPkg: WorkspacePackage): PackageJson {
+/** Packs the package as-is on disk and returns its manifest and file list. */
+function packAndExtract(wsPkg: WorkspacePackage): PackedTarball {
 	const outDir = mkdtempSync(join(tmpdir(), 'chkit-pack-'))
 
 	const packed = spawnSync(
@@ -132,6 +151,15 @@ function packAndExtract(wsPkg: WorkspacePackage): PackageJson {
 		throw new Error(`No tarball produced for ${wsPkg.pkg.name} in ${outDir}`)
 	}
 
+	const listed = spawnSync('tar', ['-tzf', join(outDir, tarball)], {
+		encoding: 'utf8',
+	})
+	if (listed.status !== 0) {
+		throw new Error(
+			`Failed to list ${tarball} for ${wsPkg.pkg.name}:\n${listed.stderr}`,
+		)
+	}
+
 	const extracted = spawnSync(
 		'tar',
 		['-xzf', join(outDir, tarball), '-C', outDir],
@@ -146,9 +174,18 @@ function packAndExtract(wsPkg: WorkspacePackage): PackageJson {
 	}
 
 	// npm tarballs always nest sources under a top-level `package/` directory.
-	return JSON.parse(
+	const entries = listed.stdout
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.map((line) => line.replace(/^package\//, ''))
+		.filter((line) => line.length > 0 && !line.endsWith('/'))
+
+	const manifest = JSON.parse(
 		readFileSync(join(outDir, 'package', 'package.json'), 'utf8'),
 	) as PackageJson
+
+	return { manifest, entries }
 }
 
 function findStaleInternalDeps(
@@ -182,6 +219,47 @@ function findStaleInternalDeps(
 					`${field}["${name}"] = "${specifier}" but current workspace version is "${expected}"`,
 				)
 			}
+		}
+	}
+
+	return issues
+}
+
+/** Collects every `source` condition target declared anywhere in `exports`. */
+function collectSourceTargets(node: ExportsField | undefined): string[] {
+	if (!node || typeof node === 'string') return []
+
+	const targets: string[] = []
+	for (const [key, value] of Object.entries(node)) {
+		if (key === 'source' && typeof value === 'string') {
+			targets.push(value)
+		} else {
+			targets.push(...collectSourceTargets(value))
+		}
+	}
+	return targets
+}
+
+/**
+ * Asserts no `source` export target (`./src/*.ts`) is actually shipped in the
+ * tarball. The condition itself stays in package.json — consumers ignore it —
+ * but the file it points at must not ship, or a bundler honoring `source` would
+ * load untranspiled TypeScript instead of the built `dist` output.
+ */
+function findShippedSourceExports(
+	manifest: PackageJson,
+	entries: string[],
+): string[] {
+	const shipped = new Set(entries)
+	const issues: string[] = []
+
+	for (const target of collectSourceTargets(manifest.exports)) {
+		const normalized = target.replace(/^\.\//, '')
+		if (shipped.has(normalized)) {
+			issues.push(
+				`exports "source" target "${target}" is shipped in the tarball; ` +
+					'it must be excluded so consumers never resolve untranspiled source',
+			)
 		}
 	}
 

--- a/scripts/workspace-deps.ts
+++ b/scripts/workspace-deps.ts
@@ -29,6 +29,9 @@ export const DEPENDENCY_FIELDS = [
 	'peerDependencies',
 ] as const
 
+/** A package.json `exports` subtree: a target string or nested conditions. */
+export type ExportsField = string | { [key: string]: ExportsField }
+
 export type PackageJson = {
 	name?: string
 	version?: string
@@ -37,6 +40,7 @@ export type PackageJson = {
 	devDependencies?: Record<string, string>
 	optionalDependencies?: Record<string, string>
 	peerDependencies?: Record<string, string>
+	exports?: ExportsField
 }
 
 export type WorkspacePackage = {


### PR DESCRIPTION
## Summary

Versioning & release hardening for a credible 1.0 (NUM-7316). Covers the decided/unblocked findings; #43 (tag-triggered CI release with provenance) and #44b (scaffold pinning) are intentionally deferred.

- **#8 / #13 / #29 — versioning policy** (`packages/cli/README.md`): documents the pre-1.0 `0.x` contract, beta-as-`latest` channel policy, public vs internal package surface, and the 1.0 SemVer commitment — readable by people and agents on npm.
- **#44a — lockstep versions** (`.changeset/config.json`): all 9 publishable packages are now a changesets `fixed` group, so versions can never skew (the private `@chkit/docs` app is excluded).
- **#26 — Zod 4 consolidation**: `@chkit/plugin-obsessiondb` was pinned to `zod@3.25.76` while the rest of the toolkit used Zod 4, pulling two majors into the tree; bumped to `^4.3.6`. `@chkit/plugin-codegen` now declares `zod` as a peer dependency (`^4.0.0`) so generated schemas resolve against the consumer's own copy. oRPC is unaffected (it validates via the schema-agnostic Standard Schema interface). Docs + README updated. Root stays on `zod 3.25.76` — load-bearing for the private Astro docs build, not published.
- **#42 — `source` export guard** (`scripts/check-packed-deps.ts`): verified empirically that the `source` condition is harmless to consumers (Node, Bun, tsc all ignore it and resolve `dist`), then extended the packed-deps release guard to assert no `source` target ever ships in a tarball — catching a future `files` change that would leak untranspiled TypeScript.

## Test plan

- [x] `bun verify` — typecheck, lint, build all pass; 234 unit tests pass. The 5 live-ClickHouse e2e tests timed out on a transient service slowdown during the run and **pass on isolated re-run** (5/5, 115s).
- [x] zod 4 runtime smoke: `.datetime()`, two-arg `z.record`, and the `~standard` interface all verified on `zod@4.3.6`; obsessiondb 74/74 + codegen 27/27 unit tests pass.
- [x] `#42` guard negative-tested: leaking `src/` into a package's `files` makes the guard fail and name the shipped `source` targets.
- [x] Docs site builds (`apps/docs`); changesets config validates via `changeset status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)