### PR TITLE
docs: sync CLI reference with ClickHouse-journaled migration state

### DIFF
--- a/apps/docs/src/content/docs/cli/check.md
+++ b/apps/docs/src/content/docs/cli/check.md
@@ -37,7 +37,9 @@ Policies can be disabled in config. The `--strict` flag forces all three on rega
 
 ### Drift evaluation
 
-Drift is only evaluated when both a `snapshot.json` and a `clickhouse` config block are present. If either is missing, drift is skipped (not treated as a failure).
+`clickhouse` config is required for `chkit check` because migration journal state is stored in ClickHouse. If it is missing, the command fails.
+
+Drift itself is evaluated only when `snapshot.json` exists. If snapshot is missing, drift is skipped (`driftEvaluated: false`) but pending/checksum/plugin checks still run.
 
 ### Plugin check integration
 

--- a/apps/docs/src/content/docs/cli/drift.md
+++ b/apps/docs/src/content/docs/cli/drift.md
@@ -84,7 +84,8 @@ chkit drift --json
 
 | Code | Meaning |
 |------|---------|
-| 0 | Always succeeds (drift is reported, not enforced) |
+| 0 | Command completed successfully (drift may be true or false) |
+| 1 | Command failed (for example snapshot missing or missing/invalid `clickhouse` config) |
 
 Use [`chkit check`](/cli/check/) with `failOnDrift` to enforce drift-free state in CI.
 

--- a/apps/docs/src/content/docs/cli/migrate.md
+++ b/apps/docs/src/content/docs/cli/migrate.md
@@ -63,13 +63,14 @@ Before applying, the CLI verifies SHA-256 checksums of all previously-applied mi
 
 ### Journal
 
-Each applied migration is recorded in `journal.json` (in `metaDir`) with:
+Each applied migration is recorded in the ClickHouse `_chkit_migrations` table with:
 
 - `name` — the migration filename
-- `appliedAt` — ISO 8601 timestamp
+- `applied_at` — timestamp stored in UTC (`DateTime64(3, 'UTC')`)
 - `checksum` — SHA-256 hash of the file content
+- `chkit_version` — CLI version that applied the migration
 
-The journal is written after each migration, not batched.
+Rows are inserted after each migration, not batched.
 
 ### Table scoping
 
@@ -136,9 +137,8 @@ chkit migrate --apply --table analytics.events
   "mode": "execute",
   "scope": { "enabled": false },
   "applied": [
-    { "name": "0004_add_column.sql", "appliedAt": "2025-06-15T10:30:00.000Z", "checksum": "a1b2c3..." }
-  ],
-  "journalFile": "./chkit/meta/journal.json"
+    { "name": "0004_add_column.sql", "appliedAt": "2025-06-15T10:30:00.000", "checksum": "a1b2c3..." }
+  ]
 }
 ```
 

--- a/apps/docs/src/content/docs/cli/overview.md
+++ b/apps/docs/src/content/docs/cli/overview.md
@@ -39,5 +39,7 @@ These flags are available on every command that loads a config file:
 |------|------|---------|-------------|
 | `--config <path>` | string | `clickhouse.config.ts` | Path to the chkit config file |
 | `--json` | boolean | `false` | Emit machine-readable JSON output |
+| `--table <selector>` | string | — | Limit command scope to matching tables (`db.table`, `db.prefix*`, or `table`) |
 | `--help` | boolean | — | Show help text |
-| `--version` | boolean | — | Print CLI version |
+
+`--version` is available as a top-level CLI flag (`chkit --version`).

--- a/apps/docs/src/content/docs/cli/status.md
+++ b/apps/docs/src/content/docs/cli/status.md
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-Reports the current migration state by comparing migration files on disk against the journal. Does not connect to ClickHouse.
+Reports the current migration state by comparing migration files on disk against the applied migration journal stored in ClickHouse.
 
 ## Synopsis
 
@@ -19,14 +19,14 @@ No command-specific flags. See [global flags](/cli/overview/#global-flags).
 
 ## Behavior
 
-`chkit status` reads the migrations directory and `journal.json` to compute:
+`chkit status` reads the migrations directory and the `_chkit_migrations` table in ClickHouse to compute:
 
 - **Total** migration files (`.sql` files in `migrationsDir`, sorted alphabetically)
-- **Applied** migrations (entries recorded in the journal)
+- **Applied** migrations (entries recorded in `_chkit_migrations`)
 - **Pending** migrations (on disk but not yet applied)
 - **Checksum mismatches** (applied migrations whose SHA-256 checksum no longer matches the file on disk)
 
-This command is read-only and does not require a ClickHouse connection.
+This command is read-only, but it requires a `clickhouse` config block because the migration journal is stored in ClickHouse.
 
 ## Examples
 
@@ -35,8 +35,10 @@ chkit status
 ```
 
 ```
-Migrations: 5 total, 3 applied, 2 pending
-Checksum mismatches: 0
+Migrations directory: /absolute/path/to/chkit/migrations
+Total migrations:     5
+Applied:              3
+Pending:              2
 ```
 
 ```sh
@@ -47,7 +49,8 @@ chkit status --json
 
 | Code | Meaning |
 |------|---------|
-| 0 | Always succeeds |
+| 0 | Success |
+| 1 | Command failed (for example missing `clickhouse` config or connection error) |
 
 ## JSON output
 

--- a/apps/docs/src/content/docs/cli/status.md
+++ b/apps/docs/src/content/docs/cli/status.md
@@ -26,7 +26,7 @@ No command-specific flags. See [global flags](/cli/overview/#global-flags).
 - **Pending** migrations (on disk but not yet applied)
 - **Checksum mismatches** (applied migrations whose SHA-256 checksum no longer matches the file on disk)
 
-This command is read-only, but it requires a `clickhouse` config block because the migration journal is stored in ClickHouse.
+`chkit status` requires a `clickhouse` config block because the migration journal is stored in ClickHouse. It does not modify your schema, but it is not strictly read-only: on the first run, if the `_chkit_migrations` journal table does not yet exist, it is created automatically. That first invocation therefore needs write privileges (or run [`chkit migrate`](/cli/migrate/) first, which creates the table). Once the table exists, `chkit status` only reads from it.
 
 ## Examples
 

--- a/apps/docs/src/content/docs/configuration/overview.md
+++ b/apps/docs/src/content/docs/configuration/overview.md
@@ -10,11 +10,13 @@ description: "clickhouse.config.ts structure and defaults."
 - `schema`: glob path to [schema files](/schema/dsl-reference/)
 - `outDir`: root folder for generated artifacts
 - `migrationsDir`: SQL migration file folder
-- `metaDir`: state folder (`snapshot.json`, `journal.json`)
+- `metaDir`: state folder for local artifacts (for example `snapshot.json`)
 - `plugins`: plugin registrations
 - `clickhouse`: live connection options
 - `check`: CI gate behavior
 - `safety`: destructive migration safety behavior
+
+Migration apply status is journaled in ClickHouse (`_chkit_migrations`), not in `metaDir`.
 
 ## Example
 

--- a/apps/docs/src/content/docs/getting-started.md
+++ b/apps/docs/src/content/docs/getting-started.md
@@ -11,20 +11,19 @@ description: Install chkit and run the first migration flow.
 ## Install
 
 ```bash
-bun install
-bun run build
-bun run chkit --help
+bun add -d chkit @chkit/core
+bunx chkit --help
 ```
 
 ## Quick Start
 
 ```bash
-bun run chkit init
-bun run chkit generate --name init
-bun run chkit migrate
-bun run chkit migrate --apply
-bun run chkit status
-bun run chkit check
+bunx chkit init
+bunx chkit generate --name init
+bunx chkit migrate
+bunx chkit migrate --apply
+bunx chkit status
+bunx chkit check
 ```
 
 ## AI Agent Skill

--- a/apps/docs/src/content/docs/guides/ci-cd.md
+++ b/apps/docs/src/content/docs/guides/ci-cd.md
@@ -47,7 +47,7 @@ When non-interactive, `chkit migrate` without `--apply` prints the migration pla
 Your `clickhouse.config.ts` can export a function that receives a `ChxConfigEnv` object with `command` and `mode` fields. Use this to vary config per environment:
 
 ```ts
-import { defineConfig } from 'chkit'
+import { defineConfig } from '@chkit/core'
 
 export default defineConfig((env) => ({
   schema: './schema/**/*.ts',


### PR DESCRIPTION
## Summary
Brings the docs in line with the current CLI, which journals applied migrations in the ClickHouse `_chkit_migrations` table instead of a local `journal.json`.

- `status`, `check`, and `drift` now require a `clickhouse` config block and can exit `1` — docs previously claimed they were offline / always-succeed.
- Document the `_chkit_migrations` schema (`applied_at DateTime64(3,'UTC')`, `checksum`, `chkit_version`) and the new multi-line `status` output.
- Update `metaDir` description (no longer holds `journal.json`), add the global `--table` flag, and fix `--version` placement.
- `getting-started` now uses `bunx chkit` / `bun add -d chkit`, and `defineConfig` is imported from `@chkit/core`.

Verified against source: `journal-store.ts` (table schema), `status.ts` (required-config error), and `global-flags.ts` (`--table` is global). No stale `journal.json`/`journalFile` references remain in the docs.

## Test plan
- [ ] Docs site builds and renders the updated CLI/config/getting-started pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)