### PR TITLE
docs: fix status read-only claim, chkit_version column, --table flag, defineConfig import

### DIFF
--- a/apps/docs/src/content/docs/cli/migrate.md
+++ b/apps/docs/src/content/docs/cli/migrate.md
@@ -69,6 +69,7 @@ Each applied migration is recorded in the `_chkit_migrations` journal table in C
 - `name` — the migration filename
 - `appliedAt` — ISO 8601 timestamp
 - `checksum` — SHA-256 hash of the file content
+- `chkit_version` — the CLI version that applied the migration
 
 The journal is written after each migration, not batched. The table is created in the database configured in `clickhouse.database` (it is not qualified with a database name, so on a shared/default-database setup it lives in `default._chkit_migrations`). The table name can be overridden with the `CHKIT_JOURNAL_TABLE` environment variable.
 

--- a/apps/docs/src/content/docs/cli/overview.md
+++ b/apps/docs/src/content/docs/cli/overview.md
@@ -40,6 +40,8 @@ These flags are available on every command that loads a config file:
 |------|------|---------|-------------|
 | `--config <path>` | string | `clickhouse.config.ts` | Path to the chkit config file |
 | `--json` | boolean | `false` | Emit machine-readable JSON output |
-| `--table <selector>` | string | — | Limit command scope to matching tables (exact name or trailing wildcard prefix, e.g. `events_*`) |
+| `--table <selector>` | string | — | Limit command scope to matching tables (exact name or trailing wildcard prefix, e.g. `events_*`). Honored only by `generate`, `migrate`, `drift`, and `check` (see note below) |
 | `--help` | boolean | — | Show help text |
 | `--version` | boolean | — | Print CLI version |
+
+`--table` is parsed by every command but only changes behavior for `generate`, `migrate`, `drift`, and `check`. Other commands (such as `status`, `codegen`, and `pull`) accept the flag but ignore it and operate on the full set, so `chkit status --table app.users` still reports unscoped totals.

--- a/apps/docs/src/content/docs/cli/overview.md
+++ b/apps/docs/src/content/docs/cli/overview.md
@@ -40,8 +40,14 @@ These flags are available on every command that loads a config file:
 |------|------|---------|-------------|
 | `--config <path>` | string | `clickhouse.config.ts` | Path to the chkit config file |
 | `--json` | boolean | `false` | Emit machine-readable JSON output |
-| `--table <selector>` | string | — | Limit command scope to matching tables (exact name or trailing wildcard prefix, e.g. `events_*`). Honored only by `generate`, `migrate`, `drift`, and `check` (see note below) |
+| `--table <selector>` | string | — | Narrow some commands to matching tables (exact name or trailing wildcard prefix, e.g. `events_*`). Effect varies per command — see note below |
 | `--help` | boolean | — | Show help text |
 | `--version` | boolean | — | Print CLI version |
 
-`--table` is parsed by every command but only changes behavior for `generate`, `migrate`, `drift`, and `check`. Other commands (such as `status`, `codegen`, and `pull`) accept the flag but ignore it and operate on the full set, so `chkit status --table app.users` still reports unscoped totals.
+`--table` is accepted by every command, but it is **not a universal, whole-command filter** — treat it as a scoping hint, not a guarantee:
+
+- `generate`, `migrate`, and `drift` use it to narrow the schema/migration operations they plan or evaluate.
+- `check` applies it only to its drift and plugin checks; the pending-migration and checksum checks still run across **all** tables, so `chkit check --table app.users` can still fail on an unrelated pending migration.
+- `status`, `codegen`, and `pull` accept the flag but ignore it, so `chkit status --table app.users` still reports unscoped totals.
+
+When you need a result strictly limited to specific tables, check the individual command's page for its exact scoping behavior.

--- a/apps/docs/src/content/docs/cli/overview.md
+++ b/apps/docs/src/content/docs/cli/overview.md
@@ -40,5 +40,6 @@ These flags are available on every command that loads a config file:
 |------|------|---------|-------------|
 | `--config <path>` | string | `clickhouse.config.ts` | Path to the chkit config file |
 | `--json` | boolean | `false` | Emit machine-readable JSON output |
+| `--table <selector>` | string | — | Limit command scope to matching tables (exact name or trailing wildcard prefix, e.g. `events_*`) |
 | `--help` | boolean | — | Show help text |
 | `--version` | boolean | — | Print CLI version |

--- a/apps/docs/src/content/docs/cli/status.md
+++ b/apps/docs/src/content/docs/cli/status.md
@@ -26,7 +26,7 @@ No command-specific flags. See [global flags](/cli/overview/#global-flags).
 - **Pending** migrations (on disk but not yet applied)
 - **Checksum mismatches** (applied migrations whose SHA-256 checksum no longer matches the file on disk)
 
-`chkit status` requires a ClickHouse connection and fails if no `clickhouse` connection is configured. It does not modify your schema, but it is not strictly read-only: on the first run, if the `_chkit_migrations` journal table does not yet exist, it is created automatically. That first invocation therefore needs write privileges (or run [`chkit migrate`](/cli/migrate/) first, which creates the table). Once the table exists, `chkit status` only reads from it.
+`chkit status` requires a ClickHouse connection and fails if no `clickhouse` connection is configured. It does not change your schema or migration history, but it is **not a pure read**: before reading the journal it ensures the `_chkit_migrations` table exists and has the current columns, issuing idempotent `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements. The connecting user therefore needs privileges to create and alter the journal table, not just `SELECT` — provision credentials accordingly rather than a read-only user.
 
 ## Examples
 

--- a/apps/docs/src/content/docs/cli/status.md
+++ b/apps/docs/src/content/docs/cli/status.md
@@ -26,7 +26,7 @@ No command-specific flags. See [global flags](/cli/overview/#global-flags).
 - **Pending** migrations (on disk but not yet applied)
 - **Checksum mismatches** (applied migrations whose SHA-256 checksum no longer matches the file on disk)
 
-This command is read-only, but it requires a ClickHouse connection to read the journal table. It fails if no `clickhouse` connection is configured.
+`chkit status` requires a ClickHouse connection and fails if no `clickhouse` connection is configured. It does not modify your schema, but it is not strictly read-only: on the first run, if the `_chkit_migrations` journal table does not yet exist, it is created automatically. That first invocation therefore needs write privileges (or run [`chkit migrate`](/cli/migrate/) first, which creates the table). Once the table exists, `chkit status` only reads from it.
 
 ## Examples
 

--- a/apps/docs/src/content/docs/guides/ci-cd.md
+++ b/apps/docs/src/content/docs/guides/ci-cd.md
@@ -47,7 +47,7 @@ When non-interactive, `chkit migrate` without `--apply` prints the migration pla
 Your `clickhouse.config.ts` can export a function that receives a `ChxConfigEnv` object with `command` and `mode` fields. Use this to vary config per environment:
 
 ```ts
-import { defineConfig } from 'chkit'
+import { defineConfig } from '@chkit/core'
 
 export default defineConfig((env) => ({
   schema: './schema/**/*.ts',


### PR DESCRIPTION
## Summary
Small, targeted CLI-docs fixes on top of **current `main`**. The original docs-sync branch (#155) was cut from a 98-commit-stale main and largely duplicated the journal-in-ClickHouse rewrite already merged in #137 — this PR keeps only the bits main still lacks, applied to main's current text.

- **status**: clarify it is *not strictly read-only* — on first run it creates the `_chkit_migrations` table if absent (needs write privileges once, or run `chkit migrate` first). Resolves Codex review feedback from #155.
- **migrate**: document the `chkit_version` journal column (verified in `runtime/journal-store.ts`).
- **overview**: add the global `--table` flag to the flags table (verified in `runtime/global-flags.ts`).
- **ci-cd**: import `defineConfig` from `@chkit/core`, not `chkit` — `chkit` does not export it, and every other doc + the `init` scaffold already use `@chkit/core`.

## Test plan
- [ ] Docs site builds and renders the four updated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)