### PR TITLE
docs: cover CHKIT_DEBUG, mode=async, profile config fallback, destructive scan

### DIFF
--- a/apps/docs/src/content/docs/cli/migrate.md
+++ b/apps/docs/src/content/docs/cli/migrate.md
@@ -48,6 +48,8 @@ Migration files containing `risk=danger` operations (such as `DROP TABLE` or `DR
 - **Non-interactive / CI mode**: `--allow-destructive` must be passed, or `safety.allowDestructive` must be `true` in config. Otherwise the command exits with code 3.
 - **JSON mode**: exits with code 3 and includes details about blocked operations
 
+Destructive statements are detected two ways. Planner-emitted migrations carry a `-- operation:` marker per statement, which sets the risk classification directly. In addition, chkit scans the executable SQL itself for hand-written destructive statements (`DROP TABLE`, `DROP COLUMN`, `TRUNCATE`, `DROP VIEW` / `DROP MATERIALIZED VIEW`, `DETACH`, `DROP DATABASE`) that carry no marker — whether a whole migration was hand-written or a statement was appended to a generated one. Such statements previously applied silently in CI; they now require `--allow-destructive` (or `safety.allowDestructive`) like any other destructive operation. Commented-out statements are ignored (comments are stripped before scanning), and planner-marked non-danger statements keep their existing classification, so a generated materialized-view recreate is not blocked.
+
 Each destructive operation includes a warning code, reason, impact description, and recommendation:
 
 | Warning code | Operation |
@@ -82,6 +84,29 @@ A hand-written migration with no `-- operation:` markers has no determinable tar
 ### Plugin hooks
 
 The `onBeforeApply` plugin hook runs before each migration is executed and can transform the SQL statements. The `onAfterApply` hook runs after successful execution.
+
+### Async operations (`mode=async`)
+
+Long-running data operations — large `INSERT ... SELECT` loads, backfills — can be marked async so chkit submits the query without blocking on its HTTP response and polls server-side for progress. Add `mode=async` to the statement's `-- operation:` marker:
+
+```sql
+-- operation: load_table_data key=table:default.hits risk=caution mode=async
+INSERT INTO default.hits SELECT * FROM s3(...);
+```
+
+When `chkit migrate --apply` encounters an async operation it:
+
+1. Computes a deterministic `query_id` from `sha256(migration_filename + ':' + statement_index)`.
+2. Checks `system.processes` / `system.query_log` for any prior attempt with that id.
+3. Submits the query without blocking on the HTTP response, polling every 5 seconds and printing a one-line progress update (`written=N.NM rows (N.N GiB), elapsed Ns`).
+4. Records the journal entry on success, or throws the server's exception on failure.
+
+This unblocks two scenarios the synchronous path cannot handle:
+
+- **Long loads through a proxy or load balancer with an HTTP request-duration ceiling** — the deterministic id lets a re-run attach to the still-running query on the server instead of cancelling and restarting it.
+- **Transient client-side errors during a multi-minute load** — re-running `chkit migrate` resumes the in-flight query rather than starting over.
+
+The annotation is opt-in and forward-compatible: statements without `mode=async` use the synchronous path, and an unknown mode value falls back to sync. Pair it with the [`-- log:` metadata header](#per-migration-metadata) to print context before the load begins.
 
 ## Examples
 

--- a/apps/docs/src/content/docs/cli/overview.md
+++ b/apps/docs/src/content/docs/cli/overview.md
@@ -51,3 +51,18 @@ These flags are available on every command that loads a config file:
 - `status`, `codegen`, and `pull` accept the flag but ignore it, so `chkit status --table app.users` still reports unscoped totals.
 
 When you need a result strictly limited to specific tables, check the individual command's page for its exact scoping behavior.
+
+## Environment variables
+
+These environment variables affect every command:
+
+| Variable | Description |
+|----------|-------------|
+| `CHKIT_DEBUG` | Set to `1` or `true` to emit structured debug logging to stderr. Covers config loading, command dispatch, plugin lifecycle hooks, ClickHouse queries with timing, journal operations, and per-command details. |
+| `CHKIT_JOURNAL_TABLE` | Override the name of the migration journal table (default `_chkit_migrations`). See [`chkit migrate`](/cli/migrate/#journal). |
+
+Debug logging is written to stderr, so it never contaminates `--json` output on stdout:
+
+```sh
+CHKIT_DEBUG=1 chkit migrate --apply
+```

--- a/apps/docs/src/content/docs/configuration/overview.md
+++ b/apps/docs/src/content/docs/configuration/overview.md
@@ -36,3 +36,9 @@ export default defineConfig({
   },
 })
 ```
+
+## User profile config fallback
+
+Project-scoped commands (`generate`, `migrate`, `status`, `drift`, `check`, `codegen`, `pull`) always require a project config in the working directory.
+
+[`chkit query`](/cli/query/) is the exception: when no project config is found, chkit falls back to a user-profile config at `~/.config/chkit/config.ts` (honoring `XDG_CONFIG_HOME`). This lets ad-hoc queries run from any directory. If ObsessionDB credentials are present (`~/.config/chkit/credentials.json`), chkit synthesizes a minimal query-only config automatically, so `chkit query` works after `chkit obsessiondb login` without a local config file at all.

--- a/apps/docs/src/content/docs/plugins/overview.md
+++ b/apps/docs/src/content/docs/plugins/overview.md
@@ -23,7 +23,9 @@ export default defineConfig({
 
 ## How plugins hook in
 
-Plugins implement a small set of lifecycle hooks — for example, transforming schema definitions before diff, registering new CLI commands, or running code after a migration applies. The [CLI: `chkit plugin`](/cli/plugin/) command lists plugins active in your config.
+Plugins implement a small set of lifecycle hooks — for example, transforming schema definitions before diff, registering new CLI commands, running setup on startup (`onInit`) or teardown on exit (`onComplete`), and transforming SQL before a migration applies (`onBeforeApply`). The [CLI: `chkit plugin`](/cli/plugin/) command lists plugins active in your config.
+
+Using a plugin doesn't require knowing these hooks — each official plugin's page covers everything needed to configure it. The hooks matter only when authoring a plugin.
 
 You can author your own plugins; the existing official plugins are the reference. See [Contributing](https://github.com/obsessiondb/chkit/blob/main/CONTRIBUTING.md#plugins) for the entry point.
 


### PR DESCRIPTION
## Summary

Documents recently-shipped features surfaced by the NUM-7396 audit (docs-only):

- **`CHKIT_DEBUG`** structured logging — new *Environment variables* section in `cli/overview.md` (also documents `CHKIT_JOURNAL_TABLE`).
- **`mode=async`** long-running migration operations — new behavior subsection in `cli/migrate.md`, cross-linked to the existing `-- log:` metadata header.
- **Hand-written destructive-SQL scanning** — added to the destructive-safety section of `cli/migrate.md` (statements without `-- operation:` markers now require `--allow-destructive`).
- **User-profile config fallback** (`~/.config/chkit/config.ts`) — light section in `configuration/overview.md`.
- **Plugin lifecycle hooks** — kept minimal in `plugins/overview.md`; full plugin-authoring docs deferred to NUM-7397.

Items already documented (`backfill --force`, `--time-column` resolution, `IngestOptions`) and intentionally-skipped ones (workerd compat, sync-migration-resume internals) are noted in NUM-7396.

Closes NUM-7396. Follow-up: NUM-7397.

## Test plan

- [x] `bun run build` in `apps/docs` succeeds (30 pages, raw-markdown sitemap regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)