### PR TITLE
fix(clickhouse): silence built-in @clickhouse/client logger to stop raw error leak

### DIFF
--- a/.changeset/fix-journal-operations-remote-executor.md
+++ b/.changeset/fix-journal-operations-remote-executor.md
@@ -1,5 +1,5 @@
 ---
-"chkit": minor
+"chkit": patch
 ---
 
 Fix `migrate --apply` crashing against an ObsessionDB-managed service. The ObsessionDB workbench API returns every column value as a string, so the migration journal's `operations` (`Array(Tuple)`) column arrived as text and `migration_completed` arrived as `"true"`/`"false"` — causing `(row.operations ?? []).map is not a function` and a `Boolean("false") === true` mis-read. The journal now reads `operations` via `toJSONString(...)` + `JSON.parse` and parses the boolean explicitly, which round-trips identically through both the native ClickHouse client and the remote executor (no journal schema change).

--- a/.changeset/obsessiondb-onboarding.md
+++ b/.changeset/obsessiondb-onboarding.md
@@ -1,7 +1,7 @@
 ---
-"@chkit/plugin-obsessiondb": minor
-"create-chkit": minor
-"chkit": minor
+"@chkit/plugin-obsessiondb": patch
+"create-chkit": patch
+"chkit": patch
 ---
 
 Add ObsessionDB onboarding to `chkit init` and `create-chkit`: a 3-way "how do you want to connect?" prompt covering an existing ClickHouse instance, an existing ObsessionDB account, and claiming a free ObsessionDB dev instance. Adds passwordless CLI signup (`chkit obsessiondb signup`, email + one-time code) with automatic personal-org creation, and `chkit obsessiondb service claim` to claim and provision a free instance, then write a ready-to-use connection.

--- a/.changeset/silence-clickhouse-client-logger.md
+++ b/.changeset/silence-clickhouse-client-logger.md
@@ -1,0 +1,10 @@
+---
+"@chkit/clickhouse": minor
+---
+
+Silence the built-in @clickhouse/client logger so a wrong password (or any connection error) no
+longer leaks the raw ClickHouse server remediation blurb to stderr. chkit emits its own clean
+one-line message and now sets the client log level to OFF explicitly, independent of the resolved
+@clickhouse/client version (the upstream default changed from OFF to WARN in 1.18). Also raises
+the @clickhouse/client dependency floor to ^1.18.0 so the shipped behavior matches what consumers
+resolve.

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
       "version": "0.1.0-beta.28",
       "dependencies": {
         "@chkit/core": "workspace:*",
-        "@clickhouse/client": "^1.11.0",
+        "@clickhouse/client": "^1.18.0",
         "@logtape/logtape": "^2.0.5",
         "p-retry": "^7.1.1",
       },
@@ -284,9 +284,9 @@
 
     "@clack/prompts": ["@clack/prompts@1.4.0", "", { "dependencies": { "@clack/core": "1.3.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA=="],
 
-    "@clickhouse/client": ["@clickhouse/client@1.17.0", "", { "dependencies": { "@clickhouse/client-common": "1.17.0" } }, "sha512-Y3DQoamKZ/Iyosoq7Lj7lqpDkQDK4R/5mI52yJs4ZLPIO+d6/CYDqTbFBIb4No3C/AlXUYE4TKhj/kXDpe6rOA=="],
+    "@clickhouse/client": ["@clickhouse/client@1.22.0", "", { "dependencies": { "@clickhouse/client-common": "1.22.0" } }, "sha512-iQAAM4VT9fO7mYVOkGB/Ul9Xxuf0atKn+GFceZqfE8xFakV8KOAQxR3tfNrXFMlJ8T+Q3gbrpfLFyj7/TbOwyA=="],
 
-    "@clickhouse/client-common": ["@clickhouse/client-common@1.17.0", "", {}, "sha512-MiwwgXViFAQA2YZkN4ymF1ynzG0K49KeSX9/iOcmJetWkxqSekDdpyp1GjwATWa9R215uQ+hGzJtJujeQVZZIw=="],
+    "@clickhouse/client-common": ["@clickhouse/client-common@1.22.0", "", {}, "sha512-MQgXRhoYXut6GhRrTJlub42bnPX7+5Vm+5gHNR0zZXU5+EwZKsBgMXiWXPOerAmQd3weGKm8hzoeZJCfU3Cw2w=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@chkit/core": "workspace:*",
-    "@clickhouse/client": "^1.11.0",
+    "@clickhouse/client": "^1.18.0",
     "@logtape/logtape": "^2.0.5",
     "p-retry": "^7.1.1"
   }

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -7,7 +7,7 @@ import {
 	parseCodec,
 	type SkipIndexDefinition,
 } from '@chkit/core'
-import { type ClickHouseSettings, createClient } from '@clickhouse/client'
+import { type ClickHouseSettings, ClickHouseLogLevel, createClient } from '@clickhouse/client'
 import { getLogger } from '@logtape/logtape'
 import {
 	parseEngineFromCreateTableQuery,
@@ -528,6 +528,13 @@ const DEFAULT_CLICKHOUSE_SETTINGS: ClickHouseSettings = {
 	send_progress_in_http_headers: 1,
 }
 
+// chkit emits its own clean, one-line connection errors (see wrapConnectionError).
+// The built-in @clickhouse/client DefaultLogger defaults to WARN since v1.18, which
+// logs the full raw server remediation blurb to stderr on any connection ERROR and
+// would otherwise leak it past our clean message. Owning the level (OFF) silences it
+// independent of the resolved client version, since the client does `level ?? DEFAULT`.
+const SILENT_CLIENT_LOG = { level: ClickHouseLogLevel.OFF }
+
 // @clickhouse/client uses socket.setTimeout under the hood, which is an
 // inactivity timeout. For long-running INSERTs (e.g. INSERT ... SELECT FROM
 // url() in the ClickBench load) ClickHouse stays silent until the operation
@@ -548,6 +555,7 @@ export function createStatelessClickHouseClient(
 		application: CHKIT_APPLICATION_ID,
 		request_timeout: NO_REQUEST_TIMEOUT,
 		clickhouse_settings: clickhouseSettings,
+		log: SILENT_CLIENT_LOG,
 		...(options.compression ? { compression: options.compression } : {}),
 	})
 }
@@ -573,6 +581,7 @@ export function createSessionClickHouseClient(
 		application: CHKIT_APPLICATION_ID,
 		request_timeout: NO_REQUEST_TIMEOUT,
 		clickhouse_settings: clickhouseSettings,
+		log: SILENT_CLIENT_LOG,
 		...(options.compression ? { compression: options.compression } : {}),
 	})
 }
@@ -611,6 +620,7 @@ export function createExecutorWithClient(
 						application: CHKIT_APPLICATION_ID,
 						request_timeout: NO_REQUEST_TIMEOUT,
 						clickhouse_settings: { wait_end_of_query: 1, async_insert: 0 },
+						log: SILENT_CLIENT_LOG,
 					})
 					try {
 						const fallbackResult = await fallback.command({


### PR DESCRIPTION
## Summary
- `@clickhouse/client`'s built-in `DefaultLogger` changed its default level from `OFF` (≤1.17) to `WARN` (≥1.18). At `WARN` it logs the full raw server remediation blurb to stderr on any connection ERROR, defeating chkit's clean one-line connection error (added in #139). Real users who `bun add -d chkit` resolve `^1.11.0` to the latest 1.x and hit the leak.
- chkit now explicitly owns the client log level, setting it `OFF` on all three `createClient(...)` call sites in `packages/clickhouse/src/index.ts`. This is version-independent — the client does `config.log?.level ?? DEFAULT`, so `OFF` always wins.
- Raises the `@clickhouse/client` dependency floor from `^1.11.0` to `^1.18.0` (no exact pin — chkit is a library) so dev/CI exercise the same WARN-defaulting client real users get.
- Adds a changeset (`@chkit/clickhouse` minor).

## Test plan
- [x] Repro: with the floor bumped (resolves 1.22.0), `auth.e2e.test.ts` ("a wrong password yields one clean line ... #7") FAILS — output contains `[ERROR][@clickhouse/client][Connection]`, `clickhouse.cloud`, and `/etc/clickhouse-server`.
- [x] After the fix: `auth.e2e.test.ts` PASSES (0 fail).
- [x] Full `bun verify` green (37/37 tasks, 243 tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)