### PR TITLE
perf(cli): parallelize test suite (~2.4x) and fix flaky obsessiondb e2e race

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: oven-sh/setup-bun@v2
       with:
-        bun-version: 1.3.5
+        bun-version: 1.3.13
 
     - uses: actions/cache@v3
       name: Setup bun cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   verify:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/examples/clickbench/package.json
+++ b/examples/clickbench/package.json
@@ -2,7 +2,7 @@
   "name": "chkit-example-clickbench",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@1.3.13",
   "scripts": {
     "migrate": "chkit migrate --apply",
     "status": "chkit status",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@1.3.13",
   "workspaces": [
     "packages/*",
     "apps/*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
     "dev": "bun run src/bin/chkit.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "biome lint src",
-    "test": "bun test src --concurrent --timeout 15000",
+    "test": "bun test src --concurrent --parallel --timeout 15000",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/cli/src/test/obsessiondb-onboarding.e2e.test.ts
+++ b/packages/cli/src/test/obsessiondb-onboarding.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -7,9 +7,6 @@ import { createFixture, WORKSPACE_ROOT } from './testkit.test'
 
 const OBSDB_PLUGIN_ENTRY = join(WORKSPACE_ROOT, 'packages/plugin-obsessiondb/src/index.ts')
 const CLI_BIN_ENTRY = join(WORKSPACE_ROOT, 'packages/cli/src/bin/chkit.ts')
-
-let tempDir: string | undefined
-let server: ReturnType<typeof Bun.serve> | undefined
 
 async function runCliAsync(
   args: string[],
@@ -91,116 +88,125 @@ function startMockServer(counts: { sendOtp: number } = { sendOtp: 0 }): ReturnTy
 }
 
 describe('@chkit/cli obsessiondb onboarding e2e', () => {
-  afterEach(async () => {
-    server?.stop()
-    server = undefined
-    if (tempDir) {
+  test('signs up, auto-creates an org, claims an instance, and selects it', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'chkit-onboarding-'))
+    const fixture = await createFixture()
+    const server = startMockServer()
+    try {
+      const apiUrl = `http://127.0.0.1:${server.port}`
+      const xdgConfigHome = join(tempDir, 'xdg')
+      const env = { XDG_CONFIG_HOME: xdgConfigHome }
+
+      await writeFile(
+        fixture.configPath,
+        `import { obsessiondb } from '${OBSDB_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [obsessiondb()],\n}\n`,
+        'utf8',
+      )
+
+      const signup = await runCliAsync(
+        [
+          'obsessiondb',
+          'signup',
+          '--api-url',
+          apiUrl,
+          '--email',
+          'playground@example.com',
+          '--code',
+          '123456',
+          '--config',
+          fixture.configPath,
+        ],
+        env,
+      )
+      expect(signup.exitCode).toBe(0)
+      expect(signup.stdout).toContain('Created organization "playground"')
+
+      const credentials = JSON.parse(
+        await readFile(join(xdgConfigHome, 'chkit', 'credentials.json'), 'utf8'),
+      ) as { access_token: string; base_url: string }
+      expect(credentials.access_token).toBe('test-token')
+      expect(credentials.base_url).toBe(apiUrl)
+
+      const claim = await runCliAsync(
+        ['obsessiondb', 'service', 'claim', '--config', fixture.configPath],
+        env,
+      )
+      expect(claim.exitCode).toBe(0)
+      expect(claim.stdout).toContain('Instance ready: free-abc')
+
+      const selected = JSON.parse(
+        await readFile(join(fixture.dir, '.chkit', 'obsessiondb.json'), 'utf8'),
+      ) as { service_slug?: string }
+      expect(selected.service_slug).toBe('free-abc')
+    } finally {
+      server.stop()
       await rm(tempDir, { recursive: true, force: true })
-      tempDir = undefined
+      await rm(fixture.dir, { recursive: true, force: true })
     }
   })
 
-  test('signs up, auto-creates an org, claims an instance, and selects it', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'chkit-onboarding-'))
-    server = startMockServer()
-    const apiUrl = `http://127.0.0.1:${server.port}`
-    const fixture = await createFixture()
-    const xdgConfigHome = join(tempDir, 'xdg')
-    const env = { XDG_CONFIG_HOME: xdgConfigHome }
-
-    await writeFile(
-      fixture.configPath,
-      `import { obsessiondb } from '${OBSDB_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [obsessiondb()],\n}\n`,
-      'utf8',
-    )
-
-    const signup = await runCliAsync(
-      [
-        'obsessiondb',
-        'signup',
-        '--api-url',
-        apiUrl,
-        '--email',
-        'playground@example.com',
-        '--code',
-        '123456',
-        '--config',
-        fixture.configPath,
-      ],
-      env,
-    )
-    expect(signup.exitCode).toBe(0)
-    expect(signup.stdout).toContain('Created organization "playground"')
-
-    const credentials = JSON.parse(
-      await readFile(join(xdgConfigHome, 'chkit', 'credentials.json'), 'utf8'),
-    ) as { access_token: string; base_url: string }
-    expect(credentials.access_token).toBe('test-token')
-    expect(credentials.base_url).toBe(apiUrl)
-
-    const claim = await runCliAsync(
-      ['obsessiondb', 'service', 'claim', '--config', fixture.configPath],
-      env,
-    )
-    expect(claim.exitCode).toBe(0)
-    expect(claim.stdout).toContain('Instance ready: free-abc')
-
-    const selected = JSON.parse(
-      await readFile(join(fixture.dir, '.chkit', 'obsessiondb.json'), 'utf8'),
-    ) as { service_slug?: string }
-    expect(selected.service_slug).toBe('free-abc')
-  })
-
   test('two-step signup: --request-only sends the code once, --code verifies without re-sending', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'chkit-onboarding-'))
-    const counts = { sendOtp: 0 }
-    server = startMockServer(counts)
-    const apiUrl = `http://127.0.0.1:${server.port}`
+    const tempDir = await mkdtemp(join(tmpdir(), 'chkit-onboarding-'))
     const fixture = await createFixture()
-    const env = { XDG_CONFIG_HOME: join(tempDir, 'xdg') }
+    const counts = { sendOtp: 0 }
+    const server = startMockServer(counts)
+    try {
+      const apiUrl = `http://127.0.0.1:${server.port}`
+      const env = { XDG_CONFIG_HOME: join(tempDir, 'xdg') }
 
-    await writeFile(
-      fixture.configPath,
-      `import { obsessiondb } from '${OBSDB_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [obsessiondb()],\n}\n`,
-      'utf8',
-    )
+      await writeFile(
+        fixture.configPath,
+        `import { obsessiondb } from '${OBSDB_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [obsessiondb()],\n}\n`,
+        'utf8',
+      )
 
-    const base = ['obsessiondb', 'signup', '--api-url', apiUrl, '--email', 'playground@example.com', '--config', fixture.configPath]
+      const base = ['obsessiondb', 'signup', '--api-url', apiUrl, '--email', 'playground@example.com', '--config', fixture.configPath]
 
-    // Step 1: request the code. Sends exactly one OTP and prints the verify command.
-    const request = await runCliAsync([...base, '--request-only'], env)
-    expect(request.exitCode).toBe(0)
-    expect(request.stdout).toContain('We sent a 6-digit code to playground@example.com')
-    expect(request.stdout).toContain('chkit obsessiondb signup --email playground@example.com --code <CODE>')
-    expect(counts.sendOtp).toBe(1)
+      // Step 1: request the code. Sends exactly one OTP and prints the verify command.
+      const request = await runCliAsync([...base, '--request-only'], env)
+      expect(request.exitCode).toBe(0)
+      expect(request.stdout).toContain('We sent a 6-digit code to playground@example.com')
+      expect(request.stdout).toContain('chkit obsessiondb signup --email playground@example.com --code <CODE>')
+      expect(counts.sendOtp).toBe(1)
 
-    // Step 2: verify with the code. Must NOT re-send the OTP (would invalidate the code).
-    const verify = await runCliAsync([...base, '--code', '123456'], env)
-    expect(verify.exitCode).toBe(0)
-    expect(verify.stdout).toContain('Created organization "playground"')
-    expect(counts.sendOtp).toBe(1)
+      // Step 2: verify with the code. Must NOT re-send the OTP (would invalidate the code).
+      const verify = await runCliAsync([...base, '--code', '123456'], env)
+      expect(verify.exitCode).toBe(0)
+      expect(verify.stdout).toContain('Created organization "playground"')
+      expect(counts.sendOtp).toBe(1)
+    } finally {
+      server.stop()
+      await rm(tempDir, { recursive: true, force: true })
+      await rm(fixture.dir, { recursive: true, force: true })
+    }
   })
 
   test('signup without an email in a non-interactive run prints the two-step runbook and fails', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'chkit-onboarding-'))
-    server = startMockServer()
-    const apiUrl = `http://127.0.0.1:${server.port}`
+    const tempDir = await mkdtemp(join(tmpdir(), 'chkit-onboarding-'))
     const fixture = await createFixture()
-    const env = { XDG_CONFIG_HOME: join(tempDir, 'xdg') }
+    const server = startMockServer()
+    try {
+      const apiUrl = `http://127.0.0.1:${server.port}`
+      const env = { XDG_CONFIG_HOME: join(tempDir, 'xdg') }
 
-    await writeFile(
-      fixture.configPath,
-      `import { obsessiondb } from '${OBSDB_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [obsessiondb()],\n}\n`,
-      'utf8',
-    )
+      await writeFile(
+        fixture.configPath,
+        `import { obsessiondb } from '${OBSDB_PLUGIN_ENTRY}'\n\nexport default {\n  schema: '${fixture.schemaPath}',\n  outDir: '${join(fixture.dir, 'chkit')}',\n  migrationsDir: '${fixture.migrationsDir}',\n  metaDir: '${fixture.metaDir}',\n  plugins: [obsessiondb()],\n}\n`,
+        'utf8',
+      )
 
-    const result = await runCliAsync(
-      ['obsessiondb', 'signup', '--api-url', apiUrl, '--config', fixture.configPath],
-      env,
-    )
+      const result = await runCliAsync(
+        ['obsessiondb', 'signup', '--api-url', apiUrl, '--config', fixture.configPath],
+        env,
+      )
 
-    expect(result.exitCode).toBe(1)
-    expect(result.stdout).toContain('chkit obsessiondb signup --email <you@example.com>')
-    expect(result.stdout).toContain('--code <CODE>')
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain('chkit obsessiondb signup --email <you@example.com>')
+      expect(result.stdout).toContain('--code <CODE>')
+    } finally {
+      server.stop()
+      await rm(tempDir, { recursive: true, force: true })
+      await rm(fixture.dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/cli/src/test/obsessiondb-service.e2e.test.ts
+++ b/packages/cli/src/test/obsessiondb-service.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -15,9 +15,6 @@ interface RpcRequest {
 	path: string
 	body: string
 }
-
-let tempDir: string | undefined
-let server: ReturnType<typeof Bun.serve> | undefined
 
 async function runCliAsync(
 	args: string[],
@@ -62,7 +59,7 @@ function service(overrides: {
 }
 
 async function setupObsessiondbCli() {
-	tempDir = await mkdtemp(join(tmpdir(), 'chkit-obsessiondb-cli-'))
+	const tempDir = await mkdtemp(join(tmpdir(), 'chkit-obsessiondb-cli-'))
 	const fixture = await createFixture()
 	const xdgConfigHome = join(tempDir, 'xdg')
 	const chkitConfigDir = join(xdgConfigHome, 'chkit')
@@ -70,7 +67,7 @@ async function setupObsessiondbCli() {
 	const profileConfigPath = join(chkitConfigDir, 'config.ts')
 	const requests: RpcRequest[] = []
 
-	server = Bun.serve({
+	const server = Bun.serve({
 		port: 0,
 		async fetch(req) {
 			const url = new URL(req.url)
@@ -130,73 +127,73 @@ async function setupObsessiondbCli() {
 		requests,
 		env: { XDG_CONFIG_HOME: xdgConfigHome },
 		servicePath: join(fixture.dir, '.chkit', 'obsessiondb.json'),
+		server,
+		tempDir,
 	}
 }
 
 describe('@chkit/cli obsessiondb service e2e', () => {
-	afterEach(async () => {
-		server?.stop()
-		server = undefined
-		if (tempDir) {
-			await rm(tempDir, { recursive: true, force: true })
-			tempDir = undefined
-		}
-	})
-
 	test('runs service list and service alias commands through the CLI', async () => {
-		const { fixture, requests, env, servicePath } = await setupObsessiondbCli()
+		const { fixture, requests, env, servicePath, server, tempDir } =
+			await setupObsessiondbCli()
 
-		const list = await runCliAsync(
-			['obsessiondb', 'service', 'list', '--config', fixture.configPath],
-			env,
-		)
-		expect(list.exitCode).toBe(0)
-		expect(list.stdout).toContain('Services:')
-		expect(list.stdout).toContain('Acme (acme):')
-		expect(list.stdout).toContain('  - production (running)')
-		expect(list.stdout).toContain('  - staging (stopped)')
+		try {
+			const list = await runCliAsync(
+				['obsessiondb', 'service', 'list', '--config', fixture.configPath],
+				env,
+			)
+			expect(list.exitCode).toBe(0)
+			expect(list.stdout).toContain('Services:')
+			expect(list.stdout).toContain('Acme (acme):')
+			expect(list.stdout).toContain('  - production (running)')
+			expect(list.stdout).toContain('  - staging (stopped)')
 
-		const setAlias = await runCliAsync(
-			[
-				'obsessiondb',
-				'service',
-				'alias',
-				'set',
-				'login',
-				'production',
-				'--config',
-				fixture.configPath,
-			],
-			env,
-		)
-		expect(setAlias.exitCode).toBe(0)
-		expect(setAlias.stdout).toContain('Service alias saved: login -> production')
+			const setAlias = await runCliAsync(
+				[
+					'obsessiondb',
+					'service',
+					'alias',
+					'set',
+					'login',
+					'production',
+					'--config',
+					fixture.configPath,
+				],
+				env,
+			)
+			expect(setAlias.exitCode).toBe(0)
+			expect(setAlias.stdout).toContain('Service alias saved: login -> production')
 
-		const aliasList = await runCliAsync(
-			[
-				'obsessiondb',
-				'service',
-				'alias',
-				'list',
-				'--config',
-				fixture.configPath,
-			],
-			env,
-		)
-		expect(aliasList.exitCode).toBe(0)
-		expect(aliasList.stdout).toContain('Service aliases:')
-		expect(aliasList.stdout).toContain('  login -> production')
+			const aliasList = await runCliAsync(
+				[
+					'obsessiondb',
+					'service',
+					'alias',
+					'list',
+					'--config',
+					fixture.configPath,
+				],
+				env,
+			)
+			expect(aliasList.exitCode).toBe(0)
+			expect(aliasList.stdout).toContain('Service aliases:')
+			expect(aliasList.stdout).toContain('  login -> production')
 
-		const stored = JSON.parse(await readFile(servicePath, 'utf8')) as {
-			aliases?: Record<string, { service_slug?: string; service_name?: string }>
+			const stored = JSON.parse(await readFile(servicePath, 'utf8')) as {
+				aliases?: Record<string, { service_slug?: string; service_name?: string }>
+			}
+			expect(stored.aliases?.login).toEqual({
+				service_slug: 'production',
+				service_name: 'production',
+			})
+			expect(requests.map((request) => request.path)).toEqual([
+				'/rpc/services/listAll',
+				'/rpc/services/listAll',
+			])
+		} finally {
+			server.stop()
+			await rm(tempDir, { recursive: true, force: true })
+			await rm(fixture.dir, { recursive: true, force: true })
 		}
-		expect(stored.aliases?.login).toEqual({
-			service_slug: 'production',
-			service_name: 'production',
-		})
-		expect(requests.map((request) => request.path)).toEqual([
-			'/rpc/services/listAll',
-			'/rpc/services/listAll',
-		])
 	})
 })


### PR DESCRIPTION
## Summary
- Add Bun's `--parallel` to the `chkit` (`packages/cli`) test script alongside `--concurrent`, so test files run across worker processes. Local wall time drops **~260s → ~110s** (243 tests, 0 fail). Defaults to core count, so it auto-scales with the runner.
- Fix a pre-existing **flaky shared-state race** in `obsessiondb-onboarding.e2e.test.ts` and `obsessiondb-service.e2e.test.ts` that `--parallel` (`--isolate`) surfaced: they shared module-level `server`/`tempDir` across concurrent tests with `afterEach` teardown (onboarding failed ~1-in-4 in isolation). Each test now owns its `server`/`tempDir`/`fixture` and cleans up in `try/finally`; also closes a fixture-dir leak. Assertions and mock servers are unchanged.
- Bump the CI **verify** runner to `blacksmith-8vcpu-ubuntu-2404` to realize single-node parallelism in CI (deploy job stays 4 vCPU).

No changeset: test infra + CI + dev tooling only — no user-facing/published behavior change.

## Test plan
- [x] `bun verify` — 37/37 tasks, 243 pass / 0 fail
- [x] Race fix: onboarding 8/8 clean (was ~1-in-4), service 4/4, both hermetic (pass without Doppler)
- [x] typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)