### PR TITLE
fix(onboarding): sanitize default org name + make fresh init runnable

### DIFF
--- a/.changeset/init-auto-install-deps.md
+++ b/.changeset/init-auto-install-deps.md
@@ -1,0 +1,5 @@
+---
+"chkit": patch
+---
+
+`chkit init` now auto-installs `chkit`, `@chkit/core`, and `@chkit/plugin-obsessiondb` when the project has no dependencies, so a fresh `init` into an empty directory produces a runnable project instead of dead-ending on unresolved config imports at the first `generate`. Detects the package manager from `npm_config_user_agent` (defaults to bun), writes a minimal `package.json` if absent, and degrades to printing the manual install command if the install fails.

--- a/.changeset/sanitize-default-org-name.md
+++ b/.changeset/sanitize-default-org-name.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-obsessiondb": patch
+---
+
+Sanitize the auto-derived default org name during ObsessionDB signup. The personal org name is now stripped of the email `+subaddress` (e.g. `marc+clisignup@…` → `marc`) and any non-display characters, falling back to `playground` when nothing usable remains. The `--org-name` override still wins.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,6 +2,7 @@ import process from 'node:process'
 import { relative, resolve } from 'node:path'
 
 import { DEFAULT_CONFIG_FILE, writeIfMissing } from '../runtime/config.js'
+import { ensureProjectDependencies } from '../runtime/deps.js'
 
 type ConnectChoice = 'claim' | 'account' | 'clickhouse' | 'later'
 
@@ -31,6 +32,11 @@ export async function cmdInit(argv: string[] = []): Promise<void> {
 
   if (wroteConfig) console.log(`Created ${relative(cwd, configPath)}`)
   if (wroteSchema) console.log(`Created ${relative(cwd, schemaPath)}`)
+
+  // Install chkit + plugins when the project has none, so the scaffolded config resolves its imports
+  // and a follow-up `generate` doesn't dead-end. Runs before onboarding so the claim flow (which
+  // dynamically imports the plugin and edits the config) operates on an already-runnable project.
+  await ensureProjectDependencies(cwd, (msg) => console.log(msg))
 
   // Interactive onboarding only when attached to a TTY (or explicitly requested via flags),
   // and not opted out with --yes. Keeps `chkit init` a silent file-writer for CI/scripts.

--- a/packages/cli/src/runtime/deps.ts
+++ b/packages/cli/src/runtime/deps.ts
@@ -1,0 +1,108 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { basename, resolve } from 'node:path'
+import process from 'node:process'
+
+/**
+ * `chkit init` scaffolds a `clickhouse.config.ts` that imports `@chkit/core` (and
+ * `@chkit/plugin-obsessiondb` once onboarding registers it), but the docs `init` flow assumes the
+ * user already ran `bun add -d chkit`. In a brand-new empty directory nothing is installed, so the
+ * scaffold looks complete but the first `generate` dead-ends on unresolved imports. This module
+ * detects that case and installs the packages so the project is runnable.
+ */
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+
+// Installed explicitly (not relying on chkit's optionalDependency hoisting) so the config's direct
+// imports resolve even under strict/non-hoisting layouts (pnpm, npm with nested node_modules).
+const PROJECT_PACKAGES: ReadonlyArray<string> = ['chkit', '@chkit/core', '@chkit/plugin-obsessiondb']
+
+const SUPPORTED: ReadonlyArray<PackageManager> = ['npm', 'pnpm', 'yarn', 'bun']
+
+/**
+ * Whether `@chkit/core` resolves from the *project* directory. Resolving against `cwd` (not the
+ * CLI's own location) is the point: it tells us if the user's project can load its scaffolded
+ * config, regardless of where the running `chkit` binary lives.
+ */
+export function projectHasCoreDependency(cwd: string): boolean {
+  try {
+    const require = createRequire(resolve(cwd, 'noop.js'))
+    require.resolve('@chkit/core')
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Detect the package manager from `npm_config_user_agent`; default to bun (this repo is bun-first). */
+export function detectPackageManager(env: NodeJS.ProcessEnv = process.env): PackageManager {
+  const userAgent = env.npm_config_user_agent
+  const name = userAgent?.split(' ')[0]?.split('/')[0]
+  return name && isSupported(name) ? name : 'bun'
+}
+
+/** Build the dev-dependency install command for a package manager. */
+export function installCommand(pm: PackageManager): { cmd: string; args: string[] } {
+  const packages = [...PROJECT_PACKAGES]
+  switch (pm) {
+    case 'npm':
+      return { cmd: 'npm', args: ['install', '-D', ...packages] }
+    case 'pnpm':
+      return { cmd: 'pnpm', args: ['add', '-D', ...packages] }
+    case 'yarn':
+      return { cmd: 'yarn', args: ['add', '-D', ...packages] }
+    case 'bun':
+      return { cmd: 'bun', args: ['add', '-d', ...packages] }
+  }
+}
+
+/**
+ * Make the project runnable by installing chkit + its plugins when they're missing.
+ * Returns true if an install was run, false if deps were already present or the install failed
+ * (a failed install never throws — init keeps going and prints the manual command instead).
+ */
+export async function ensureProjectDependencies(
+  cwd: string,
+  print: (msg: string) => void,
+): Promise<boolean> {
+  if (projectHasCoreDependency(cwd)) return false
+
+  await ensurePackageJson(cwd)
+  const pm = detectPackageManager()
+  const { cmd, args } = installCommand(pm)
+
+  print(`No dependencies found — installing chkit with ${cmd}…`)
+  try {
+    await run(cmd, args, cwd)
+    return true
+  } catch {
+    print(`Could not install dependencies automatically. Run this first, then retry: ${cmd} ${args.join(' ')}`)
+    return false
+  }
+}
+
+/** Write a minimal `package.json` if the project has none, so the package manager has a manifest. */
+async function ensurePackageJson(cwd: string): Promise<void> {
+  const pkgPath = resolve(cwd, 'package.json')
+  if (existsSync(pkgPath)) return
+  const name = basename(cwd).toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-|-$/g, '') || 'chkit-project'
+  const manifest = { name, private: true, type: 'module' }
+  await writeFile(pkgPath, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+function run(command: string, args: ReadonlyArray<string>, cwd: string): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit' })
+    child.on('close', (code) => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`))
+    })
+    child.on('error', reject)
+  })
+}
+
+function isSupported(value: string): value is PackageManager {
+  return (SUPPORTED as ReadonlyArray<string>).includes(value)
+}

--- a/packages/cli/src/test/deps.test.ts
+++ b/packages/cli/src/test/deps.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+
+import { detectPackageManager, installCommand, projectHasCoreDependency } from '../runtime/deps'
+
+describe('installCommand', () => {
+  const packages = ['chkit', '@chkit/core', '@chkit/plugin-obsessiondb']
+
+  test('builds a bun dev-install command', () => {
+    expect(installCommand('bun')).toEqual({ cmd: 'bun', args: ['add', '-d', ...packages] })
+  })
+
+  test('builds an npm dev-install command', () => {
+    expect(installCommand('npm')).toEqual({ cmd: 'npm', args: ['install', '-D', ...packages] })
+  })
+
+  test('builds a pnpm dev-install command', () => {
+    expect(installCommand('pnpm')).toEqual({ cmd: 'pnpm', args: ['add', '-D', ...packages] })
+  })
+
+  test('builds a yarn dev-install command', () => {
+    expect(installCommand('yarn')).toEqual({ cmd: 'yarn', args: ['add', '-D', ...packages] })
+  })
+})
+
+describe('detectPackageManager', () => {
+  test('reads the package manager from npm_config_user_agent', () => {
+    expect(detectPackageManager({ npm_config_user_agent: 'pnpm/9.0.0 npm/? node/v22' })).toBe('pnpm')
+  })
+
+  test('defaults to bun when the user agent is absent', () => {
+    expect(detectPackageManager({})).toBe('bun')
+  })
+
+  test('defaults to bun for an unsupported package manager', () => {
+    expect(detectPackageManager({ npm_config_user_agent: 'deno/2.0.0' })).toBe('bun')
+  })
+})
+
+describe('projectHasCoreDependency', () => {
+  test('returns false for a directory with no installed dependencies', () => {
+    expect(projectHasCoreDependency('/nonexistent-empty-chkit-dir')).toBe(false)
+  })
+})

--- a/packages/plugin-obsessiondb/src/auth/signup.test.ts
+++ b/packages/plugin-obsessiondb/src/auth/signup.test.ts
@@ -10,6 +10,18 @@ describe('deriveOrgName', () => {
   test('falls back to playground for an empty local-part', () => {
     expect(deriveOrgName('@co.com')).toBe('playground')
   })
+
+  test('strips the +subaddress from a plus-addressed email', () => {
+    expect(deriveOrgName('marc+clisignup@numia.xyz')).toBe('marc')
+  })
+
+  test('keeps dots in a dotted local-part', () => {
+    expect(deriveOrgName('marc.hoeffl@numia.xyz')).toBe('marc.hoeffl')
+  })
+
+  test('falls back to playground for an all-symbol local-part', () => {
+    expect(deriveOrgName('+++@x.com')).toBe('playground')
+  })
 })
 
 describe('slugifyOrgName', () => {

--- a/packages/plugin-obsessiondb/src/auth/signup.ts
+++ b/packages/plugin-obsessiondb/src/auth/signup.ts
@@ -156,8 +156,11 @@ async function promptCode(print: (msg: string) => void): Promise<string | null> 
 
 /** Derive a personal org name from the email local-part; fallback to `playground`. */
 export function deriveOrgName(email: string): string {
-  const localPart = email.split('@')[0]?.trim().toLowerCase() ?? ''
-  return localPart.length > 0 ? localPart : 'playground'
+  // Drop the +subaddress (everything from the first '+' to the '@') and any non-display chars so a
+  // plus-addressed email like `marc+clisignup@…` yields `marc`, not `marc+clisignup`.
+  const localPart = email.split('@')[0]?.split('+')[0] ?? ''
+  const cleaned = localPart.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, '')
+  return cleaned.length > 0 ? cleaned : 'playground'
 }
 
 /** Build a unique-ish org slug from a name (random suffix avoids collisions across machines). */


### PR DESCRIPTION
## Summary

Onboarding polish (NUM-7394) — two independent UX fixes:

1. **Sanitize the auto-derived default org name** (`@chkit/plugin-obsessiondb`). `deriveOrgName()` now strips the email `+subaddress` and non-display characters, so a plus-addressed email like `marc+clisignup@numia.xyz` yields `marc` instead of `marc+clisignup`. Keeps the `playground` fallback; the `--org-name` override still wins.
2. **Auto-install deps so a fresh `init` is runnable** (`chkit`). `chkit init` into an empty directory previously scaffolded a `clickhouse.config.ts` that imported `@chkit/core` / `@chkit/plugin-obsessiondb` but installed nothing, so the first `generate` dead-ended on unresolved imports. `init` now detects the missing dependency, writes a minimal `package.json` if absent, and installs `chkit` + plugins with the detected package manager (defaults to bun) before onboarding. A failed install degrades to printing the manual command instead of crashing.

Both changes ship with `patch` changesets and unit tests.

## Test plan

- [x] `bun test packages/plugin-obsessiondb/src/auth/signup.test.ts` (plus-addressing, dotted, all-symbol → `playground`)
- [x] `bun test packages/cli/src/test/deps.test.ts` (install command per package manager, PM detection, missing-dep detection)
- [x] `typecheck`, `lint`, `build` all green
- [x] Manual fresh-dir e2e: empty dir → `chkit init` auto-installs deps + writes `package.json` → `chkit generate --name init` resolves config imports and produces a migration; re-running `init` does not reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)