### PR TITLE
feat(obsessiondb): structured --json next envelope for signup/claim

### DIFF
--- a/.changeset/obsessiondb-json-next-envelope.md
+++ b/.changeset/obsessiondb-json-next-envelope.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-obsessiondb": patch
+---
+
+Emit a structured `--json` envelope from the non-interactive ObsessionDB auth flow so programmatic callers can chain steps without parsing prose. `signup` and `service claim` now honor `--json`: each terminal/pause state prints a single `{ command, schemaVersion, status, next }` object instead of human runbook text, where `next` carries the exact command to run (e.g. `{ "status": "otp_sent", "email": "me@x.com", "next": { "needs": "code", "command": "chkit obsessiondb signup --email me@x.com --code <CODE>" } }`). Statuses cover `no_email → otp_sent → verified` (signup) and `claimed` / `provisioning` / `already_claimed` (claim); failures emit the `ok:false` error envelope. Text-mode output is unchanged, and the runbook command strings are now the single source shared by both prose and JSON so they cannot drift.

--- a/apps/docs/src/content/docs/obsessiondb/getting-started.md
+++ b/apps/docs/src/content/docs/obsessiondb/getting-started.md
@@ -150,6 +150,29 @@ chkit obsessiondb signup --email you@example.com --code 123456
 chkit obsessiondb service claim
 ```
 
+### Structured JSON for agents
+
+Pass `--json` to `signup` and `service claim` to get a machine-readable envelope instead of prose, so an agent or script can chain the flow without parsing text. Each call emits a single object with the current `status` and a `next` hint carrying the exact command to run next (`next` is `null` at a terminal state):
+
+```sh
+chkit obsessiondb signup --email you@example.com --json
+```
+
+```json
+{
+  "command": "obsessiondb signup",
+  "schemaVersion": 1,
+  "status": "otp_sent",
+  "email": "you@example.com",
+  "next": {
+    "needs": "code",
+    "command": "chkit obsessiondb signup --email you@example.com --code <CODE>"
+  }
+}
+```
+
+`signup` moves through `no_email → otp_sent → verified`, and `service claim` reports `claimed`, `provisioning`, or `already_claimed`. Failures (no capacity, rate-limited, not logged in) emit a stable error envelope — `{ "ok": false, "error": { "code", "message" } }`. In `--json` mode nothing else is written to stdout, so the output is always safe to pipe to `jq`.
+
 ### Exit codes
 
 When an explicit connect path is requested but can't complete — for example `--connect claim` with no email, or a wrong code — `chkit init` and `create-chkit` exit non-zero instead of falling through to "next steps" with a success status, so scripts can detect the failure.

--- a/packages/plugin-obsessiondb/src/auth/commands.ts
+++ b/packages/plugin-obsessiondb/src/auth/commands.ts
@@ -19,6 +19,7 @@ function resolveBaseUrlFromFlags(flags: Record<string, string | string[] | boole
 interface PluginCommandContext {
   configPath: string
   flags: Record<string, string | string[] | boolean | undefined>
+  jsonMode?: boolean
   print: (value: unknown) => void
 }
 
@@ -65,11 +66,12 @@ const SIGNUP_COMMAND: PluginCommand = {
   ],
   async run(context) {
     const baseUrl = resolveBaseUrlFromFlags(context.flags)
-    return runSignup(baseUrl, (msg) => context.print(msg), {
+    return runSignup(baseUrl, context.print, {
       email: optionalStringFlag(context.flags, '--email'),
       code: optionalStringFlag(context.flags, '--code'),
       orgName: optionalStringFlag(context.flags, '--org-name'),
       requestOnly: context.flags['--request-only'] === true,
+      jsonMode: context.jsonMode === true,
     })
   },
 }

--- a/packages/plugin-obsessiondb/src/auth/signup.test.ts
+++ b/packages/plugin-obsessiondb/src/auth/signup.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 
-import { deriveOrgName, signupEmailRunbook, slugifyOrgName, verifyStepHint } from './signup'
+import { noEmailEnvelope } from '../json-envelope'
+import { deriveOrgName, runSignup, signupEmailRunbook, slugifyOrgName, verifyStepHint } from './signup'
 
 describe('deriveOrgName', () => {
   test('uses the lowercased email local-part', () => {
@@ -61,5 +62,34 @@ describe('verifyStepHint', () => {
     const text = verifyStepHint('me@x.com').join('\n')
     expect(text).toContain('chkit obsessiondb signup --email me@x.com --code <CODE>')
     expect(text).toContain('chkit obsessiondb service claim')
+  })
+})
+
+// The no-email, non-interactive branch returns before any network call, so it is the one
+// runSignup state we can exercise without a live API. Force non-TTY to make the path deterministic.
+describe('runSignup with no email (non-interactive)', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY
+  })
+
+  test('jsonMode emits a single no_email envelope and exits non-zero', async () => {
+    process.stdin.isTTY = false
+    const emitted: unknown[] = []
+    const code = await runSignup('https://api.test.com', (v) => emitted.push(v), { jsonMode: true })
+
+    expect(code).toBe(1)
+    expect(emitted).toEqual([noEmailEnvelope()])
+  })
+
+  test('prose mode prints the two-step runbook and exits non-zero', async () => {
+    process.stdin.isTTY = false
+    const emitted: unknown[] = []
+    const code = await runSignup('https://api.test.com', (v) => emitted.push(v))
+
+    expect(code).toBe(1)
+    expect(emitted).toHaveLength(1)
+    expect(String(emitted[0])).toContain('chkit obsessiondb signup --email <you@example.com>')
   })
 })

--- a/packages/plugin-obsessiondb/src/auth/signup.ts
+++ b/packages/plugin-obsessiondb/src/auth/signup.ts
@@ -2,6 +2,15 @@ import process from 'node:process'
 import { cancel, isCancel, text } from '@clack/prompts'
 
 import {
+  CLAIM_COMMAND,
+  errorEnvelope,
+  noEmailEnvelope,
+  otpSentEnvelope,
+  SIGNUP_EMAIL_COMMAND,
+  verifiedEnvelope,
+  verifyCodeCommand,
+} from '../json-envelope.js'
+import {
   createOrganization,
   getSession,
   OtpRateLimitError,
@@ -20,6 +29,8 @@ export interface SignupOptions {
   orgName?: string
   /** Only send the OTP and print the follow-up command, then stop (step 1 of the 2-step flow). */
   requestOnly?: boolean
+  /** Emit a structured `--json` envelope at each state instead of the prose runbook. */
+  jsonMode?: boolean
 }
 
 /**
@@ -33,14 +44,16 @@ export interface SignupOptions {
  *    lives server-side keyed by email, so nothing has to persist on the client between runs.
  *  - Scripted/test: pass `--email` and `--code` together; the code's presence skips the re-send.
  *
- * TODO: structured --json `next`/`needs` envelope so callers can chain without parsing prose.
+ * With `jsonMode`, each terminal/pause state emits a structured `{ status, next }` envelope
+ * (see json-envelope.ts) instead of prose, so a `--json` pipe stays valid.
  */
 export async function runSignup(
   baseUrl: string,
-  print: (msg: string) => void,
+  print: (value: unknown) => void,
   options: SignupOptions = {},
 ): Promise<number> {
-  const email = options.email ?? (await promptEmail(print))
+  const jsonMode = options.jsonMode === true
+  const email = options.email ?? (await promptEmail(print, jsonMode))
   if (email === null) return 1
 
   // A supplied code means this is the verify step of a prior request — re-sending would
@@ -50,22 +63,24 @@ export async function runSignup(
       await sendVerificationOtp(baseUrl, email)
     } catch (error) {
       if (error instanceof OtpRateLimitError) {
-        print(error.message)
+        if (jsonMode) print(errorEnvelope('obsessiondb signup', 'otp_rate_limited', error.message))
+        else print(error.message)
         return 1
       }
       throw error
     }
-    print(`We sent a 6-digit code to ${email}.`)
+    if (!jsonMode) print(`We sent a 6-digit code to ${email}.`)
 
     // No way to prompt for the code in this process (explicit --request-only, or no TTY).
     // Hand the caller the exact follow-up command and stop — the send already succeeded.
     if (options.requestOnly || !process.stdin.isTTY) {
-      print(verifyStepHint(email).join('\n'))
+      if (jsonMode) print(otpSentEnvelope(email))
+      else print(verifyStepHint(email).join('\n'))
       return 0
     }
   }
 
-  const code = options.code ?? (await promptCode(print))
+  const code = options.code ?? (await promptCode(print, jsonMode))
   if (code === null) return 1
 
   const { token, user } = await verifyOtp(baseUrl, email, code)
@@ -75,7 +90,9 @@ export async function runSignup(
     email,
     orgName: options.orgName,
   })
-  if (created) {
+  if (jsonMode) {
+    print(verifiedEnvelope(email))
+  } else if (created) {
     print(`Created organization "${created}".`)
     print(`Signed in as ${user.email}.`)
   } else {
@@ -108,23 +125,24 @@ async function ensureActiveOrganization(
 export function signupEmailRunbook(): string[] {
   return [
     'No email provided. In non-interactive environments, sign up in two steps:',
-    '  1. chkit obsessiondb signup --email <you@example.com>          # sends a 6-digit code',
-    '  2. chkit obsessiondb signup --email <you@example.com> --code <CODE>   # verifies and signs in',
-    'Then claim a service: chkit obsessiondb service claim',
+    `  1. ${SIGNUP_EMAIL_COMMAND}          # sends a 6-digit code`,
+    `  2. ${verifyCodeCommand('<you@example.com>')}   # verifies and signs in`,
+    `Then claim a service: ${CLAIM_COMMAND}`,
   ]
 }
 
 /** Follow-up commands shown after a code has been sent to `email` (the verify step). */
 export function verifyStepHint(email: string): string[] {
-  return [
-    `Next: chkit obsessiondb signup --email ${email} --code <CODE>`,
-    'Then: chkit obsessiondb service claim',
-  ]
+  return [`Next: ${verifyCodeCommand(email)}`, `Then: ${CLAIM_COMMAND}`]
 }
 
-async function promptEmail(print: (msg: string) => void): Promise<string | null> {
+async function promptEmail(
+  print: (value: unknown) => void,
+  jsonMode: boolean,
+): Promise<string | null> {
   if (!process.stdin.isTTY) {
-    print(signupEmailRunbook().join('\n'))
+    if (jsonMode) print(noEmailEnvelope())
+    else print(signupEmailRunbook().join('\n'))
     return null
   }
   const value = await text({
@@ -138,9 +156,16 @@ async function promptEmail(print: (msg: string) => void): Promise<string | null>
   return value.trim()
 }
 
-async function promptCode(print: (msg: string) => void): Promise<string | null> {
+async function promptCode(
+  print: (value: unknown) => void,
+  jsonMode: boolean,
+): Promise<string | null> {
   if (!process.stdin.isTTY) {
-    print('No code provided. Re-run with --code <code> in non-interactive environments.')
+    if (jsonMode) {
+      print(errorEnvelope('obsessiondb signup', 'code_required', 'No code provided. Re-run with --code <code>.'))
+    } else {
+      print('No code provided. Re-run with --code <code> in non-interactive environments.')
+    }
     return null
   }
   const value = await text({

--- a/packages/plugin-obsessiondb/src/json-envelope.test.ts
+++ b/packages/plugin-obsessiondb/src/json-envelope.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  alreadyClaimedEnvelope,
+  CLAIM_COMMAND,
+  claimedEnvelope,
+  errorEnvelope,
+  JSON_CONTRACT_VERSION,
+  noEmailEnvelope,
+  otpSentEnvelope,
+  provisioningEnvelope,
+  SERVICE_SELECT_COMMAND,
+  SIGNUP_EMAIL_COMMAND,
+  verifiedEnvelope,
+  verifyCodeCommand,
+} from './json-envelope'
+
+describe('signup envelopes', () => {
+  test('no_email points the caller at the request-a-code command', () => {
+    expect(noEmailEnvelope()).toEqual({
+      command: 'obsessiondb signup',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      status: 'no_email',
+      next: { needs: 'email', command: SIGNUP_EMAIL_COMMAND },
+    })
+  })
+
+  test('otp_sent carries the email and the exact verify command', () => {
+    expect(otpSentEnvelope('me@x.com')).toEqual({
+      command: 'obsessiondb signup',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      status: 'otp_sent',
+      email: 'me@x.com',
+      next: { needs: 'code', command: 'chkit obsessiondb signup --email me@x.com --code <CODE>' },
+    })
+  })
+
+  test('verified points the caller at claim', () => {
+    expect(verifiedEnvelope('me@x.com')).toEqual({
+      command: 'obsessiondb signup',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      status: 'verified',
+      email: 'me@x.com',
+      next: { needs: 'claim', command: CLAIM_COMMAND },
+    })
+  })
+})
+
+describe('claim envelopes', () => {
+  test('claimed includes the selected service and is terminal (next null)', () => {
+    expect(claimedEnvelope({ service_slug: 'free-abc', service_name: 'free-abc' })).toEqual({
+      command: 'obsessiondb service claim',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      status: 'claimed',
+      service: { service_slug: 'free-abc', service_name: 'free-abc' },
+      next: null,
+    })
+  })
+
+  test('provisioning points the caller at service select', () => {
+    expect(provisioningEnvelope()).toEqual({
+      command: 'obsessiondb service claim',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      status: 'provisioning',
+      next: { needs: 'select', command: SERVICE_SELECT_COMMAND },
+    })
+  })
+
+  test('already_claimed points the caller at service select', () => {
+    expect(alreadyClaimedEnvelope()).toEqual({
+      command: 'obsessiondb service claim',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      status: 'already_claimed',
+      next: { needs: 'select', command: SERVICE_SELECT_COMMAND },
+    })
+  })
+})
+
+describe('errorEnvelope', () => {
+  test('emits a stable ok:false shape for failure states', () => {
+    expect(errorEnvelope('obsessiondb service claim', 'none_available', 'No capacity.')).toEqual({
+      command: 'obsessiondb service claim',
+      schemaVersion: JSON_CONTRACT_VERSION,
+      ok: false,
+      error: { code: 'none_available', message: 'No capacity.' },
+    })
+  })
+})
+
+describe('command strings', () => {
+  test('verifyCodeCommand embeds the email so the caller can paste the code', () => {
+    expect(verifyCodeCommand('a@b.com')).toBe('chkit obsessiondb signup --email a@b.com --code <CODE>')
+  })
+})

--- a/packages/plugin-obsessiondb/src/json-envelope.ts
+++ b/packages/plugin-obsessiondb/src/json-envelope.ts
@@ -1,0 +1,108 @@
+import type { SelectedService } from './service/types.js'
+
+/**
+ * Schema version for obsessiondb `--json` envelopes. Mirrors the CLI's JSON contract version
+ * (`packages/cli/src/runtime/json-output.ts`); duplicated rather than imported because the CLI
+ * depends on this package, not the other way around.
+ */
+export const JSON_CONTRACT_VERSION = 1
+
+// --- Next-step command strings -------------------------------------------------------------
+// Single source for the commands a non-interactive caller runs next, shared by both the prose
+// runbooks (auth/signup.ts) and the JSON envelopes below so the two can never drift.
+
+/** Step 1 of the non-interactive signup: request a code (placeholder email until one is known). */
+export const SIGNUP_EMAIL_COMMAND = 'chkit obsessiondb signup --email <you@example.com>'
+/** Claim a free dev instance after signing in. */
+export const CLAIM_COMMAND = 'chkit obsessiondb service claim'
+/** Pick an instance once one exists / finishes provisioning. */
+export const SERVICE_SELECT_COMMAND = 'chkit obsessiondb service select'
+
+/** Step 2 of the non-interactive signup: verify the emailed code for a known email. */
+export function verifyCodeCommand(email: string): string {
+  return `chkit obsessiondb signup --email ${email} --code <CODE>`
+}
+
+// --- Envelope shape ------------------------------------------------------------------------
+
+const SIGNUP_COMMAND_ID = 'obsessiondb signup'
+const CLAIM_COMMAND_ID = 'obsessiondb service claim'
+
+/** Machine-readable hint telling a non-interactive caller what to run next. */
+export interface NextAction {
+  /** The input the next step needs, e.g. "email", "code", "claim", "select". */
+  needs: string
+  /** The exact command to run next. */
+  command: string
+}
+
+/** Structured `--json` envelope for the linear signup → claim flow. `next` is null at a terminal state. */
+export interface NextEnvelope {
+  command: string
+  schemaVersion: number
+  status: string
+  email?: string
+  service?: SelectedService
+  next: NextAction | null
+}
+
+/** Stable error envelope mirroring the CLI's `JsonErrorEnvelope` for `--json` consumers. */
+export interface ErrorEnvelope {
+  command: string
+  schemaVersion: number
+  ok: false
+  error: { code: string; message: string }
+}
+
+// --- Builders (one per emitted state) ------------------------------------------------------
+
+/** signup with no email in a non-interactive run: the caller must supply `--email` to start. */
+export function noEmailEnvelope(): NextEnvelope {
+  return envelope(SIGNUP_COMMAND_ID, 'no_email', { needs: 'email', command: SIGNUP_EMAIL_COMMAND })
+}
+
+/** signup `--email` sent a code and paused: the caller must re-run with `--code`. */
+export function otpSentEnvelope(email: string): NextEnvelope {
+  return envelope(SIGNUP_COMMAND_ID, 'otp_sent', { needs: 'code', command: verifyCodeCommand(email) }, { email })
+}
+
+/** signup verified and signed in: the caller can now claim an instance. */
+export function verifiedEnvelope(email: string): NextEnvelope {
+  return envelope(SIGNUP_COMMAND_ID, 'verified', { needs: 'claim', command: CLAIM_COMMAND }, { email })
+}
+
+/** claim succeeded and the instance is running: terminal, no next action. */
+export function claimedEnvelope(service: SelectedService): NextEnvelope {
+  return envelope(CLAIM_COMMAND_ID, 'claimed', null, { service })
+}
+
+/** claim started but the instance is still provisioning: the caller should select it once ready. */
+export function provisioningEnvelope(): NextEnvelope {
+  return envelope(CLAIM_COMMAND_ID, 'provisioning', { needs: 'select', command: SERVICE_SELECT_COMMAND })
+}
+
+/** The org already has an instance: the caller should select one rather than claim. */
+export function alreadyClaimedEnvelope(): NextEnvelope {
+  return envelope(CLAIM_COMMAND_ID, 'already_claimed', { needs: 'select', command: SERVICE_SELECT_COMMAND })
+}
+
+/** Terminal failure (e.g. no capacity, rate limit): a `--json` pipe stays valid. */
+export function errorEnvelope(command: string, code: string, message: string): ErrorEnvelope {
+  return { command, schemaVersion: JSON_CONTRACT_VERSION, ok: false, error: { code, message } }
+}
+
+function envelope(
+  command: string,
+  status: string,
+  next: NextAction | null,
+  extra?: { email?: string; service?: SelectedService },
+): NextEnvelope {
+  return {
+    command,
+    schemaVersion: JSON_CONTRACT_VERSION,
+    status,
+    ...(extra?.email !== undefined ? { email: extra.email } : {}),
+    ...(extra?.service !== undefined ? { service: extra.service } : {}),
+    next,
+  }
+}

--- a/packages/plugin-obsessiondb/src/onboarding/index.ts
+++ b/packages/plugin-obsessiondb/src/onboarding/index.ts
@@ -28,7 +28,7 @@ export interface OnboardingOptions {
  * Never throws for the "configure later" path; degrades to next-steps when non-interactive.
  */
 export async function runOnboarding(options: OnboardingOptions): Promise<void> {
-  const print = (msg: string) => log.message(msg)
+  const print = (value: unknown) => log.message(typeof value === 'string' ? value : JSON.stringify(value))
 
   // Non-interactive with no explicit choice: we can't show the menu, so instead of silently
   // deferring, hand the caller the full runbook for every connect path before next steps.
@@ -165,7 +165,12 @@ function insertImport(source: string, importLine: string): string {
  * menu walks a human through these; without a TTY we hand the caller every path as explicit
  * commands so they can finish without reverse-engineering the CLI.
  *
- * TODO: structured --json `next`/`needs` envelope so callers can chain without parsing prose.
+ * NUM-7392 added the structured `--json` `next` envelope to the linear, chainable flow
+ * (`signup` → `service claim`; see json-envelope.ts). This connect menu intentionally keeps its
+ * prose runbook: it's a 3-way choice (not a single `next`), it has no `--json` plumbing here
+ * (`init` doesn't thread `jsonMode` into onboarding), and it emits via clack's `log.message`
+ * rather than clean stdout — so a JSON envelope would cost disproportionate plumbing for no real
+ * chaining benefit. The per-command JSON envelopes above are what programmatic callers consume.
  */
 export function connectRunbookLines(): string[] {
   return [

--- a/packages/plugin-obsessiondb/src/service/claim.test.ts
+++ b/packages/plugin-obsessiondb/src/service/claim.test.ts
@@ -4,6 +4,12 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'bun:test'
 
 import type { ApiClient } from '../client'
+import {
+  alreadyClaimedEnvelope,
+  claimedEnvelope,
+  errorEnvelope,
+  provisioningEnvelope,
+} from '../json-envelope'
 import { claimInstanceFlow } from './claim'
 
 const RUNNING_SERVICE = {
@@ -91,5 +97,79 @@ describe('claimInstanceFlow', () => {
     expect(claimCalled).toBe(false)
     expect(code).toBe(1)
     expect(messages.some((m) => m.includes('already have a free instance'))).toBe(true)
+  })
+})
+
+describe('claimInstanceFlow with --json', () => {
+  test('emits a single claimed envelope with the saved service and next:null', async () => {
+    const configPath = await tempConfigPath()
+    const emitted: unknown[] = []
+    const client = fakeClient({
+      instanceClaimStatus: async () => ({ eligible: true }),
+      claimInstance: async () => ({ outcome: 'claimed', id: 'svc-1', slug: 'free-abc' }),
+      get: async () => RUNNING_SERVICE,
+    })
+
+    const code = await claimInstanceFlow(client, configPath, (v) => emitted.push(v), true)
+
+    expect(code).toBe(0)
+    expect(emitted).toEqual([
+      claimedEnvelope({ service_slug: 'free-abc', service_name: 'free-abc' }),
+    ])
+  })
+
+  test('emits an already_claimed envelope and skips the interactive picker when not eligible', async () => {
+    const configPath = await tempConfigPath()
+    const emitted: unknown[] = []
+    let listCalled = false
+    const client = fakeClient({
+      instanceClaimStatus: async () => ({ eligible: false, claimedOrganizationName: 'marc' }),
+      listAll: async () => {
+        listCalled = true
+        return { organizations: [] }
+      },
+    })
+
+    const code = await claimInstanceFlow(client, configPath, (v) => emitted.push(v), true)
+
+    expect(listCalled).toBe(false)
+    expect(code).toBe(0)
+    expect(emitted).toEqual([alreadyClaimedEnvelope()])
+  })
+
+  test('emits an ok:false error envelope when the pool is empty', async () => {
+    const configPath = await tempConfigPath()
+    const emitted: unknown[] = []
+    const client = fakeClient({
+      instanceClaimStatus: async () => ({ eligible: true }),
+      claimInstance: async () => ({ outcome: 'none_available' }),
+    })
+
+    const code = await claimInstanceFlow(client, configPath, (v) => emitted.push(v), true)
+
+    expect(code).toBe(1)
+    expect(emitted).toEqual([
+      errorEnvelope(
+        'obsessiondb service claim',
+        'none_available',
+        'No free dev instances are available right now. We have been notified — please try again later.',
+      ),
+    ])
+  })
+
+  test('emits a provisioning envelope when the instance never reaches running', async () => {
+    const configPath = await tempConfigPath()
+    const emitted: unknown[] = []
+    const client = fakeClient({
+      instanceClaimStatus: async () => ({ eligible: true }),
+      claimInstance: async () => ({ outcome: 'claimed', id: 'svc-1', slug: 'free-abc' }),
+      // An 'error' status ends the poll immediately with no running service.
+      get: async () => ({ ...RUNNING_SERVICE, status: 'error' }),
+    })
+
+    const code = await claimInstanceFlow(client, configPath, (v) => emitted.push(v), true)
+
+    expect(code).toBe(1)
+    expect(emitted).toEqual([provisioningEnvelope()])
   })
 })

--- a/packages/plugin-obsessiondb/src/service/claim.ts
+++ b/packages/plugin-obsessiondb/src/service/claim.ts
@@ -3,74 +3,98 @@ import { setTimeout as sleep } from 'node:timers/promises'
 import type { Credentials } from '../auth/index.js'
 import type { ApiClient } from '../client.js'
 import { createApiClient } from '../client.js'
+import {
+  alreadyClaimedEnvelope,
+  claimedEnvelope,
+  errorEnvelope,
+  provisioningEnvelope,
+} from '../json-envelope.js'
 import { selectServiceInteractive, serviceChoiceLabel } from './select.js'
 import { saveSelectedService } from './storage.js'
 import type { Service } from './types.js'
 
 const POLL_INTERVAL_MS = 3_000
 const POLL_TIMEOUT_MS = 5 * 60 * 1_000
+const CLAIM_COMMAND_ID = 'obsessiondb service claim'
 
 /**
  * Claim a free ObsessionDB dev instance for the active org, wait for it to provision,
  * and persist it as the project's selected service.
+ *
+ * With `jsonMode`, each terminal state emits a structured `--json` envelope instead of prose,
+ * and the already-claimed paths return a `service select` hint rather than dropping into the
+ * interactive picker (which can't run without a TTY).
  */
 export async function runClaim(
   creds: Credentials,
   configPath: string,
-  print: (msg: string) => void,
+  print: (value: unknown) => void,
+  jsonMode = false,
 ): Promise<number> {
-  return claimInstanceFlow(createApiClient(creds), configPath, print)
+  return claimInstanceFlow(createApiClient(creds), configPath, print, jsonMode)
 }
 
 /** Claim flow against an injected client — the unit-testable core of {@link runClaim}. */
 export async function claimInstanceFlow(
   client: ApiClient,
   configPath: string,
-  print: (msg: string) => void,
+  print: (value: unknown) => void,
+  jsonMode = false,
 ): Promise<number> {
   const status = await client.services.instanceClaimStatus({})
   if (!status.eligible) {
+    if (jsonMode) {
+      print(alreadyClaimedEnvelope())
+      return 0
+    }
     print(`You already have a free instance in organization "${status.claimedOrganizationName}".`)
     return selectExistingInstance(client, configPath, print)
   }
 
   const result = await client.services.claimInstance({})
   if (result.outcome === 'none_available') {
-    print('No free dev instances are available right now. We have been notified — please try again later.')
+    const message = 'No free dev instances are available right now. We have been notified — please try again later.'
+    if (jsonMode) print(errorEnvelope(CLAIM_COMMAND_ID, 'none_available', message))
+    else print(message)
     return 1
   }
   if (result.outcome === 'already_claimed') {
+    if (jsonMode) {
+      print(alreadyClaimedEnvelope())
+      return 0
+    }
     print(`You already have a free instance in organization "${result.claimedOrganizationName}".`)
     return selectExistingInstance(client, configPath, print)
   }
 
-  print(`Claimed a free instance (${result.slug}). Provisioning — this can take a minute…`)
+  if (!jsonMode) print(`Claimed a free instance (${result.slug}). Provisioning — this can take a minute…`)
 
-  const service = await pollUntilRunning(client, result.slug, print)
+  const service = await pollUntilRunning(client, result.slug, print, jsonMode)
   if (!service) {
-    print('Instance is still provisioning. Run `chkit obsessiondb service select` once it is ready.')
+    if (jsonMode) print(provisioningEnvelope())
+    else print('Instance is still provisioning. Run `chkit obsessiondb service select` once it is ready.')
     return 1
   }
 
-  await saveSelectedService(configPath, {
-    service_slug: service.slug,
-    service_name: service.name,
-  })
-  print(`Instance ready: ${service.name} (${service.slug}).`)
+  const selected = { service_slug: service.slug, service_name: service.name }
+  await saveSelectedService(configPath, selected)
+  if (jsonMode) print(claimedEnvelope(selected))
+  else print(`Instance ready: ${service.name} (${service.slug}).`)
   return 0
 }
 
 async function pollUntilRunning(
   client: ApiClient,
   slug: string,
-  print: (msg: string) => void,
+  print: (value: unknown) => void,
+  jsonMode: boolean,
 ): Promise<Service | null> {
   const deadline = Date.now() + POLL_TIMEOUT_MS
   while (Date.now() < deadline) {
     const service = await client.services.get({ serviceSlug: slug })
     if (service.status === 'running') return service
     if (service.status === 'error' || service.status === 'terminated') {
-      print(`Provisioning failed — instance entered status "${service.status}".`)
+      if (!jsonMode) print(`Provisioning failed — instance entered status "${service.status}".`)
       return null
     }
     await sleep(POLL_INTERVAL_MS)
@@ -81,7 +105,7 @@ async function pollUntilRunning(
 async function selectExistingInstance(
   client: ApiClient,
   configPath: string,
-  print: (msg: string) => void,
+  print: (value: unknown) => void,
 ): Promise<number> {
   const { organizations } = await client.services.listAll({})
   const selected = await selectServiceInteractive(organizations, print)

--- a/packages/plugin-obsessiondb/src/service/commands.ts
+++ b/packages/plugin-obsessiondb/src/service/commands.ts
@@ -1,4 +1,5 @@
 import { loadCredentials, resolveBaseUrl } from '../auth/index.js'
+import { errorEnvelope } from '../json-envelope.js'
 import { listServiceOrganizations, listServices } from './api.js'
 import { runClaim } from './claim.js'
 import {
@@ -18,6 +19,7 @@ interface PluginCommandContext {
 	configPath: string
 	args: string[]
 	flags: Record<string, string | string[] | boolean | undefined>
+	jsonMode?: boolean
 	print: (value: unknown) => void
 }
 
@@ -111,9 +113,20 @@ export const SERVICE_COMMAND: PluginCommand = {
 		}
 
 		if (action === 'claim') {
-			const effectiveCreds = await loadEffectiveCredentials(print)
-			if (!effectiveCreds) return 1
-			return runClaim(effectiveCreds, context.configPath, print)
+			// Inline the credential check (rather than loadEffectiveCredentials) so a `--json` run
+			// emits a single error envelope instead of stringified prose on the not-logged-in path.
+			const creds = await loadCredentials()
+			if (!creds) {
+				const message = 'Not logged in. Run `chkit obsessiondb login` to authenticate.'
+				if (context.jsonMode) {
+					context.print(errorEnvelope('obsessiondb service claim', 'not_logged_in', message))
+				} else {
+					print(message)
+				}
+				return 1
+			}
+			const effectiveCreds = { ...creds, base_url: resolveBaseUrl(creds.base_url) }
+			return runClaim(effectiveCreds, context.configPath, context.print, context.jsonMode === true)
 		}
 
 		if (action === 'alias') {


### PR DESCRIPTION
## Summary

Closes NUM-7392. Honors `--json` on `chkit obsessiondb signup` and `service claim` so non-interactive callers (agents/CI) can chain the auth flow without scraping prose from stderr — previously these commands printed human runbooks even under `--json`, breaking any `| jq`.

- New `packages/plugin-obsessiondb/src/json-envelope.ts` — envelope type + one pure builder per state. The next-step command strings live here as a single source shared by both the prose runbooks and the JSON envelopes so they can't drift.
- `signup` and `service claim` emit a single `{ command, schemaVersion, status, next }` object at each terminal/pause state via the already-json-aware `print` channel; `next.command` carries the exact follow-up command (`next: null` at a terminal state). Failures emit an `ok:false` error envelope.
- States: `no_email → otp_sent → verified` (signup); `claimed` / `provisioning` / `already_claimed` (claim). In `--json` mode the already-claimed paths return a `service select` hint instead of dropping into the interactive picker.
- **Scoped down from the ticket on purpose:** no state-machine module (statuses are derived inline for a linear flow), and onboarding's 3-way connect menu keeps its prose runbook (no `--json` plumbing, wrong output channel — see the comment at `onboarding/index.ts`). Text-mode output is byte-for-byte unchanged.
- Docs: new "Structured JSON for agents" section in `obsessiondb/getting-started.md`. Changeset: `patch` for `@chkit/plugin-obsessiondb`.

## Test plan

- [x] `bun verify` green (typecheck + lint + full live e2e suite + build; 37/37 tasks).
- [x] Unit tests for every emitted state: envelope builders (`json-envelope.test.ts`), `runSignup` no-email JSON/prose branches, `claimInstanceFlow` JSON branches (claimed / already_claimed / none_available / provisioning).
- [x] **Real end-to-end** against live `console-api.obsessiondb.com` with OTP delivered to a real inbox: `otp_sent` → `verified` (credentials persisted) → `claimed` (instance provisioned) → re-run `already_claimed` (no TTY hang), and `signup --json | jq -r '.next.command'` extracted cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)