### PR TITLE
docs: agent onboarding page, llms.txt, and clean .md URLs

### DIFF
--- a/.claude/skills/documentation-authoring/SKILL.md
+++ b/.claude/skills/documentation-authoring/SKILL.md
@@ -216,11 +216,11 @@ After every documentation change, always run this checklist:
 2. **Confirm build succeeds** without errors.
 
 3. **Check integration output** in the build log:
-   - Raw-markdown integration: `Copied N markdown files to _raw/`
-   - Sitemap generation: `Generated index.md with N pages`
+   - Raw-markdown integration: `Wrote N raw Markdown pages to _raw/`
+   - Index generation: `Generated _raw/index.md and llms.txt with N pages`
    - Verify N matches the expected file count after your change.
 
-4. **Review the sitemap** — Read `apps/docs/dist/_raw/index.md` and verify:
+4. **Review the sitemap** — Read `apps/docs/dist/_raw/index.md` (and `apps/docs/dist/llms.txt`) and verify:
    - New pages appear with correct title, description, and URL path.
    - Deleted pages no longer appear.
    - Modified titles/descriptions are reflected.
@@ -229,4 +229,10 @@ After every documentation change, always run this checklist:
 
 ## Agent discoverability
 
-The site supports `Accept: text/markdown` content negotiation. A build-time integration (`apps/docs/src/integrations/raw-markdown.ts`) copies every doc file into `dist/_raw/` and generates a sitemap at `dist/_raw/index.md`. The sitemap is auto-generated from frontmatter — there is no hand-maintained index file. This enables AI agents to discover and read documentation programmatically.
+A build-time integration (`apps/docs/src/integrations/raw-markdown.ts`) makes every doc page available to AI agents three ways, all auto-generated from frontmatter (no hand-maintained index):
+
+- **Clean `.md` URLs** — append `.md` to any page URL (e.g. `/ai-agents.md`, `/cli/migrate.md`) to get its raw Markdown directly, no headers needed. The Cloudflare Pages Function in `apps/docs/functions/_middleware.ts` rewrites these to the raw files under `dist/_raw/`.
+- **Content negotiation** — request any page URL with `Accept: text/markdown` to get the Markdown version of the same path.
+- **`/llms.txt`** — an [llms.txt](https://llmstxt.org/)-format index at the site root listing every page and linking to its `.md` URL. A full sitemap also lives at `/_raw/index.md`.
+
+When adding, removing, or renaming a page, all three update automatically on the next build — no manual edits required.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
 				}),
 			],
 			components: {
+				Head: './src/components/Head.astro',
 				Header: './src/components/Header.astro',
 				Hero: './src/components/Hero.astro',
 				Footer: './src/components/Footer.astro',
@@ -46,6 +47,10 @@ export default defineConfig({
 				ThemeSelect: './src/components/ThemeSelect.astro',
 			},
 			sidebar: [
+				{
+					label: 'For AI Agents',
+					link: '/ai-agents/',
+				},
 				{
 					label: 'Getting Started',
 					items: [

--- a/apps/docs/functions/_middleware.ts
+++ b/apps/docs/functions/_middleware.ts
@@ -1,30 +1,35 @@
 export const onRequest: PagesFunction<{ ASSETS: Fetcher }> = async (context) => {
+	const url = new URL(context.request.url);
+
+	// Serve the raw Markdown asset behind /_raw/ as text/markdown.
+	async function serveRaw(slug: string): Promise<Response | null> {
+		const assetUrl = new URL(`/_raw/${slug}.md`, url.origin);
+		const asset = await context.env.ASSETS.fetch(assetUrl.toString());
+		if (!asset.ok) return null;
+		return new Response(asset.body, {
+			status: 200,
+			headers: {
+				'Content-Type': 'text/markdown; charset=utf-8',
+				'Vary': 'Accept',
+			},
+		});
+	}
+
+	// 1. Explicit ".md" URL (e.g. /ai-agents.md) — serve raw Markdown directly,
+	//    no Accept header required. Skip assets already under /_raw/.
+	if (url.pathname.endsWith('.md') && !url.pathname.startsWith('/_raw/')) {
+		const slug = url.pathname.replace(/^\//, '').replace(/\.md$/, '');
+		const raw = await serveRaw(slug);
+		if (raw) return raw;
+	}
+
+	// 2. Content negotiation — same HTML URL, served as Markdown when the
+	//    client explicitly asks for it. Ignore Accept: */* so browsers get HTML.
 	const accept = context.request.headers.get('Accept') ?? '';
-
-	// Only negotiate when the client explicitly asks for markdown.
-	// Ignore Accept: */* to avoid breaking browsers.
 	if (accept.includes('text/markdown') && !accept.startsWith('*/*')) {
-		const url = new URL(context.request.url);
-
-		// Normalise path: strip trailing slash, default to index
-		let slug = url.pathname.replace(/\/$/, '') || '/index';
-		slug = slug.replace(/^\//, '');
-
-		// Try .md first, fall back to .mdx
-		for (const ext of ['.md', '.mdx']) {
-			const assetUrl = new URL(`/_raw/${slug}${ext}`, url.origin);
-			const asset = await context.env.ASSETS.fetch(assetUrl.toString());
-
-			if (asset.ok) {
-				return new Response(asset.body, {
-					status: 200,
-					headers: {
-						'Content-Type': 'text/markdown; charset=utf-8',
-						'Vary': 'Accept',
-					},
-				});
-			}
-		}
+		const slug = (url.pathname.replace(/\/$/, '') || '/index').replace(/^\//, '');
+		const raw = await serveRaw(slug);
+		if (raw) return raw;
 	}
 
 	const response = await context.next();

--- a/apps/docs/src/components/CopyPromptButton.astro
+++ b/apps/docs/src/components/CopyPromptButton.astro
@@ -1,0 +1,107 @@
+---
+interface Props {
+	prompt: string;
+	label?: string;
+}
+
+const { prompt, label = 'Copy setup prompt' } = Astro.props;
+---
+
+<div class="copy-prompt" data-copy-prompt>
+	<button type="button" class="copy-prompt-btn" data-prompt={prompt}>
+		<svg
+			width="15"
+			height="15"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<rect x="9" y="9" width="13" height="13" rx="2"></rect>
+			<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+		</svg>
+		<span class="copy-prompt-btn-label" data-default-label={label}>{label}</span>
+	</button>
+	<pre class="copy-prompt-text"><code>{prompt}</code></pre>
+</div>
+
+<style>
+	.copy-prompt {
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.5rem;
+		overflow: hidden;
+		margin: 1rem 0 1.5rem;
+	}
+
+	.copy-prompt-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		border: 0;
+		border-bottom: 1px solid var(--sl-color-gray-5);
+		background: var(--sl-color-gray-6, transparent);
+		color: var(--txt-strong);
+		cursor: pointer;
+		padding: 0.7rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		transition: background-color 120ms ease, color 120ms ease;
+	}
+
+	.copy-prompt-btn:hover {
+		background: rgba(255, 255, 255, 0.06);
+	}
+
+	.copy-prompt-btn.is-copied {
+		color: var(--accent);
+	}
+
+	.copy-prompt-text {
+		background: transparent !important;
+		border: 0 !important;
+		border-radius: 0 !important;
+		margin: 0;
+		padding: 0.85rem 1rem;
+		overflow-x: auto;
+	}
+
+	.copy-prompt-text code {
+		background: transparent;
+		color: var(--cmd-text);
+		font-family: var(--sl-font-mono);
+		font-size: 0.8125rem;
+		line-height: 1.6;
+		white-space: pre-wrap;
+	}
+</style>
+
+<script>
+	function init() {
+		document.querySelectorAll<HTMLButtonElement>('[data-copy-prompt] .copy-prompt-btn').forEach((button) => {
+			button.addEventListener('click', () => {
+				const text = button.dataset.prompt;
+				if (!text) return;
+				void navigator.clipboard.writeText(text).then(() => {
+					const label = button.querySelector<HTMLElement>('.copy-prompt-btn-label');
+					const original = label?.dataset.defaultLabel ?? '';
+					button.classList.add('is-copied');
+					if (label) label.textContent = 'Copied to clipboard';
+					setTimeout(() => {
+						button.classList.remove('is-copied');
+						if (label) label.textContent = original;
+					}, 1400);
+				});
+			});
+		});
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+</script>

--- a/apps/docs/src/components/Head.astro
+++ b/apps/docs/src/components/Head.astro
@@ -1,12 +1,21 @@
 ---
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import Default from '@astrojs/starlight/components/Head.astro';
 
 // Advertise the raw-Markdown version of this page so agents and crawlers can
-// discover it from the HTML. The href mirrors how functions/_middleware.ts
-// resolves ".md" URLs: derive it from the pathname. The homepage has no
-// Markdown page, so point it at the llms.txt index instead.
-const path = Astro.url.pathname.replace(/\/$/, '');
-const mdHref = path === '' ? '/llms.txt' : `${path}.md`;
+// discover it from the HTML. The raw-markdown integration writes one .md per
+// source doc under src/content/docs, and the middleware resolves "<path>.md"
+// by URL pathname — so the href is derived from the pathname.
+//
+// Only emit a page-specific alternate when the source doc actually exists.
+// Generated routes carry a synthesized filePath that points at a missing
+// source (e.g. the starlight-blog index claims src/content/docs/blog.md), and
+// the homepage has no per-page .md — both fall back to the llms.txt index.
+const { entry } = Astro.locals.starlightRoute;
+const slug = Astro.url.pathname.replace(/\/$/, '').replace(/^\//, '');
+const sourceExists = !!entry?.filePath && existsSync(join(process.cwd(), entry.filePath));
+const mdHref = slug !== '' && sourceExists ? `/${slug}.md` : '/llms.txt';
 ---
 
 <Default />

--- a/apps/docs/src/components/Head.astro
+++ b/apps/docs/src/components/Head.astro
@@ -1,0 +1,13 @@
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+
+// Advertise the raw-Markdown version of this page so agents and crawlers can
+// discover it from the HTML. The href mirrors how functions/_middleware.ts
+// resolves ".md" URLs: derive it from the pathname. The homepage has no
+// Markdown page, so point it at the llms.txt index instead.
+const path = Astro.url.pathname.replace(/\/$/, '');
+const mdHref = path === '' ? '/llms.txt' : `${path}.md`;
+---
+
+<Default />
+<link rel="alternate" type="text/markdown" href={mdHref} />

--- a/apps/docs/src/content/docs/ai-agents.md
+++ b/apps/docs/src/content/docs/ai-agents.md
@@ -1,0 +1,105 @@
+---
+title: For AI Agents
+description: How an AI coding agent should set up and operate chkit on a user's behalf.
+sidebar:
+  order: 0
+---
+
+This page is written for AI coding agents (Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, and others) tasked with adding ClickHouse schema management to a user's project. It tells you what to install, what to recommend, and what not to do unprompted.
+
+chkit is a ClickHouse schema and migration toolkit for TypeScript. Schemas are defined in TypeScript, diffed into migration SQL, applied to ClickHouse, and verified against the live database.
+
+## If a user asked you to set up chkit
+
+1. Install the [agent skill](#install-the-agent-skill) so you have the full command surface, schema DSL, and workflows in context.
+2. Run the [setup flow](#manual-setup) to scaffold config and produce the first migration.
+3. Pick plugins from the [decision table](#which-plugins-to-recommend) based on what the project needs.
+4. Read the [guardrails](#guardrails) before running anything that touches a live database.
+
+## Install the agent skill
+
+chkit ships an installable agent skill that teaches you its commands, schema DSL, and workflows. Install it first — it is the most reliable way to operate chkit correctly:
+
+```sh
+skills add obsessiondb/chkit
+```
+
+The skill installs into the project's agent directory (for example `.claude/skills/chkit/` or `.cursor/skills/chkit/`). On the first interactive `chkit init`, chkit also detects the active agent and offers to install the skill automatically.
+
+## Manual setup
+
+If the skill is unavailable, drive the setup directly. Install chkit as a dev dependency:
+
+```sh
+bun add -d chkit @chkit/core
+```
+
+Then run the standard flow:
+
+```sh
+chkit init        # scaffold clickhouse.config.ts + a starter schema (idempotent)
+chkit generate    # diff schema against the last snapshot → migration SQL
+chkit migrate     # plan pending migrations (no changes applied without --apply)
+chkit status      # report applied vs pending migrations
+chkit check       # CI gate: pending, checksums, drift, plugins
+```
+
+`chkit init` writes `clickhouse.config.ts` and `src/db/schema/example.ts`. Edit the example schema to match the table the user actually wants before running `generate`. A ClickHouse endpoint is needed via `CLICKHOUSE_URL` (optionally `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_DB`) before any command that talks to the database.
+
+## Which plugins to recommend
+
+Plugins are npm packages registered in the `plugins` array of `clickhouse.config.ts`. Recommend only what the project needs:
+
+| If the project needs to... | Recommend | Notes |
+|----------------------------|-----------|-------|
+| Adopt chkit on an **existing** ClickHouse database | [`@chkit/plugin-pull`](/plugins/pull/) | Introspects the live database into local schema files so the user starts from real tables, not a blank example. |
+| Generate **TypeScript types** (and optional Zod schemas) from the schema | [`@chkit/plugin-codegen`](/plugins/codegen/) | Keeps application row types in sync with the schema definitions. |
+| **Backfill** historical data into materialized views | [`@chkit/plugin-backfill`](/plugins/backfill/) | Time-windowed loads with checkpoints, for large or resumable backfills. |
+| Deploy to **ObsessionDB** | [`@chkit/plugin-obsessiondb`](/obsessiondb/overview/) | First-class ObsessionDB integration; rewrites `Shared` engines when targeting non-ObsessionDB ClickHouse. |
+
+When the project has none of these needs, the core CLI alone is enough — do not add plugins speculatively.
+
+## Guardrails
+
+chkit applies DDL to real databases. Treat the following as hard rules unless the user explicitly overrides them:
+
+:::caution
+- **`migrate` does not apply changes without `--apply`.** Run `chkit migrate` first to plan, show the user the pending SQL, and only then run `chkit migrate --apply`.
+- **Verify before applying against anything shared or production.** Run `chkit check` and `chkit drift` first; surface drift to the user rather than silently overwriting it.
+- **Generate, then review.** After `chkit generate`, read the migration SQL in `chkit/migrations/` and confirm it matches intent before applying. Migrations are forward-only DDL.
+- **Never auto-apply against a production endpoint** without explicit user confirmation. Connection details come from the environment — confirm which database the env points at before `--apply`.
+:::
+
+## Machine-readable output
+
+Every command accepts `--json` for structured output you can parse instead of scraping stdout. Use it when you need to act on results programmatically:
+
+```sh
+chkit status --json
+chkit check --json
+chkit migrate --json   # plan as JSON; add --apply to execute
+```
+
+Debug logging goes to stderr (`CHKIT_DEBUG=1`), so it never contaminates `--json` output on stdout.
+
+## Prompt to give your user
+
+If a human wants to trigger this setup themselves, they can paste this into their coding agent:
+
+```text
+Fetch https://chkit.obsessiondb.com/ai-agents.md and set up chkit schema
+management in this repo: install the agent skill, scaffold the config,
+recommend any plugins this project needs, and walk me through the first
+migration. Don't apply anything against the database without confirming
+with me first.
+```
+
+Every docs page is available as raw Markdown by appending `.md` to its URL — this page is [`/ai-agents.md`](https://chkit.obsessiondb.com/ai-agents.md). A full machine-readable index lives at [`/llms.txt`](https://chkit.obsessiondb.com/llms.txt).
+
+## Related pages
+
+- [Add to an existing project](/getting-started/add-to-existing-project/) — the human-facing version of the setup flow
+- [CLI reference](/cli/overview/) — every command, flag, and JSON output shape
+- [Schema DSL](/schema/dsl-reference/) — define tables, views, and materialized views
+- [Plugins overview](/plugins/overview/) — how plugins register and hook in
+- [CI/CD guide](/guides/ci-cd/) — wire `chkit check` into a pipeline gate

--- a/apps/docs/src/content/docs/getting-started/index.mdx
+++ b/apps/docs/src/content/docs/getting-started/index.mdx
@@ -7,8 +7,17 @@ sidebar:
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import CopyPromptButton from '../../../components/CopyPromptButton.astro';
 
 chkit is a ClickHouse schema and migration toolkit for TypeScript projects. Pick the path that matches what you're working on.
+
+## Let an agent set it up
+
+If you work in an AI coding agent (Claude Code, Cursor, Codex, and others), let it do the setup. Copy this prompt and paste it into your agent — it fetches chkit's [agent instructions](/ai-agents/) and walks you through install, config, plugins, and your first migration.
+
+<CopyPromptButton prompt="Set up chkit (ClickHouse schema management) in this repo. First fetch https://chkit.obsessiondb.com/ai-agents.md and follow the instructions there: install the agent skill, scaffold the config, recommend any plugins this project needs, and walk me through the first migration. Don't apply anything to the database without confirming with me first." />
+
+Prefer to do it yourself? Pick a path below.
 
 <CardGrid>
   <LinkCard

--- a/apps/docs/src/integrations/raw-markdown.ts
+++ b/apps/docs/src/integrations/raw-markdown.ts
@@ -1,19 +1,22 @@
-import { cpSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join, relative, dirname } from 'node:path';
+import { readFileSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
 import type { AstroIntegration } from 'astro';
+
+const BASE_URL = 'https://chkit.obsessiondb.com';
+const SITE_TAGLINE = 'ClickHouse schema management and migration toolkit for TypeScript.';
 
 interface DocEntry {
 	slug: string;
 	title: string;
 	description: string;
+	source: string;
 }
 
 function stripQuotes(s: string): string {
 	return s.replace(/^["']|["']$/g, '');
 }
 
-function extractFrontmatter(filePath: string): { title: string; description: string } {
-	const content = readFileSync(filePath, 'utf-8');
+function extractFrontmatter(content: string): { title: string; description: string } {
 	const match = content.match(/^---\n([\s\S]*?)\n---/);
 	if (!match) return { title: '', description: '' };
 
@@ -21,6 +24,11 @@ function extractFrontmatter(filePath: string): { title: string; description: str
 	const title = stripQuotes(fm.match(/^title:\s*(.+)$/m)?.[1]?.trim() ?? '');
 	const description = stripQuotes(fm.match(/^description:\s*(.+)$/m)?.[1]?.trim() ?? '');
 	return { title, description };
+}
+
+// Strip extension and collapse "index" / "<dir>/index" into the directory slug.
+function toSlug(rel: string): string {
+	return rel.replace(/\.mdx?$/, '').replace(/(^|\/)index$/, '');
 }
 
 function collectMarkdownFiles(srcDir: string, destDir: string): DocEntry[] {
@@ -32,17 +40,20 @@ function collectMarkdownFiles(srcDir: string, destDir: string): DocEntry[] {
 			if (statSync(fullPath).isDirectory()) {
 				walk(fullPath);
 			} else if (/\.mdx?$/.test(entry)) {
-				const rel = relative(srcDir, fullPath);
-				const dest = join(destDir, rel);
-				mkdirSync(dirname(dest), { recursive: true });
-				cpSync(fullPath, dest);
+				const source = readFileSync(fullPath, 'utf-8');
+				const slug = toSlug(relative(srcDir, fullPath));
+				const { title, description } = extractFrontmatter(source);
 
-				// Build slug: strip extension, "index" becomes ""
-				let slug = rel.replace(/\.mdx?$/, '');
-				if (slug === 'index') slug = '';
+				// Emit every page as raw Markdown at a clean, slug-based path
+				// (e.g. ai-agents.md, cli/migrate.md). The homepage (empty slug)
+				// is a marketing page, not useful as Markdown — skip it.
+				if (slug !== '') {
+					const dest = join(destDir, `${slug}.md`);
+					mkdirSync(dirname(dest), { recursive: true });
+					writeFileSync(dest, source);
+				}
 
-				const { title, description } = extractFrontmatter(fullPath);
-				entries.push({ slug, title, description });
+				entries.push({ slug, title, description, source });
 			}
 		}
 	}
@@ -51,31 +62,51 @@ function collectMarkdownFiles(srcDir: string, destDir: string): DocEntry[] {
 	return entries;
 }
 
-function generateIndex(entries: DocEntry[], baseUrl: string): string {
-	const lines: string[] = [
-		'# chkit Documentation',
-		'',
-		'ClickHouse schema management and migration toolkit for TypeScript.',
-		'',
-		'## Pages',
-		'',
-	];
-
-	// Sort: root pages first, then by slug alphabetically
-	const sorted = [...entries].sort((a, b) => {
+// Sort root pages first, then alphabetically by slug.
+function sortEntries(entries: DocEntry[]): DocEntry[] {
+	return [...entries].sort((a, b) => {
 		const aDepth = a.slug === '' ? -1 : a.slug.split('/').length;
 		const bDepth = b.slug === '' ? -1 : b.slug.split('/').length;
 		if (aDepth !== bDepth) return aDepth - bDepth;
 		return a.slug.localeCompare(b.slug);
 	});
+}
 
-	for (const entry of sorted) {
-		const path = entry.slug === '' ? '/' : `/${entry.slug}/`;
-		const url = `${baseUrl}${path}`;
+// Link to the raw Markdown URL of each page (.md), so an agent reading the
+// index can fetch each page's Markdown directly without HTML conversion.
+function mdUrl(slug: string): string {
+	return slug === '' ? `${BASE_URL}/` : `${BASE_URL}/${slug}.md`;
+}
+
+// Full sitemap served at /_raw/index.md (and /index.md via routing).
+function generateIndex(entries: DocEntry[]): string {
+	const lines = ['# chkit Documentation', '', SITE_TAGLINE, '', '## Pages', ''];
+	for (const entry of sortEntries(entries)) {
 		const desc = entry.description ? ` - ${entry.description}` : '';
-		lines.push(`- [${entry.title || path}](${url})${desc}`);
+		lines.push(`- [${entry.title || entry.slug || '/'}](${mdUrl(entry.slug)})${desc}`);
 	}
+	lines.push('');
+	return lines.join('\n');
+}
 
+// llms.txt — the agent entry point. https://llmstxt.org/ format: H1, a
+// blockquote summary, then a flat list of pages linking to their Markdown.
+function generateLlmsTxt(entries: DocEntry[]): string {
+	const lines = [
+		'# chkit',
+		'',
+		`> ${SITE_TAGLINE}`,
+		'',
+		'chkit defines ClickHouse schemas in TypeScript, diffs them into migration SQL, applies migrations, and verifies the live database stays in sync. Each link below points to the raw Markdown of that page.',
+		'',
+		'## Docs',
+		'',
+	];
+	for (const entry of sortEntries(entries)) {
+		if (entry.slug === '') continue;
+		const desc = entry.description ? `: ${entry.description}` : '';
+		lines.push(`- [${entry.title || entry.slug}](${mdUrl(entry.slug)})${desc}`);
+	}
 	lines.push('');
 	return lines.join('\n');
 }
@@ -86,18 +117,18 @@ export default function rawMarkdown(): AstroIntegration {
 		hooks: {
 			'astro:build:done': ({ dir, logger }) => {
 				const srcDir = new URL('../src/content/docs/', dir).pathname;
-				const destDir = new URL('_raw/', dir).pathname;
+				const distDir = new URL(dir).pathname;
+				const rawDir = join(distDir, '_raw');
 
-				const entries = collectMarkdownFiles(srcDir, destDir);
+				const entries = collectMarkdownFiles(srcDir, rawDir);
 
-				// Generate index.md as a full sitemap for agents
-				const baseUrl = 'https://chkit.obsessiondb.com';
-				const index = generateIndex(entries, baseUrl);
-				mkdirSync(destDir, { recursive: true });
-				writeFileSync(join(destDir, 'index.md'), index);
+				mkdirSync(rawDir, { recursive: true });
+				writeFileSync(join(rawDir, 'index.md'), generateIndex(entries));
+				writeFileSync(join(distDir, 'llms.txt'), generateLlmsTxt(entries));
 
-				logger.info(`Copied ${entries.length} markdown files to _raw/`);
-				logger.info(`Generated index.md with ${entries.length} pages`);
+				const pageCount = entries.filter((e) => e.slug !== '').length;
+				logger.info(`Wrote ${pageCount} raw Markdown pages to _raw/`);
+				logger.info(`Generated _raw/index.md and llms.txt with ${pageCount} pages`);
 			},
 		},
 	};


### PR DESCRIPTION
## Summary
- Add an agent-facing **/ai-agents** onboarding page: written to the coding agent, with a plugin decision tree, agent-skill install, destructive-op guardrails, and a pasteable setup prompt.
- Add a **"Let an agent set it up"** section to getting-started with a copy-to-clipboard prompt (new `CopyPromptButton.astro`, no React dependency).
- Serve every docs page as raw Markdown at a clean **`.md` URL** (e.g. `/ai-agents.md`) via the Pages Function — no `Accept` header required — and generate an **`/llms.txt`** index.
- Advertise each page's Markdown via a `<link rel="alternate" type="text/markdown">` head tag (new `Head.astro` override).
- Fix a pre-existing slug bug where index pages got `/foo/index/` URLs in the raw-markdown sitemap.
- Update the `documentation-authoring` skill to match the new build output and discoverability paths.

No changeset: docs site + skill file only, no published package touched.

## Test plan
- [x] `bun run build` in `apps/docs` succeeds (32 raw pages + index + llms.txt)
- [x] Middleware routing simulated against `dist`: `.md` URLs return `text/markdown`, content negotiation works both ways, missing `.md` falls through to 404
- [x] Built HTML contains one correct `rel=alternate` markdown link per page; default head tags intact
- [ ] Cloudflare preview deploy to confirm the Pages Function serves `.md` URLs live