### PR TITLE
feat(backfill): chkit backfill submit — managed ObsessionDB jobs

### DIFF
--- a/.changeset/obsession-jobs-submit.md
+++ b/.changeset/obsession-jobs-submit.md
@@ -1,0 +1,6 @@
+---
+"@chkit/plugin-backfill": patch
+"@chkit/plugin-obsessiondb": patch
+---
+
+Add `chkit backfill submit` to run a backfill as a managed ObsessionDB job. It builds the plan with the same chunking algorithm as the local `run`, submits the chunks to the ObsessionDB job backend, and prints a console link to track progress instead of polling locally — the heavier, MV-replay-aware path lives in the ObsessionDB plugin. The plugin's remote executor now forwards ClickHouse query settings (e.g. `enable_parallel_replicas`) so remote plan sizing matches the local planner.

--- a/apps/docs/src/content/docs/plugins/backfill.md
+++ b/apps/docs/src/content/docs/plugins/backfill.md
@@ -175,6 +175,19 @@ Build a deterministic backfill plan and persist immutable plan state.
 | `--force-large-window` | No | Allow windows exceeding `limits.maxWindowHours` |
 | `--force` | No | Delete existing plan and regenerate from scratch |
 
+### `chkit plugin backfill submit`
+
+Build the plan with the same chunking algorithm as `run`, then submit it to a managed job backend instead of executing it locally. Requires an authenticated [ObsessionDB](/plugins/overview/) session with a selected service (`chkit obsessiondb login`, then `chkit obsessiondb service select`); without one, the command explains how to set it up or fall back to `run --local`. On success it prints the job ID and a console link to track progress — the backend runs the chunks, so no local polling is needed.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--target <db.table>` | Yes | Target table in `database.table` format |
+| `--from <timestamp>` | No | Window start (ISO timestamp; defaults to the table's earliest partition) |
+| `--to <timestamp>` | No | Window end (ISO timestamp; defaults to the table's latest partition) |
+| `--max-chunk-bytes <size>` | No | Max bytes per chunk (e.g. `10G`, `500M`) |
+| `--title <title>` | No | Human-readable job title shown in the console |
+| `--concurrency <n>` | No | Max concurrent tasks the backend runs (1–48) |
+
 ### `chkit plugin backfill run`
 
 Execute a planned backfill by submitting chunks as async queries to ClickHouse with concurrent execution and progress polling.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "chkit",
@@ -137,6 +136,7 @@
       "dependencies": {
         "@chkit/clickhouse": "workspace:*",
         "@chkit/core": "workspace:*",
+        "@chkit/plugin-backfill": "workspace:*",
         "@clack/prompts": "^1.4.0",
         "@orpc/client": "1.13.4",
         "@orpc/contract": "1.13.4",

--- a/packages/plugin-backfill/src/options.ts
+++ b/packages/plugin-backfill/src/options.ts
@@ -105,6 +105,15 @@ export const PlanSchema = z.object({
 })
 export type PlanOptions = z.infer<typeof PlanSchema>
 
+// `submit` reuses the planning options (same chunking algorithm) and adds the
+// fields a managed job backend cares about: a human-readable title and the
+// backend-side execution concurrency.
+export const SubmitSchema = PlanSchema.extend({
+  title: z.string().min(1).optional(),
+  concurrency: z.number().int().positive().max(48).optional(),
+})
+export type SubmitOptions = z.infer<typeof SubmitSchema>
+
 export const RunSchema = z.object({
   planId: z.string(),
   forceEnvironment: z.boolean().default(false),
@@ -139,6 +148,15 @@ export const PLAN_FLAGS = defineFlags([
   { name: '--max-chunk-bytes', type: 'string', description: 'Max bytes per chunk (e.g. 10G, 500M)', placeholder: '<bytes>' },
 ] as const)
 
+export const SUBMIT_FLAGS = defineFlags([
+  { name: '--target', type: 'string', description: 'Target table (database.table)', placeholder: '<database.table>' },
+  { name: '--from', type: 'string', description: 'Filter partitions starting from timestamp', placeholder: '<timestamp>' },
+  { name: '--to', type: 'string', description: 'Filter partitions up to timestamp', placeholder: '<timestamp>' },
+  { name: '--max-chunk-bytes', type: 'string', description: 'Max bytes per chunk (e.g. 10G, 500M)', placeholder: '<bytes>' },
+  { name: '--title', type: 'string', description: 'Human-readable job title', placeholder: '<title>' },
+  { name: '--concurrency', type: 'string', description: 'Max concurrent tasks the backend runs', placeholder: '<n>' },
+] as const)
+
 export const RUN_FLAGS = defineFlags([
   { name: '--plan-id', type: 'string', description: 'Plan ID to execute', placeholder: '<id>' },
   { name: '--force-environment', type: 'boolean', description: 'Skip environment mismatch checks' },
@@ -165,6 +183,15 @@ export const PLAN_FLAG_MAP: FlagMapping = {
   '--from': { key: 'from', coerce: (v) => normalizeTimestamp(v, '--from') },
   '--to': { key: 'to', coerce: (v) => normalizeTimestamp(v, '--to') },
   '--max-chunk-bytes': { key: 'maxChunkBytes', coerce: parseByteSize },
+}
+
+export const SUBMIT_FLAG_MAP: FlagMapping = {
+  '--target': { key: 'target', coerce: normalizeTarget },
+  '--from': { key: 'from', coerce: (v) => normalizeTimestamp(v, '--from') },
+  '--to': { key: 'to', coerce: (v) => normalizeTimestamp(v, '--to') },
+  '--max-chunk-bytes': { key: 'maxChunkBytes', coerce: parseByteSize },
+  '--title': { key: 'title' },
+  '--concurrency': { key: 'concurrency', coerce: (v) => coercePositiveInt(v, '--concurrency') },
 }
 
 function coercePositiveInt(v: string, flag: string): number {

--- a/packages/plugin-backfill/src/plugin.test.ts
+++ b/packages/plugin-backfill/src/plugin.test.ts
@@ -20,6 +20,7 @@ describe('@chkit/plugin-backfill plugin surface', () => {
     expect(plugin.manifest.apiVersion).toBe(1)
     expect(plugin.commands.map((command) => command.name)).toEqual([
       'plan',
+      'submit',
       'run',
       'resume',
       'status',

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -20,6 +20,9 @@ import {
   RUN_FLAG_MAP,
   RunSchema,
   StatusSchema,
+  SUBMIT_FLAGS,
+  SUBMIT_FLAG_MAP,
+  SubmitSchema,
   type PlanOptions,
   type PluginConfig,
   type ResumeOptions,
@@ -207,6 +210,7 @@ function withFactoryDefaults<T>(
 export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin {
   const factoryOptions = options as Record<string, unknown>
   const planOptionsSchema = withFactoryDefaults(PlanSchema, factoryOptions)
+  const submitOptionsSchema = withFactoryDefaults(SubmitSchema, factoryOptions)
   const runOptionsSchema = withFactoryDefaults(RunSchema, factoryOptions)
   const resumeOptionsSchema = withFactoryDefaults(ResumeSchema, factoryOptions)
   const statusOptionsSchema = withFactoryDefaults(StatusSchema, factoryOptions)
@@ -277,6 +281,32 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
               } finally {
                 await db.close()
               }
+            },
+          }),
+      },
+      {
+        name: 'submit',
+        description: 'Submit a backfill plan to a managed job backend (e.g. ObsessionDB) instead of running it locally',
+        flags: SUBMIT_FLAGS,
+        optionsSchema: submitOptionsSchema,
+        flagMapping: SUBMIT_FLAG_MAP,
+        run: async (context) =>
+          wrapPluginRun({
+            command: 'submit',
+            label: 'Backfill submit',
+            jsonMode: context.jsonMode,
+            print: context.print,
+            configErrorClass: BackfillConfigError,
+            fn: async () => {
+              // Reaching this handler means no managed backend intercepted the
+              // command. The ObsessionDB plugin handles `submit` via its
+              // onBeforePluginCommand hook when a service is selected; without
+              // one there is nowhere to submit to.
+              throw new BackfillConfigError(
+                'backfill submit requires a managed job backend. Log in and select an ObsessionDB service ' +
+                  '(`chkit obsessiondb login`, then `chkit obsessiondb service select`), ' +
+                  'or use `chkit backfill run --local` to execute the backfill against a direct connection.',
+              )
             },
           }),
       },

--- a/packages/plugin-backfill/src/sdk.ts
+++ b/packages/plugin-backfill/src/sdk.ts
@@ -7,6 +7,8 @@ export {
   encodeChunkPlanForPersistence,
 } from './chunking/boundary-codec.js'
 export { generateChunkPlan } from './chunking/planner.js'
+export { buildBackfillPlan } from './planner.js'
+export { PlanSchema, SubmitSchema, parseByteSize } from './options.js'
 export {
   CHKIT_BACKFILL_LOGGER_CATEGORY,
   CHKIT_LOGGER_CATEGORY,
@@ -19,6 +21,9 @@ export {
   rewriteSelectColumns,
 } from './chunking/sql.js'
 export { generateIdempotencyToken } from './chunking/utils/ids.js'
+
+export type { PlanOptions, SubmitOptions } from './options.js'
+export type { BackfillPlanState, BuildBackfillPlanOutput } from './types.js'
 
 export type {
   BackfillOptions,

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -161,7 +161,7 @@ export interface BackfillPlugin {
   }
   optionsSchema?: SafeParseable<Record<string, unknown>>
   commands: Array<{
-    name: 'plan' | 'run' | 'resume' | 'status' | 'cancel' | 'doctor'
+    name: 'plan' | 'submit' | 'run' | 'resume' | 'status' | 'cancel' | 'doctor'
     description: string
     flags?: ReadonlyArray<{
       name: string

--- a/packages/plugin-obsessiondb/package.json
+++ b/packages/plugin-obsessiondb/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@chkit/clickhouse": "workspace:*",
     "@chkit/core": "workspace:*",
+    "@chkit/plugin-backfill": "workspace:*",
     "@clack/prompts": "^1.4.0",
     "@orpc/client": "1.13.4",
     "@orpc/contract": "1.13.4",

--- a/packages/plugin-obsessiondb/src/backfill/console-url.test.ts
+++ b/packages/plugin-obsessiondb/src/backfill/console-url.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildJobConsoleUrl, consoleWebBaseUrl } from './console-url'
+
+describe('consoleWebBaseUrl', () => {
+	test('maps the console-api host to the web console host', () => {
+		expect(consoleWebBaseUrl('https://console-api.obsessiondb.com')).toBe(
+			'https://console.obsessiondb.com',
+		)
+	})
+
+	test('drops any path on the API base url', () => {
+		expect(consoleWebBaseUrl('https://console-api.obsessiondb.com/rpc')).toBe(
+			'https://console.obsessiondb.com',
+		)
+	})
+
+	test('strips an -api segment for non-console hosts', () => {
+		expect(consoleWebBaseUrl('https://my-api.example.com')).toBe('https://my.example.com')
+	})
+
+	test('returns the origin unchanged when no -api mapping applies', () => {
+		expect(consoleWebBaseUrl('http://localhost:3000')).toBe('http://localhost:3000')
+	})
+
+	test('falls back to the trimmed string for an unparseable url', () => {
+		expect(consoleWebBaseUrl('not-a-url')).toBe('not-a-url')
+	})
+})
+
+describe('buildJobConsoleUrl', () => {
+	test('builds a service/jobs/job deep link', () => {
+		expect(
+			buildJobConsoleUrl('https://console-api.obsessiondb.com', 'my-service', 'job-123'),
+		).toBe('https://console.obsessiondb.com/my-service/jobs/job-123')
+	})
+
+	test('url-encodes the slug and job id', () => {
+		expect(buildJobConsoleUrl('https://console-api.obsessiondb.com', 'a b', 'j/1')).toBe(
+			'https://console.obsessiondb.com/a%20b/jobs/j%2F1',
+		)
+	})
+})

--- a/packages/plugin-obsessiondb/src/backfill/console-url.ts
+++ b/packages/plugin-obsessiondb/src/backfill/console-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Derive the web-console base URL from the stored API base URL.
+ *
+ * Credentials store the API host (e.g. `https://console-api.obsessiondb.com`);
+ * the web console lives at the sibling host (`console.obsessiondb.com`). We map
+ * a leading `console-api.` to `console.`, fall back to stripping an `-api`
+ * segment, and finally return the origin unchanged when no mapping applies.
+ */
+export function consoleWebBaseUrl(apiBaseUrl: string): string {
+	try {
+		const url = new URL(apiBaseUrl)
+		if (url.hostname.startsWith('console-api.')) {
+			url.hostname = `console.${url.hostname.slice('console-api.'.length)}`
+		} else if (url.hostname.includes('-api.')) {
+			url.hostname = url.hostname.replace('-api.', '.')
+		}
+		return url.origin
+	} catch {
+		return apiBaseUrl.replace(/\/+$/, '')
+	}
+}
+
+/**
+ * Build the deep-link to a job's progress page in the ObsessionDB console.
+ * Shape: `<console>/<serviceSlug>/jobs/<jobId>`.
+ */
+export function buildJobConsoleUrl(
+	apiBaseUrl: string,
+	serviceSlug: string,
+	jobId: string,
+): string {
+	return `${consoleWebBaseUrl(apiBaseUrl)}/${encodeURIComponent(serviceSlug)}/jobs/${encodeURIComponent(jobId)}`
+}

--- a/packages/plugin-obsessiondb/src/backfill/handler.test.ts
+++ b/packages/plugin-obsessiondb/src/backfill/handler.test.ts
@@ -208,7 +208,7 @@ describe('handleBackfillCommand', () => {
       const result = await handleBackfillCommand(context)
 
       expect(result).toEqual({ handled: true, exitCode: 1 })
-      expect(printed[0]).toContain('not supported yet')
+      expect(printed[0]).toContain('backfill submit')
       expect(printed[0]).toContain('--local')
     })
   }
@@ -244,5 +244,24 @@ describe('handleBackfillCommand', () => {
 
     expect(result).toEqual({ handled: true, exitCode: 1 })
     expect(printed[0]).toMatchObject({ ok: false, command: 'backfill plan' })
+  })
+
+  test('defers submit to the local command when authenticated but no service is selected', async () => {
+    await setupAuth()
+
+    const { context } = makeContext({ command: 'submit', flags: { '--target': 'app.events' } })
+    const result = await handleBackfillCommand(context)
+    expect(result).toEqual({ handled: false })
+  })
+
+  test('defers submit to the local command when not authenticated', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'chkit-bf-'))
+    originalXdg = process.env.XDG_CONFIG_HOME
+    process.env.XDG_CONFIG_HOME = tempDir
+    // No credentials saved
+
+    const { context } = makeContext({ command: 'submit', flags: { '--target': 'app.events' } })
+    const result = await handleBackfillCommand(context)
+    expect(result).toEqual({ handled: false })
   })
 })

--- a/packages/plugin-obsessiondb/src/backfill/handler.ts
+++ b/packages/plugin-obsessiondb/src/backfill/handler.ts
@@ -1,6 +1,9 @@
+import type { ResolvedChxConfig } from '@chkit/core'
+
 import { loadCredentials, resolveBaseUrl } from '../auth/index.js'
 import { loadSelectedService } from '../service/storage.js'
 import { createJobsClient, isSessionExpiredError, type JobsClient } from './client.js'
+import { handleSubmit } from './submit.js'
 
 interface BeforePluginCommandContext {
   targetPlugin: string
@@ -31,6 +34,14 @@ export async function handleBackfillCommand(context: BeforePluginCommandContext)
 
   // --local flag bypasses remote routing and runs against the direct ClickHouse connection.
   if (context.flags['--local'] === true) return { handled: false }
+
+  // `submit` builds the plan with the same chunking algorithm as the local path
+  // and submits it to the ObsessionDB job backend. Only intercept when there is a
+  // backend to submit to (authenticated + service selected); otherwise let the
+  // local command print its "no managed backend" guidance.
+  if (context.command === 'submit') {
+    return routeSubmit(context)
+  }
 
   if (EXECUTION_SUBCOMMANDS.has(context.command)) {
     return guardRemoteExecution(context)
@@ -65,10 +76,33 @@ export async function handleBackfillCommand(context: BeforePluginCommandContext)
   }
 }
 
-// A backfill execution command targets ObsessionDB when the user is authenticated and a
-// service is selected (the same condition under which getContext hands out the remote
-// executor). In that case remote execution is not implemented yet, so refuse with a clear
-// message rather than opening a direct ClickHouse connection that bypasses ObsessionDB.
+// `submit` targets ObsessionDB when authenticated and a service is selected (the
+// same condition under which getContext hands out the remote executor). Without a
+// service there is nothing to submit to, so defer to the local command's guidance.
+async function routeSubmit(
+  context: BeforePluginCommandContext,
+): Promise<HandlerResult> {
+  const creds = await loadCredentials()
+  if (!creds) return { handled: false }
+
+  const selected = await loadSelectedService(context.configPath)
+  if (!selected) return { handled: false }
+
+  const effectiveCreds = { ...creds, base_url: resolveBaseUrl(creds.base_url) }
+  return handleSubmit({
+    flags: context.flags,
+    configPath: context.configPath,
+    jsonMode: context.jsonMode,
+    config: context.config as Pick<ResolvedChxConfig, 'metaDir' | 'schema'>,
+    print: context.print,
+    credentials: effectiveCreds,
+    serviceSlug: selected.service_slug,
+  })
+}
+
+// `plan`/`run`/`resume` run the chunk loop against a direct ClickHouse connection.
+// Against ObsessionDB the managed path is `backfill submit`, so point users there
+// rather than silently opening a direct connection that bypasses ObsessionDB.
 async function guardRemoteExecution(
   context: BeforePluginCommandContext,
 ): Promise<HandlerResult> {
@@ -82,8 +116,8 @@ async function guardRemoteExecution(
   if (!hasService) return { handled: false }
 
   const message =
-    `Backfill ${context.command} against ObsessionDB is not supported yet — it will submit jobs to the ObsessionDB backend, which is not implemented. ` +
-    'Re-run with --local to execute against a direct ClickHouse connection, or unselect the service with `chkit obsessiondb service select`.'
+    `Backfill ${context.command} runs locally and is not supported directly against ObsessionDB. ` +
+    'Use `chkit backfill submit` to run it as a managed ObsessionDB job, or re-run with --local to execute against a direct ClickHouse connection.'
   if (context.jsonMode) {
     context.print({ ok: false, command: `backfill ${context.command}`, error: message })
   } else {

--- a/packages/plugin-obsessiondb/src/backfill/submit.test.ts
+++ b/packages/plugin-obsessiondb/src/backfill/submit.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { BackfillPlanState } from '@chkit/plugin-backfill/sdk'
+
+import { buildSubmitTasks, parseSubmitInput } from './submit'
+
+function makePlan(requireIdempotencyToken = true): BackfillPlanState {
+	return {
+		planId: 'abcdef0123456789',
+		target: 'app.events',
+		createdAt: '2026-06-30T00:00:00.000Z',
+		from: '2026-01-01T00:00:00.000Z',
+		to: '2026-02-01T00:00:00.000Z',
+		chunkPlan: {
+			planId: 'abcdef0123456789',
+			generatedAt: '2026-06-30T00:00:00.000Z',
+			rowProbeStrategy: 'count',
+			targetChunkBytes: 1000,
+			table: {
+				database: 'app',
+				table: 'events',
+				sortKeys: [
+					{ name: 'id', type: 'UInt64', category: 'numeric', boundaryEncoding: 'literal' },
+				],
+			},
+			partitions: [],
+			chunks: [
+				{
+					id: 'c1',
+					partitionId: 'p0',
+					ranges: [{ dimensionIndex: 0, from: '0', to: '100' }],
+					estimate: {
+						rows: 100,
+						bytesCompressed: 1000,
+						bytesUncompressed: 3000,
+						confidence: 'high',
+						reason: 'partition-metadata',
+					},
+					analysis: { lineage: [] },
+				},
+				{
+					id: 'c2',
+					partitionId: 'p1',
+					ranges: [],
+					estimate: {
+						rows: 50,
+						bytesCompressed: 500,
+						bytesUncompressed: 1500,
+						confidence: 'high',
+						reason: 'partition-metadata',
+					},
+					analysis: { lineage: [] },
+				},
+			],
+			totalRows: 150,
+			totalBytesCompressed: 1500,
+			totalBytesUncompressed: 4500,
+			stats: {
+				totalPartitions: 2,
+				oversizedPartitions: 0,
+				focusedChunks: 0,
+				totalChunks: 2,
+				avgChunkBytes: 750,
+				maxChunkBytes: 1000,
+				minChunkBytes: 500,
+			},
+		},
+		execution: { mode: 'copy', sourceTarget: 'app.events', requireIdempotencyToken },
+		options: { maxParallelChunks: 1, maxRetriesPerChunk: 5, requireIdempotencyToken },
+		policy: {
+			requireDryRunBeforeRun: true,
+			requireExplicitWindow: true,
+			blockOverlappingRuns: true,
+			failCheckOnRequiredPendingBackfill: true,
+		},
+		limits: { maxWindowHours: 720, minChunkMinutes: 15 },
+	}
+}
+
+describe('buildSubmitTasks', () => {
+	test('produces one task per chunk, preserving ids', () => {
+		const tasks = buildSubmitTasks(makePlan())
+		expect(tasks.map((t) => t.id)).toEqual(['c1', 'c2'])
+	})
+
+	test('renders the same INSERT … SELECT the local executor would run', () => {
+		const [first] = buildSubmitTasks(makePlan())
+		expect(first?.sql).toContain('INSERT INTO app.events')
+		expect(first?.sql).toContain('FROM app.events')
+		expect(first?.sql).toContain("_partition_id = 'p0'")
+		expect(first?.sql).toContain('id >= ')
+	})
+
+	test('carries estimates, group, and retry budget onto each task', () => {
+		const [first] = buildSubmitTasks(makePlan())
+		expect(first?.group).toBe('p0')
+		expect(first?.estimatedBytes).toBe(1000)
+		expect(first?.estimatedBytesUncompressed).toBe(3000)
+		expect(first?.maxRetries).toBe(5)
+	})
+
+	test('includes an idempotency token when required', () => {
+		const [first] = buildSubmitTasks(makePlan(true))
+		expect(first?.sql).toContain('insert_deduplication_token=')
+	})
+
+	test('omits the idempotency token when not required', () => {
+		const [first] = buildSubmitTasks(makePlan(false))
+		expect(first?.sql).not.toContain('insert_deduplication_token=')
+	})
+})
+
+describe('parseSubmitInput', () => {
+	test('parses a valid target', () => {
+		const { opts } = parseSubmitInput({ '--target': 'app.events' })
+		expect(opts.target).toBe('app.events')
+	})
+
+	test('throws when target is missing', () => {
+		expect(() => parseSubmitInput({})).toThrow('--target')
+	})
+
+	test('throws when target is not database.table', () => {
+		expect(() => parseSubmitInput({ '--target': 'events' })).toThrow('--target')
+	})
+
+	test('coerces a byte-size suffix', () => {
+		const { opts } = parseSubmitInput({ '--target': 'app.events', '--max-chunk-bytes': '500M' })
+		expect(opts.maxChunkBytes).toBe(500 * 1024 ** 2)
+	})
+
+	test('normalizes from/to timestamps to ISO', () => {
+		const { opts } = parseSubmitInput({
+			'--target': 'app.events',
+			'--from': '2026-01-01',
+		})
+		expect(opts.from).toBe('2026-01-01T00:00:00.000Z')
+	})
+
+	test('throws on an invalid timestamp', () => {
+		expect(() =>
+			parseSubmitInput({ '--target': 'app.events', '--from': 'not-a-date' }),
+		).toThrow('--from')
+	})
+
+	test('accepts a valid concurrency', () => {
+		const { concurrency } = parseSubmitInput({ '--target': 'app.events', '--concurrency': '4' })
+		expect(concurrency).toBe(4)
+	})
+
+	test('rejects an out-of-range concurrency', () => {
+		expect(() =>
+			parseSubmitInput({ '--target': 'app.events', '--concurrency': '100' }),
+		).toThrow('--concurrency')
+	})
+
+	test('passes through a title', () => {
+		const { title } = parseSubmitInput({ '--target': 'app.events', '--title': 'My backfill' })
+		expect(title).toBe('My backfill')
+	})
+})

--- a/packages/plugin-obsessiondb/src/backfill/submit.ts
+++ b/packages/plugin-obsessiondb/src/backfill/submit.ts
@@ -1,0 +1,182 @@
+import type { ClickHouseSettings } from '@chkit/clickhouse'
+import type { ResolvedChxConfig } from '@chkit/core'
+import {
+	type BackfillPlanState,
+	buildBackfillPlan,
+	buildChunkExecutionSql,
+	generateIdempotencyToken,
+	parseByteSize,
+	PlanSchema,
+} from '@chkit/plugin-backfill/sdk'
+
+import { isSessionExpiredError } from '../api-request.js'
+import type { Credentials } from '../auth/index.js'
+import { createRemoteExecutor } from '../query/remote-executor.js'
+import { createJobsClient } from './client.js'
+import { buildJobConsoleUrl } from './console-url.js'
+
+interface SubmitTask {
+	id: string
+	sql: string
+	group?: string
+	estimatedBytes?: number
+	estimatedBytesUncompressed?: number
+	maxRetries?: number
+}
+
+/**
+ * Map a backfill plan into the task list the jobs backend expects. Each chunk
+ * renders the exact same `INSERT … SELECT` the local executor would run, so the
+ * algorithm is identical — only the execution venue differs.
+ */
+export function buildSubmitTasks(plan: BackfillPlanState): SubmitTask[] {
+	return plan.chunkPlan.chunks.map((chunk) => ({
+		id: chunk.id,
+		sql: buildChunkExecutionSql({
+			planId: plan.planId,
+			chunk,
+			target: plan.target,
+			sourceTarget: plan.execution.sourceTarget,
+			table: plan.chunkPlan.table,
+			mvAsQuery: plan.execution.mvAsQuery,
+			targetColumns: plan.execution.targetColumns,
+			idempotencyToken: plan.execution.requireIdempotencyToken
+				? generateIdempotencyToken(plan.planId, chunk.id)
+				: '',
+		}),
+		group: chunk.partitionId,
+		estimatedBytes: chunk.estimate.bytesCompressed,
+		estimatedBytesUncompressed: chunk.estimate.bytesUncompressed,
+		maxRetries: plan.options.maxRetriesPerChunk,
+	}))
+}
+
+interface ParsedSubmitInput {
+	opts: ReturnType<typeof PlanSchema.parse>
+	title?: string
+	concurrency?: number
+}
+
+function flagString(
+	flags: Record<string, string | string[] | boolean | undefined>,
+	name: string,
+): string | undefined {
+	const value = flags[name]
+	return typeof value === 'string' && value.trim().length > 0
+		? value.trim()
+		: undefined
+}
+
+function coerceTimestamp(raw: string | undefined, flag: string): string | undefined {
+	if (!raw) return undefined
+	const date = new Date(raw)
+	if (Number.isNaN(date.getTime())) {
+		throw new Error(`Invalid timestamp for ${flag}: ${raw}`)
+	}
+	return date.toISOString()
+}
+
+export function parseSubmitInput(
+	flags: Record<string, string | string[] | boolean | undefined>,
+): ParsedSubmitInput {
+	const target = flagString(flags, '--target')
+	if (!target || !/^[A-Za-z0-9_]+\.[A-Za-z0-9_]+$/.test(target)) {
+		throw new Error('backfill submit requires --target <database.table>')
+	}
+
+	const rawBytes = flagString(flags, '--max-chunk-bytes')
+	const rawConcurrency = flagString(flags, '--concurrency')
+	let concurrency: number | undefined
+	if (rawConcurrency !== undefined) {
+		const parsed = Number(rawConcurrency)
+		if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 48) {
+			throw new Error('Invalid value for --concurrency. Expected an integer between 1 and 48.')
+		}
+		concurrency = parsed
+	}
+
+	const opts = PlanSchema.parse({
+		target,
+		from: coerceTimestamp(flagString(flags, '--from'), '--from'),
+		to: coerceTimestamp(flagString(flags, '--to'), '--to'),
+		maxChunkBytes: rawBytes !== undefined ? parseByteSize(rawBytes) : undefined,
+	})
+
+	return { opts, title: flagString(flags, '--title'), concurrency }
+}
+
+export interface SubmitContext {
+	flags: Record<string, string | string[] | boolean | undefined>
+	configPath: string
+	jsonMode: boolean
+	config: Pick<ResolvedChxConfig, 'metaDir' | 'schema'>
+	print: (value: unknown) => void
+	credentials: Credentials
+	serviceSlug: string
+}
+
+export async function handleSubmit(
+	context: SubmitContext,
+): Promise<{ handled: true; exitCode: number }> {
+	try {
+		const { opts, title, concurrency } = parseSubmitInput(context.flags)
+
+		const executor = createRemoteExecutor({
+			credentials: context.credentials,
+			serviceSlug: context.serviceSlug,
+		})
+
+		const { plan } = await buildBackfillPlan({
+			opts,
+			configPath: context.configPath,
+			config: context.config,
+			clickhouseQuery: <T>(sql: string, settings?: Record<string, string | number | boolean | undefined>) =>
+				executor.query<T>(sql, settings as ClickHouseSettings | undefined),
+			// ObsessionDB enables parallel replicas by default, which inflates
+			// aggregate results used for chunk sizing. Disable for planning.
+			querySettings: { enable_parallel_replicas: 0 },
+		})
+
+		const tasks = buildSubmitTasks(plan)
+		const jobs = createJobsClient(context.credentials)
+		const { jobId } = await jobs.submit({
+			serviceSlug: context.serviceSlug,
+			type: 'backfill',
+			target: plan.target,
+			tasks,
+			...(title ? { title } : {}),
+			...(concurrency !== undefined ? { concurrency } : {}),
+			metadata: { planId: plan.planId, mode: plan.execution.mode, source: 'chkit' },
+		})
+
+		const url = buildJobConsoleUrl(context.credentials.base_url, context.serviceSlug, jobId)
+		if (context.jsonMode) {
+			context.print({
+				ok: true,
+				command: 'backfill submit',
+				jobId,
+				target: plan.target,
+				taskCount: tasks.length,
+				url,
+			})
+		} else {
+			context.print(
+				`Submitted backfill job ${jobId} for ${plan.target} (${tasks.length} task${tasks.length === 1 ? '' : 's'}).\n` +
+					`Track progress: ${url}`,
+			)
+		}
+		return { handled: true, exitCode: 0 }
+	} catch (error) {
+		if (isSessionExpiredError(error)) {
+			context.print(error instanceof Error ? error.message : String(error))
+			return { handled: true, exitCode: 1 }
+		}
+		const message = error instanceof Error ? error.message : String(error)
+		if (context.jsonMode) {
+			context.print({ ok: false, command: 'backfill submit', error: message })
+		} else {
+			context.print(`Backfill submit failed: ${message}`)
+		}
+		return { handled: true, exitCode: 1 }
+	}
+}

--- a/packages/plugin-obsessiondb/src/query/remote-executor.ts
+++ b/packages/plugin-obsessiondb/src/query/remote-executor.ts
@@ -1,6 +1,7 @@
 import type {
 	ClickHouseExecutor,
 	ClickHouseJsonQueryResult,
+	ClickHouseSettings,
 	QueryStatus,
 	SchemaObjectRef,
 } from '@chkit/clickhouse'
@@ -20,6 +21,28 @@ function throwIfError(
 	if (res.error) {
 		throw new Error(res.error)
 	}
+}
+
+/**
+ * The workbench query API accepts only string/number setting values. Drop
+ * undefined entries and coerce booleans so chkit can forward ClickHouse query
+ * settings (e.g. `enable_parallel_replicas: 0` used by backfill planning).
+ */
+function toApiSettings(
+	settings?: ClickHouseSettings,
+): Record<string, string | number> | undefined {
+	if (!settings) return undefined
+	const out: Record<string, string | number> = {}
+	for (const [key, value] of Object.entries(settings)) {
+		if (typeof value === 'string' || typeof value === 'number') {
+			out[key] = value
+		} else if (typeof value === 'boolean') {
+			out[key] = value ? 1 : 0
+		}
+		// Skip undefined and nested setting maps — the workbench API only
+		// accepts scalar setting values.
+	}
+	return Object.keys(out).length > 0 ? out : undefined
 }
 
 export function normalizeQueryData<T>(
@@ -63,10 +86,12 @@ export function createRemoteExecutor(deps: {
 			throwIfError(res)
 		},
 
-		async query<T>(sql: string): Promise<T[]> {
+		async query<T>(sql: string, settings?: ClickHouseSettings): Promise<T[]> {
+			const apiSettings = toApiSettings(settings)
 			const res = await client.workbench.query.execute({
 				serviceSlug,
 				query: sql,
+				...(apiSettings ? { settings: apiSettings } : {}),
 			})
 			throwIfError(res)
 			return normalizeQueryData<T>(res)


### PR DESCRIPTION
## Summary
- Adds **`chkit backfill submit`**: builds a backfill plan with the **same chunking algorithm** as the local `run`, then submits the chunks to the **ObsessionDB job backend** instead of executing them locally, and prints a console deep-link (`https://console.obsessiondb.com/{serviceSlug}/jobs/{jobId}`) to track progress — no local polling (NUM-7426).
- `plugin-backfill`: registers the `submit` subcommand and exports `buildBackfillPlan` + plan schema/types from the SDK so the integration reuses the canonical planner (incl. **MV-replay** auto-detection — a copy-mode-only path would emit wrong SQL for MV targets).
- `plugin-obsessiondb`: intercepts `submit` via the existing backfill hook, builds the plan through the **remote executor** (introspects the live service via the API), maps each chunk → a `jobs.submit` task (reusing `buildChunkExecutionSql` + idempotency tokens), calls `jobs.submit`, and prints the link. The remote executor now **forwards ClickHouse query settings** (e.g. `enable_parallel_replicas: 0`) so remote plan sizing matches local.
- `plan`/`run`/`resume` keep refusing against ObsessionDB and now point to `backfill submit`; local `submit` with no managed backend errors with setup guidance.
- Docs: `submit` added to the backfill plugin page. Changeset: patch for both plugins (beta).

## Test plan
- [x] `turbo run typecheck lint build` — 27/27 packages green (excl. docs app's unrelated missing-dep, now resolved locally)
- [x] Unit tests (42): `buildSubmitTasks` (task mapping + idempotency), `parseSubmitInput` (flag validation), `consoleWebBaseUrl`/`buildJobConsoleUrl`, handler routing guards; no regressions in either plugin's suite
- [x] Real CLI binary: `chkit backfill` lists `submit`; `chkit backfill submit --target …` (no service) prints guidance in text + `--json`
- [x] `apps/docs` build green (38 pages)
- [x] **Not yet live-verified:** the `jobs.submit` API round-trip — it authenticates against the console API (not `.env.test`) and creates a real job on a selected service. To verify once a service is selected + token refreshed.

## Notes
- v1 covers copy + MV-replay (inherited from `buildBackfillPlan`). `submit` submits to the *selected* service (no `--service` override yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQWcHnA6KkSKL5UKe7XjMZ