### PR TITLE
refactor: shared plugin command runner in @chkit/core

### DIFF
--- a/.changeset/shared-plugin-command-runner.md
+++ b/.changeset/shared-plugin-command-runner.md
@@ -1,0 +1,8 @@
+---
+"@chkit/core": patch
+"@chkit/plugin-backfill": patch
+"@chkit/plugin-codegen": patch
+"@chkit/plugin-pull": patch
+---
+
+Extract shared plugin command scaffolding into `@chkit/core`: new `createPluginRunner` (binds a plugin's config-error class once and wraps command `run` handlers in the shared error-to-exit-code envelope) and `withFactoryDefaults` (layers plugin-factory options under parsed data). The backfill, codegen, and pull plugins now use these helpers instead of private copies — no behavior change, but the plugins require the matching `@chkit/core` version.

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -4,6 +4,7 @@
     "conditions": ["source", "bun"]
   },
   "ignorePatterns": ["examples/**"],
+  "entry": ["apps/docs/src/components/*.astro"],
   "duplicates": {
     "ignore": [
       "packages/**/*.test.ts",
@@ -16,7 +17,8 @@
     "ignore": [
       "packages/**/*.test.ts",
       "packages/**/*.spec.ts",
-      "packages/**/*.e2e.test.ts"
+      "packages/**/*.e2e.test.ts",
+      "packages/core/src/model.ts"
     ]
   }
 }

--- a/packages/core/src/flags.ts
+++ b/packages/core/src/flags.ts
@@ -81,6 +81,25 @@ export interface SafeParseable<T> {
 }
 
 /**
+ * Layer plugin-factory options under parsed data so registration-time defaults
+ * apply wherever the schema is evaluated (command dispatch, hooks).
+ */
+export function withFactoryDefaults<T>(
+  schema: SafeParseable<T>,
+  defaults: Record<string, unknown>,
+): SafeParseable<T> {
+  return {
+    safeParse(data) {
+      return schema.safeParse({ ...defaults, ...(isPlainRecord(data) ? data : {}) })
+    },
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
  * Two-layer option resolution: registration options → CLI flags.
  * Merges sources, validates through a schema, and throws ErrorClass on failure.
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,6 @@ export {
   renderCodec,
 } from './codec.js'
 export { assertValidDefinitions, validateDefinitions } from './validate.js'
-export { wrapPluginRun } from './plugin-error.js'
+export { createPluginRunner, wrapPluginRun, type PluginRunContext } from './plugin-error.js'
 export { splitSqlStatements, extractExecutableStatements } from './sql-splitter.js'
 export { importModuleFile } from './ts-import.js'

--- a/packages/core/src/plugin-error.ts
+++ b/packages/core/src/plugin-error.ts
@@ -1,3 +1,33 @@
+export interface PluginRunContext {
+  jsonMode: boolean
+  print: (value: unknown) => void
+}
+
+/**
+ * Bind a plugin's error class once and get a factory for command `run`
+ * handlers: each handler is wrapped in the shared error-to-exit-code
+ * envelope (json/text failure output, exit 2 for config errors, 1 otherwise).
+ */
+export function createPluginRunner<C extends PluginRunContext>(runner: {
+  configErrorClass?: new (message: string) => Error
+}) {
+  return function pluginCommandRun(input: {
+    command: string
+    label: string
+    fn: (context: C) => Promise<undefined | number> | undefined | number
+  }): (context: C) => Promise<number | undefined> {
+    return (context) =>
+      wrapPluginRun({
+        command: input.command,
+        label: input.label,
+        jsonMode: context.jsonMode,
+        print: context.print,
+        configErrorClass: runner.configErrorClass,
+        fn: () => input.fn(context),
+      })
+  }
+}
+
 export async function wrapPluginRun(options: {
   command: string
   label: string

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -1,5 +1,5 @@
 import { createClickHouseExecutor } from '@chkit/clickhouse'
-import { wrapPluginRun, type SafeParseable } from '@chkit/core'
+import { createPluginRunner, withFactoryDefaults } from '@chkit/core'
 
 import { executeBackfill, type BackfillProgress } from './async-backfill.js'
 import { buildChunkExecutionSql } from './chunking/sql.js'
@@ -44,9 +44,14 @@ import {
 } from './state.js'
 import type {
   BackfillPlugin,
+  BackfillPluginCommandContext,
   BackfillPluginRegistration,
   BackfillRunState,
 } from './types.js'
+
+const runCommand = createPluginRunner<BackfillPluginCommandContext>({
+  configErrorClass: BackfillConfigError,
+})
 
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`
@@ -192,21 +197,6 @@ async function runBackfill(input: {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function withFactoryDefaults<T>(
-  schema: SafeParseable<T>,
-  defaults: Record<string, unknown>,
-): SafeParseable<T> {
-  return {
-    safeParse(data) {
-      return schema.safeParse({ ...defaults, ...(isRecord(data) ? data : {}) })
-    },
-  }
-}
-
 export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin {
   const factoryOptions = options as Record<string, unknown>
   const planOptionsSchema = withFactoryDefaults(PlanSchema, factoryOptions)
@@ -228,61 +218,57 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: PLAN_FLAGS,
         optionsSchema: planOptionsSchema,
         flagMapping: PLAN_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'plan',
-            label: 'Backfill plan',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              const opts = context.options as PlanOptions
+        run: runCommand({
+          command: 'plan',
+          label: 'Backfill plan',
+          fn: async (context) => {
+            const opts = context.options as PlanOptions
 
-              if (!context.config.clickhouse) {
-                throw new BackfillConfigError(
-                  'ClickHouse connection is required for backfill planning. Configure clickhouse in your clickhouse.config.ts.'
+            if (!context.config.clickhouse) {
+              throw new BackfillConfigError(
+                'ClickHouse connection is required for backfill planning. Configure clickhouse in your clickhouse.config.ts.'
+              )
+            }
+
+            const db = createClickHouseExecutor(context.config.clickhouse)
+
+            try {
+              const output = await buildBackfillPlan({
+                opts,
+                configPath: context.configPath,
+                config: context.config,
+                clickhouse: context.config.clickhouse,
+                clickhouseQuery: async <T>(sql: string, settings?: Record<string, string | number | boolean | undefined>) => {
+                  const result = await db.query(sql, settings)
+                  return result as T[]
+                },
+                // ObsessionDB enables parallel replicas by default, which inflates
+                // aggregate results (count, GROUP BY). Disable for planning queries
+                // until ObsessionDB handles it at the profile level.
+                querySettings: { enable_parallel_replicas: 0 },
+              })
+
+              const payload = planPayload(output)
+              if (context.jsonMode) {
+                context.print(payload)
+              } else {
+                const partitionCount = output.plan.chunkPlan.partitions.length
+                const totalBytes = formatBytes(output.plan.chunkPlan.totalBytesCompressed)
+                const primarySortKey = output.plan.chunkPlan.table.sortKeys[0]
+                const sortKeyLabel = primarySortKey
+                  ? `, sort key: ${primarySortKey.name} (${primarySortKey.category})`
+                  : ''
+                context.print(
+                  `Backfill plan ${payload.planId} for ${payload.target} (${payload.chunkCount} chunks across ${partitionCount} partitions, ~${totalBytes}${sortKeyLabel}) -> ${payload.planPath}`
                 )
               }
 
-              const db = createClickHouseExecutor(context.config.clickhouse)
-
-              try {
-                const output = await buildBackfillPlan({
-                  opts,
-                  configPath: context.configPath,
-                  config: context.config,
-                  clickhouse: context.config.clickhouse,
-                  clickhouseQuery: async <T>(sql: string, settings?: Record<string, string | number | boolean | undefined>) => {
-                    const result = await db.query(sql, settings)
-                    return result as T[]
-                  },
-                  // ObsessionDB enables parallel replicas by default, which inflates
-                  // aggregate results (count, GROUP BY). Disable for planning queries
-                  // until ObsessionDB handles it at the profile level.
-                  querySettings: { enable_parallel_replicas: 0 },
-                })
-
-                const payload = planPayload(output)
-                if (context.jsonMode) {
-                  context.print(payload)
-                } else {
-                  const partitionCount = output.plan.chunkPlan.partitions.length
-                  const totalBytes = formatBytes(output.plan.chunkPlan.totalBytesCompressed)
-                  const primarySortKey = output.plan.chunkPlan.table.sortKeys[0]
-                  const sortKeyLabel = primarySortKey
-                    ? `, sort key: ${primarySortKey.name} (${primarySortKey.category})`
-                    : ''
-                  context.print(
-                    `Backfill plan ${payload.planId} for ${payload.target} (${payload.chunkCount} chunks across ${partitionCount} partitions, ~${totalBytes}${sortKeyLabel}) -> ${payload.planPath}`
-                  )
-                }
-
-                return 0
-              } finally {
-                await db.close()
-              }
-            },
-          }),
+              return 0
+            } finally {
+              await db.close()
+            }
+          },
+        }),
       },
       {
         name: 'submit',
@@ -290,25 +276,21 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: SUBMIT_FLAGS,
         optionsSchema: submitOptionsSchema,
         flagMapping: SUBMIT_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'submit',
-            label: 'Backfill submit',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              // Reaching this handler means no managed backend intercepted the
-              // command. The ObsessionDB plugin handles `submit` via its
-              // onBeforePluginCommand hook when a service is selected; without
-              // one there is nowhere to submit to.
-              throw new BackfillConfigError(
-                'backfill submit requires a managed job backend. Log in and select an ObsessionDB service ' +
-                  '(`chkit obsessiondb login`, then `chkit obsessiondb service select`), ' +
-                  'or use `chkit backfill run --local` to execute the backfill against a direct connection.',
-              )
-            },
-          }),
+        run: runCommand({
+          command: 'submit',
+          label: 'Backfill submit',
+          fn: async () => {
+            // Reaching this handler means no managed backend intercepted the
+            // command. The ObsessionDB plugin handles `submit` via its
+            // onBeforePluginCommand hook when a service is selected; without
+            // one there is nowhere to submit to.
+            throw new BackfillConfigError(
+              'backfill submit requires a managed job backend. Log in and select an ObsessionDB service ' +
+                '(`chkit obsessiondb login`, then `chkit obsessiondb service select`), ' +
+                'or use `chkit backfill run --local` to execute the backfill against a direct connection.',
+            )
+          },
+        }),
       },
       {
         name: 'run',
@@ -316,36 +298,32 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: RUN_FLAGS,
         optionsSchema: runOptionsSchema,
         flagMapping: RUN_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'run',
-            label: 'Backfill run',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              const opts = context.options as RunOptions
+        run: runCommand({
+          command: 'run',
+          label: 'Backfill run',
+          fn: async (context) => {
+            const opts = context.options as RunOptions
 
-              if (!context.config.clickhouse) {
-                throw new BackfillConfigError(
-                  'ClickHouse connection is required for backfill execution. Configure clickhouse in your clickhouse.config.ts.'
-                )
-              }
+            if (!context.config.clickhouse) {
+              throw new BackfillConfigError(
+                'ClickHouse connection is required for backfill execution. Configure clickhouse in your clickhouse.config.ts.'
+              )
+            }
 
-              return runBackfill({
-                planId: opts.planId,
-                forceEnvironment: opts.forceEnvironment,
-                concurrency: opts.concurrency,
-                pollIntervalMs: opts.pollIntervalMs,
-                stateDir: opts.stateDir,
-                configPath: context.configPath,
-                config: context.config,
-                clickhouse: context.config.clickhouse,
-                print: context.print,
-                jsonMode: context.jsonMode,
-              })
-            },
-          }),
+            return runBackfill({
+              planId: opts.planId,
+              forceEnvironment: opts.forceEnvironment,
+              concurrency: opts.concurrency,
+              pollIntervalMs: opts.pollIntervalMs,
+              stateDir: opts.stateDir,
+              configPath: context.configPath,
+              config: context.config,
+              clickhouse: context.config.clickhouse,
+              print: context.print,
+              jsonMode: context.jsonMode,
+            })
+          },
+        }),
       },
       {
         name: 'resume',
@@ -353,60 +331,56 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: RESUME_FLAGS,
         optionsSchema: resumeOptionsSchema,
         flagMapping: RESUME_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'resume',
-            label: 'Backfill resume',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              const opts = context.options as ResumeOptions
+        run: runCommand({
+          command: 'resume',
+          label: 'Backfill resume',
+          fn: async (context) => {
+            const opts = context.options as ResumeOptions
 
-              if (!context.config.clickhouse) {
-                throw new BackfillConfigError(
-                  'ClickHouse connection is required for backfill execution. Configure clickhouse in your clickhouse.config.ts.'
-                )
-              }
+            if (!context.config.clickhouse) {
+              throw new BackfillConfigError(
+                'ClickHouse connection is required for backfill execution. Configure clickhouse in your clickhouse.config.ts.'
+              )
+            }
 
-              const { stateDir } = await readPlan({
-                planId: opts.planId,
-                configPath: context.configPath,
-                config: context.config,
-                stateDir: opts.stateDir,
-              })
-              const paths = backfillPaths(stateDir, opts.planId)
-              const existingRun = await readRun(paths.runPath)
-              if (!existingRun) {
-                throw new BackfillConfigError(
-                  `Run state not found for plan ${opts.planId}. Start with backfill run before resume.`
-                )
+            const { stateDir } = await readPlan({
+              planId: opts.planId,
+              configPath: context.configPath,
+              config: context.config,
+              stateDir: opts.stateDir,
+            })
+            const paths = backfillPaths(stateDir, opts.planId)
+            const existingRun = await readRun(paths.runPath)
+            if (!existingRun) {
+              throw new BackfillConfigError(
+                `Run state not found for plan ${opts.planId}. Start with backfill run before resume.`
+              )
+            }
+            if (existingRun.status === 'completed') {
+              if (context.jsonMode) {
+                context.print({ ok: true, noop: true, planId: opts.planId, status: 'completed', message: 'Run already completed. Nothing to resume.' })
+              } else {
+                context.print(`Backfill ${opts.planId}: already completed. Nothing to resume.`)
               }
-              if (existingRun.status === 'completed') {
-                if (context.jsonMode) {
-                  context.print({ ok: true, noop: true, planId: opts.planId, status: 'completed', message: 'Run already completed. Nothing to resume.' })
-                } else {
-                  context.print(`Backfill ${opts.planId}: already completed. Nothing to resume.`)
-                }
-                return 0
-              }
+              return 0
+            }
 
-              return runBackfill({
-                planId: opts.planId,
-                forceEnvironment: opts.forceEnvironment,
-                concurrency: opts.concurrency,
-                pollIntervalMs: opts.pollIntervalMs,
-                stateDir: opts.stateDir,
-                resumeFrom: existingRun.progress,
-                replayFailed: opts.replayFailed,
-                configPath: context.configPath,
-                config: context.config,
-                clickhouse: context.config.clickhouse,
-                print: context.print,
-                jsonMode: context.jsonMode,
-              })
-            },
-          }),
+            return runBackfill({
+              planId: opts.planId,
+              forceEnvironment: opts.forceEnvironment,
+              concurrency: opts.concurrency,
+              pollIntervalMs: opts.pollIntervalMs,
+              stateDir: opts.stateDir,
+              resumeFrom: existingRun.progress,
+              replayFailed: opts.replayFailed,
+              configPath: context.configPath,
+              config: context.config,
+              clickhouse: context.config.clickhouse,
+              print: context.print,
+              jsonMode: context.jsonMode,
+            })
+          },
+        }),
       },
       {
         name: 'status',
@@ -414,37 +388,33 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: PLAN_ID_FLAGS,
         optionsSchema: statusOptionsSchema,
         flagMapping: PLAN_ID_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'status',
-            label: 'Backfill status',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              const opts = context.options as StatusOptions
-              const summary = await getBackfillStatus({
-                planId: opts.planId,
-                config: context.config,
-                configPath: context.configPath,
-                stateDir: opts.stateDir,
-              })
-              const payload = statusPayload(summary)
-              if (context.jsonMode) {
-                context.print(payload)
-              } else {
-                let line = `Backfill status ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total}, failed=${payload.chunkCounts.failed}, ${payload.rowsWritten} rows written)`
-                if (payload.lastError) line += ` \u2014 ${payload.lastError}`
-                context.print(line)
-                if (payload.status === 'completed' && payload.rowsWritten === 0) {
-                  context.print(
-                    'Warning: 0 rows written across all chunks. Verify that source data exists in the time range and passes the query\'s WHERE filters.'
-                  )
-                }
+        run: runCommand({
+          command: 'status',
+          label: 'Backfill status',
+          fn: async (context) => {
+            const opts = context.options as StatusOptions
+            const summary = await getBackfillStatus({
+              planId: opts.planId,
+              config: context.config,
+              configPath: context.configPath,
+              stateDir: opts.stateDir,
+            })
+            const payload = statusPayload(summary)
+            if (context.jsonMode) {
+              context.print(payload)
+            } else {
+              let line = `Backfill status ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total}, failed=${payload.chunkCounts.failed}, ${payload.rowsWritten} rows written)`
+              if (payload.lastError) line += ` \u2014 ${payload.lastError}`
+              context.print(line)
+              if (payload.status === 'completed' && payload.rowsWritten === 0) {
+                context.print(
+                  'Warning: 0 rows written across all chunks. Verify that source data exists in the time range and passes the query\'s WHERE filters.'
+                )
               }
-              return payload.ok ? 0 : 1
-            },
-          }),
+            }
+            return payload.ok ? 0 : 1
+          },
+        }),
       },
       {
         name: 'cancel',
@@ -452,32 +422,28 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: PLAN_ID_FLAGS,
         optionsSchema: statusOptionsSchema,
         flagMapping: PLAN_ID_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'cancel',
-            label: 'Backfill cancel',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              const opts = context.options as StatusOptions
-              const summary = await cancelBackfillRun({
-                planId: opts.planId,
-                config: context.config,
-                configPath: context.configPath,
-                stateDir: opts.stateDir,
-              })
-              const payload = cancelPayload(summary)
-              if (context.jsonMode) {
-                context.print(payload)
-              } else {
-                context.print(
-                  `Backfill cancel ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total})`
-                )
-              }
-              return payload.ok ? 0 : 1
-            },
-          }),
+        run: runCommand({
+          command: 'cancel',
+          label: 'Backfill cancel',
+          fn: async (context) => {
+            const opts = context.options as StatusOptions
+            const summary = await cancelBackfillRun({
+              planId: opts.planId,
+              config: context.config,
+              configPath: context.configPath,
+              stateDir: opts.stateDir,
+            })
+            const payload = cancelPayload(summary)
+            if (context.jsonMode) {
+              context.print(payload)
+            } else {
+              context.print(
+                `Backfill cancel ${payload.planId}: ${payload.status} (done=${payload.chunkCounts.done}/${payload.chunkCounts.total})`
+              )
+            }
+            return payload.ok ? 0 : 1
+          },
+        }),
       },
       {
         name: 'doctor',
@@ -485,35 +451,31 @@ export function createBackfillPlugin(options: PluginConfig = {}): BackfillPlugin
         flags: PLAN_ID_FLAGS,
         optionsSchema: statusOptionsSchema,
         flagMapping: PLAN_ID_FLAG_MAP,
-        run: async (context) =>
-          wrapPluginRun({
-            command: 'doctor',
-            label: 'Backfill doctor',
-            jsonMode: context.jsonMode,
-            print: context.print,
-            configErrorClass: BackfillConfigError,
-            fn: async () => {
-              const opts = context.options as StatusOptions
-              const report = await getBackfillDoctorReport({
-                planId: opts.planId,
-                config: context.config,
-                configPath: context.configPath,
-                stateDir: opts.stateDir,
-              })
-              const payload = doctorPayload(report)
-              if (context.jsonMode) {
-                context.print(payload)
-              } else {
-                context.print(
-                  `Backfill doctor ${payload.planId}: ${payload.issueCodes.length === 0 ? 'ok' : payload.issueCodes.join(', ')}`
-                )
-                for (const recommendation of payload.recommendations) {
-                  context.print(`- ${recommendation}`)
-                }
+        run: runCommand({
+          command: 'doctor',
+          label: 'Backfill doctor',
+          fn: async (context) => {
+            const opts = context.options as StatusOptions
+            const report = await getBackfillDoctorReport({
+              planId: opts.planId,
+              config: context.config,
+              configPath: context.configPath,
+              stateDir: opts.stateDir,
+            })
+            const payload = doctorPayload(report)
+            if (context.jsonMode) {
+              context.print(payload)
+            } else {
+              context.print(
+                `Backfill doctor ${payload.planId}: ${payload.issueCodes.length === 0 ? 'ok' : payload.issueCodes.join(', ')}`
+              )
+              for (const recommendation of payload.recommendations) {
+                context.print(`- ${recommendation}`)
               }
-              return payload.ok ? 0 : 1
-            },
-          }),
+            }
+            return payload.ok ? 0 : 1
+          },
+        }),
       },
     ],
     hooks: {

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -142,7 +142,7 @@ export interface BackfillDoctorReport {
   failedChunkIds: string[]
 }
 
-interface BackfillPluginCommandContext<TOptions = Record<string, unknown>> {
+export interface BackfillPluginCommandContext<TOptions = Record<string, unknown>> {
   args: string[]
   flags: Record<string, string | string[] | boolean | undefined>
   jsonMode: boolean

--- a/packages/plugin-codegen/src/plugin.ts
+++ b/packages/plugin-codegen/src/plugin.ts
@@ -1,12 +1,13 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
-import { wrapPluginRun, type SafeParseable } from '@chkit/core'
+import { createPluginRunner, withFactoryDefaults } from '@chkit/core'
 import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 
 import type {
   CodegenPlugin,
   CodegenPluginCheckResult,
+  CodegenPluginCommandContext,
   CodegenPluginOptions,
   CodegenPluginRegistration,
   GenerateIngestArtifactsOutput,
@@ -102,20 +103,9 @@ function mergeCheckResults(results: CodegenPluginCheckResult[]): CodegenPluginCh
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function withFactoryDefaults<T>(
-  schema: SafeParseable<T>,
-  defaults: Record<string, unknown>,
-): SafeParseable<T> {
-  return {
-    safeParse(data) {
-      return schema.safeParse({ ...defaults, ...(isRecord(data) ? data : {}) })
-    },
-  }
-}
+const runCommand = createPluginRunner<CodegenPluginCommandContext>({
+  configErrorClass: CodegenConfigError,
+})
 
 export function createCodegenPlugin(options: CodegenPluginOptions = {}): CodegenPlugin {
   const factoryOptions = options as Record<string, unknown>
@@ -134,129 +124,124 @@ export function createCodegenPlugin(options: CodegenPluginOptions = {}): Codegen
         flags: CODEGEN_FLAGS,
         optionsSchema,
         flagMapping: CODEGEN_FLAG_MAP,
-        async run({ flags, jsonMode, print, options: effectiveOptions, config, configPath }): Promise<undefined | number> {
-          return wrapPluginRun({
-            command: 'codegen',
-            label: 'Codegen',
-            jsonMode,
-            print,
-            configErrorClass: CodegenConfigError,
-            fn: async () => {
-              const checkMode = flags['--check'] === true
-              const configDir = resolve(configPath, '..')
-              const outFile = resolve(configDir, effectiveOptions.outFile)
-              const definitions = await loadSchemaDefinitions(config.schema, { cwd: configDir })
-              const generated = generateTypeArtifacts({
+        run: runCommand({
+          command: 'codegen',
+          label: 'Codegen',
+          fn: async ({ flags, jsonMode, print, options: effectiveOptions, config, configPath }) => {
+            const checkMode = flags['--check'] === true
+            const configDir = resolve(configPath, '..')
+            const outFile = resolve(configDir, effectiveOptions.outFile)
+            const definitions = await loadSchemaDefinitions(config.schema, { cwd: configDir })
+            const generated = generateTypeArtifacts({
+              definitions,
+              options: effectiveOptions,
+            })
+
+            let ingestGenerated: GenerateIngestArtifactsOutput | null = null
+            let ingestOutFile: string | null = null
+            if (effectiveOptions.emitIngest) {
+              ingestGenerated = generateIngestArtifacts({
                 definitions,
                 options: effectiveOptions,
               })
+              ingestOutFile = resolve(configDir, effectiveOptions.ingestOutFile)
+            }
 
-              let ingestGenerated: GenerateIngestArtifactsOutput | null = null
-              let ingestOutFile: string | null = null
-              if (effectiveOptions.emitIngest) {
-                ingestGenerated = generateIngestArtifacts({
-                  definitions,
-                  options: effectiveOptions,
-                })
-                ingestOutFile = resolve(configDir, effectiveOptions.ingestOutFile)
-              }
+            let migrationsGenerated: GenerateMigrationArtifactsOutput | null = null
+            let migrationsOutFile: string | null = null
+            if (effectiveOptions.emitMigrations) {
+              migrationsGenerated = await generateMigrationArtifacts({
+                migrationsDir: resolve(configDir, config.migrationsDir),
+                options: effectiveOptions,
+              })
+              migrationsOutFile = resolve(configDir, effectiveOptions.migrationsOutFile)
+            }
 
-              let migrationsGenerated: GenerateMigrationArtifactsOutput | null = null
-              let migrationsOutFile: string | null = null
-              if (effectiveOptions.emitMigrations) {
-                migrationsGenerated = await generateMigrationArtifacts({
-                  migrationsDir: resolve(configDir, config.migrationsDir),
-                  options: effectiveOptions,
-                })
-                migrationsOutFile = resolve(configDir, effectiveOptions.migrationsOutFile)
-              }
+            if (checkMode) {
+              const current = await readMaybe(outFile)
+              const typeCheckResult = checkGeneratedOutput({
+                label: 'Codegen',
+                outFile,
+                expected: generated.content,
+                current,
+                missingCode: 'codegen_missing_output',
+                staleCode: 'codegen_stale_output',
+              })
 
-              if (checkMode) {
-                const current = await readMaybe(outFile)
-                const typeCheckResult = checkGeneratedOutput({
-                  label: 'Codegen',
-                  outFile,
-                  expected: generated.content,
-                  current,
-                  missingCode: 'codegen_missing_output',
-                  staleCode: 'codegen_stale_output',
-                })
-
-                const results = [typeCheckResult]
-
-                if (ingestGenerated && ingestOutFile) {
-                  const ingestCurrent = await readMaybe(ingestOutFile)
-                  results.push(checkGeneratedOutput({
-                    label: 'Codegen ingest',
-                    outFile: ingestOutFile,
-                    expected: ingestGenerated.content,
-                    current: ingestCurrent,
-                    missingCode: 'codegen_missing_ingest_output',
-                    staleCode: 'codegen_stale_ingest_output',
-                  }))
-                }
-
-                if (migrationsGenerated && migrationsOutFile) {
-                  const migrationsCurrent = await readMaybe(migrationsOutFile)
-                  results.push(checkGeneratedOutput({
-                    label: 'Codegen migrations',
-                    outFile: migrationsOutFile,
-                    expected: migrationsGenerated.content,
-                    current: migrationsCurrent,
-                    missingCode: 'codegen_missing_migrations_output',
-                    staleCode: 'codegen_stale_migrations_output',
-                  }))
-                }
-
-                const checkResult = mergeCheckResults(results)
-                const payload = {
-                  ok: checkResult.ok,
-                  findingCodes: checkResult.findings.map((finding) => finding.code),
-                  outFile,
-                  mode: 'check',
-                }
-
-                if (jsonMode) {
-                  print(payload)
-                } else {
-                  if (checkResult.ok) {
-                    print(`Codegen up-to-date: ${outFile}`)
-                  } else {
-                    const firstCode = checkResult.findings[0]?.code ?? 'codegen_stale_output'
-                    print(`Codegen check failed (${firstCode}): ${outFile}`)
-                  }
-                }
-                return checkResult.ok ? 0 : 1
-              }
-
-              await writeAtomic(outFile, generated.content)
+              const results = [typeCheckResult]
 
               if (ingestGenerated && ingestOutFile) {
-                await writeAtomic(ingestOutFile, ingestGenerated.content)
+                const ingestCurrent = await readMaybe(ingestOutFile)
+                results.push(checkGeneratedOutput({
+                  label: 'Codegen ingest',
+                  outFile: ingestOutFile,
+                  expected: ingestGenerated.content,
+                  current: ingestCurrent,
+                  missingCode: 'codegen_missing_ingest_output',
+                  staleCode: 'codegen_stale_ingest_output',
+                }))
               }
 
               if (migrationsGenerated && migrationsOutFile) {
-                await writeAtomic(migrationsOutFile, migrationsGenerated.content)
+                const migrationsCurrent = await readMaybe(migrationsOutFile)
+                results.push(checkGeneratedOutput({
+                  label: 'Codegen migrations',
+                  outFile: migrationsOutFile,
+                  expected: migrationsGenerated.content,
+                  current: migrationsCurrent,
+                  missingCode: 'codegen_missing_migrations_output',
+                  staleCode: 'codegen_stale_migrations_output',
+                }))
               }
 
+              const checkResult = mergeCheckResults(results)
               const payload = {
-                ok: true,
+                ok: checkResult.ok,
+                findingCodes: checkResult.findings.map((finding) => finding.code),
                 outFile,
-                declarationCount: generated.declarationCount,
-                findingCodes: generated.findings.map((finding) => finding.code),
-                mode: 'write',
+                mode: 'check',
               }
 
               if (jsonMode) {
                 print(payload)
               } else {
-                print(`Codegen wrote ${outFile} (${generated.declarationCount} declarations)`)
+                if (checkResult.ok) {
+                  print(`Codegen up-to-date: ${outFile}`)
+                } else {
+                  const firstCode = checkResult.findings[0]?.code ?? 'codegen_stale_output'
+                  print(`Codegen check failed (${firstCode}): ${outFile}`)
+                }
               }
+              return checkResult.ok ? 0 : 1
+            }
 
-              return 0
-            },
-          })
-        },
+            await writeAtomic(outFile, generated.content)
+
+            if (ingestGenerated && ingestOutFile) {
+              await writeAtomic(ingestOutFile, ingestGenerated.content)
+            }
+
+            if (migrationsGenerated && migrationsOutFile) {
+              await writeAtomic(migrationsOutFile, migrationsGenerated.content)
+            }
+
+            const payload = {
+              ok: true,
+              outFile,
+              declarationCount: generated.declarationCount,
+              findingCodes: generated.findings.map((finding) => finding.code),
+              mode: 'write',
+            }
+
+            if (jsonMode) {
+              print(payload)
+            } else {
+              print(`Codegen wrote ${outFile} (${generated.declarationCount} declarations)`)
+            }
+
+            return 0
+          },
+        }),
       },
     ],
     hooks: {

--- a/packages/plugin-pull/src/index.ts
+++ b/packages/plugin-pull/src/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   canonicalizeDefinitions,
   type ChxInlinePluginRegistration,
+  createPluginRunner,
   defineFlags,
   type FlagMapping,
   normalizeEngine,
@@ -19,7 +20,7 @@ import {
   type SchemaDefinition,
   splitTopLevelComma,
   type TableDefinition,
-  wrapPluginRun,
+  withFactoryDefaults,
 } from '@chkit/core'
 export { renderSchemaFile } from './render-schema.js'
 import { renderSchemaFile } from './render-schema.js'
@@ -144,16 +145,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function withFactoryDefaults<T>(
-  schema: SafeParseable<T>,
-  defaults: Record<string, unknown>,
-): SafeParseable<T> {
-  return {
-    safeParse(data) {
-      return schema.safeParse({ ...defaults, ...(isRecord(data) ? data : {}) })
-    },
-  }
-}
+const runCommand = createPluginRunner<PullPluginCommandContext>({
+  configErrorClass: PullConfigError,
+})
 
 export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
   const { introspect: introspector, ...factoryOptions } = options
@@ -172,74 +166,69 @@ export function createPullPlugin(options: PullPluginOptions = {}): PullPlugin {
         flags: PULL_SCHEMA_FLAGS,
         optionsSchema,
         flagMapping: PULL_FLAG_MAP,
-        async run({ flags, jsonMode, print, options: opts, config, pluginContext }) {
-          return wrapPluginRun({
-            command: 'schema',
-            label: 'Pull schema',
-            jsonMode,
-            print,
-            configErrorClass: PullConfigError,
-            fn: async () => {
-              const flagOptions = {
-                ...(typeof flags['--out-file'] === 'string' ? { outFile: flags['--out-file'] } : {}),
-                ...(flags['--force'] === true || flags['--overwrite'] === true
-                  ? { overwrite: true }
-                  : {}),
-                ...(stringArrayFlag(flags['--database'])
-                  ? { databases: stringArrayFlag(flags['--database']) }
-                  : {}),
-              }
-              const effectiveOptions = PullSchema.parse({
-                ...factoryOptions,
-                ...(isRecord(opts) ? opts : {}),
-                ...flagOptions,
-              })
-              const dryrun = flags['--dryrun'] === true
-              const pulled = await pullSchema({
-                config,
-                executor: pluginContext?.hasExecutor ? pluginContext.executor : null,
-                options: { ...effectiveOptions, introspect: introspector },
-              })
+        run: runCommand({
+          command: 'schema',
+          label: 'Pull schema',
+          fn: async ({ flags, jsonMode, print, options: opts, config, pluginContext }) => {
+            const flagOptions = {
+              ...(typeof flags['--out-file'] === 'string' ? { outFile: flags['--out-file'] } : {}),
+              ...(flags['--force'] === true || flags['--overwrite'] === true
+                ? { overwrite: true }
+                : {}),
+              ...(stringArrayFlag(flags['--database'])
+                ? { databases: stringArrayFlag(flags['--database']) }
+                : {}),
+            }
+            const effectiveOptions = PullSchema.parse({
+              ...factoryOptions,
+              ...(isRecord(opts) ? opts : {}),
+              ...flagOptions,
+            })
+            const dryrun = flags['--dryrun'] === true
+            const pulled = await pullSchema({
+              config,
+              executor: pluginContext?.hasExecutor ? pluginContext.executor : null,
+              options: { ...effectiveOptions, introspect: introspector },
+            })
 
-              if (!dryrun) {
-                await writeSchemaFile({
-                  outFile: pulled.outFile,
-                  content: pulled.content,
-                  overwrite: effectiveOptions.overwrite,
-                })
-              }
-
-              const payload = {
-                ok: true,
-                command: 'schema' as const,
+            if (!dryrun) {
+              await writeSchemaFile({
                 outFile: pulled.outFile,
-                definitionCount: pulled.definitionCount,
-                tableCount: pulled.tableCount,
-                databases: pulled.databases,
-                skippedObjects: pulled.skippedObjects,
-                dryrun,
-                ...(dryrun ? { content: pulled.content } : {}),
-              }
+                content: pulled.content,
+                overwrite: effectiveOptions.overwrite,
+              })
+            }
 
-              if (jsonMode) {
-                print(payload)
-                return 0
-              }
+            const payload = {
+              ok: true,
+              command: 'schema' as const,
+              outFile: pulled.outFile,
+              definitionCount: pulled.definitionCount,
+              tableCount: pulled.tableCount,
+              databases: pulled.databases,
+              skippedObjects: pulled.skippedObjects,
+              dryrun,
+              ...(dryrun ? { content: pulled.content } : {}),
+            }
 
-              if (dryrun) {
-                print(
-                  `Pull preview: ${pulled.definitionCount} objects from ${pulled.databases.join(', ') || '(none)'}`
-                )
-                print(pulled.content)
-              } else {
-                print(
-                  `Pulled ${pulled.definitionCount} objects from ${pulled.databases.join(', ') || '(none)'} to ${pulled.outFile}`
-                )
-              }
+            if (jsonMode) {
+              print(payload)
               return 0
-            },
-          })
-        },
+            }
+
+            if (dryrun) {
+              print(
+                `Pull preview: ${pulled.definitionCount} objects from ${pulled.databases.join(', ') || '(none)'}`
+              )
+              print(pulled.content)
+            } else {
+              print(
+                `Pulled ${pulled.definitionCount} objects from ${pulled.databases.join(', ') || '(none)'} to ${pulled.outFile}`
+              )
+            }
+            return 0
+          },
+        }),
       },
     ],
   }


### PR DESCRIPTION
## Summary
- Add `createPluginRunner` and `withFactoryDefaults` to `@chkit/core` — the error-to-exit-code `run` wrapper and registration-options layering that the backfill, codegen, and pull plugins each carried as private copies.
- Rewire all 9 plugin commands (7 backfill, 1 codegen, 1 pull) to the shared runner; per-command scaffold shrinks from ~10 lines to ~4 and the error envelope (exit 2 for config errors, 1 otherwise, json/text failure output) now exists exactly once.
- No behavior change. Removes the ~350-line cross-plugin structural clone flagged by fallow; repo duplication drops from 5.09% to 2.37%.
- Changeset: patch bumps for `@chkit/core` and the three plugins, since the plugins now require the matching core version.

## Test plan
- [x] `bun verify` (typecheck, lint, test, build — 37/37 tasks) including live-ClickHouse e2e for backfill, pull, and the CLI plugin-dispatch/usage-error suites
- [x] `fallow dupes` re-run confirms the cross-plugin clone family is gone