### PR TITLE
docs: document backfill jobs (local vs managed ObsessionDB)

### DIFF
--- a/apps/docs/src/content/docs/obsessiondb/backfills.md
+++ b/apps/docs/src/content/docs/obsessiondb/backfills.md
@@ -1,0 +1,80 @@
+---
+title: Backfill Jobs
+description: Run backfills as managed ObsessionDB jobs — submit a plan, track it in the console, and let the backend execute the chunks server-side.
+sidebar:
+  order: 5
+---
+
+The [backfill plugin](/plugins/backfill/) runs a backfill in one of two venues: locally against a direct ClickHouse connection, or as a **managed job** on ObsessionDB. This page covers the managed path — submitting a plan to the ObsessionDB job backend and tracking it from the console.
+
+The chunking algorithm is identical either way. `submit` builds the exact same plan `run` would, then hands the chunks to the backend instead of streaming them from your machine.
+
+## Prerequisites
+
+Managed backfills need the ObsessionDB plugin registered (see the [Overview](/obsessiondb/overview/)), an authenticated session, and a selected service:
+
+```sh
+chkit obsessiondb login
+chkit obsessiondb service select
+```
+
+The selection is persisted to `.chkit/obsessiondb.json` next to your config. Without a selected service there is nowhere to submit to, and `chkit plugin backfill submit` explains how to set one up (or fall back to local execution).
+
+## Submit a backfill
+
+`submit` plans and submits in one step — there is no separate `plan` command to run first:
+
+```sh
+chkit plugin backfill submit --target analytics.events --from 2025-01-01 --to 2025-02-01
+```
+
+On success it prints the job ID and a console deep-link:
+
+```
+Submitted backfill job 4f2c… for analytics.events (12 tasks).
+Track progress: https://console.obsessiondb.com/<service>/jobs/4f2c…
+```
+
+The backend runs the chunks server-side, so there is no local checkpoint and nothing to poll from your machine. The window flags are optional — omit `--from`/`--to` to backfill from the table's earliest partition to its latest. See the [`submit` reference](/plugins/backfill/#chkit-plugin-backfill-submit) for the full flag table (`--title`, `--concurrency`, `--max-chunk-bytes`).
+
+## Track progress
+
+The console link from `submit` is the primary way to watch a job. From the CLI, the remote job commands query the backend directly — they take a `--job-id` or `--service-slug` instead of a local `--plan-id`:
+
+```sh
+# Status of one job
+chkit plugin backfill status --job-id <jobId>
+
+# All backfill jobs for a service
+chkit plugin backfill status --service-slug <service>
+
+# Cancel a running job
+chkit plugin backfill cancel --job-id <jobId>
+```
+
+Passing `--plan-id` instead keeps `status`/`cancel` local, operating on on-disk run state rather than the backend.
+
+## Local execution is guarded against ObsessionDB
+
+`plan`, `run`, and `resume` execute the chunk loop against a direct ClickHouse connection. When ObsessionDB is the active target (logged in with a service selected, or `--service` set), these commands are **refused** rather than silently opening a connection that bypasses ObsessionDB:
+
+```
+Backfill run runs locally and is not supported directly against ObsessionDB.
+Use `chkit backfill submit` to run it as a managed ObsessionDB job, or re-run with
+--local to execute against a direct ClickHouse connection.
+```
+
+Two ways forward:
+
+- **Run it as a managed job** — use `submit` (recommended for ObsessionDB targets).
+- **Force local execution** — add `--local` to `plan`, `run`, or `resume` to skip remote routing and execute against a direct ClickHouse connection. This requires a `clickhouse` block in your config.
+
+## How it works
+
+Each chunk renders the same idempotent `INSERT … SELECT` the local executor would run, including CTE-wrapped materialized-view replay when the target is an MV's `to` table. The backend receives the task list, executes chunks with the requested `--concurrency` (1–48), and retries failed chunks up to the plan's per-chunk retry budget. Idempotency tokens make re-runs safe: re-submitting the same window does not double-write.
+
+## Related
+
+- [Backfill Plugin](/plugins/backfill/) — full command reference, planning options, and local execution.
+- [Services](/obsessiondb/services/) — select and override the ObsessionDB service jobs run against.
+- [Overview](/obsessiondb/overview/) — install and register the ObsessionDB plugin.

--- a/apps/docs/src/content/docs/obsessiondb/overview.md
+++ b/apps/docs/src/content/docs/obsessiondb/overview.md
@@ -44,4 +44,4 @@ The plugin hooks into `generate`, `migrate`, `status`, `drift`, `check`, and `qu
 - [Getting Started](/obsessiondb/getting-started/) — sign up, authenticate, and select your first service.
 - [Engine Rewriting](/obsessiondb/engine-rewriting/) — how `Shared*` engines are stripped for non-ObsessionDB targets.
 - [Services](/obsessiondb/services/) — list, select, alias, and override services per command.
-- [Backfill Plugin](/plugins/backfill/) — for backfills against ObsessionDB once a service is selected.
+- [Backfill Jobs](/obsessiondb/backfills/) — submit backfills as managed jobs and track them in the console.

--- a/apps/docs/src/content/docs/obsessiondb/services.md
+++ b/apps/docs/src/content/docs/obsessiondb/services.md
@@ -78,4 +78,4 @@ See [`chkit query`](/cli/query/) for the command reference, including the `--ser
 
 - [`chkit query`](/cli/query/) — ad-hoc SQL execution against the selected service.
 - [Engine Rewriting](/obsessiondb/engine-rewriting/) — how `Shared*` engines are handled depending on the active target.
-- [Backfill Plugin](/plugins/backfill/) — backfills can submit jobs to ObsessionDB once a service is selected.
+- [Backfill Jobs](/obsessiondb/backfills/) — submit backfills as managed jobs to the selected service.

--- a/apps/docs/src/content/docs/plugins/backfill.md
+++ b/apps/docs/src/content/docs/plugins/backfill.md
@@ -18,6 +18,7 @@ The `backfill` plugin is in alpha. Its API, configuration, and CLI flags may cha
 
 - Builds deterministic, immutable backfill plans that divide a time window into chunks.
 - Executes backfills via async query submission with configurable concurrency and server-side polling.
+- Runs either locally against a direct ClickHouse connection or as a managed job on [ObsessionDB](/obsessiondb/backfills/) — the same plan, a different execution venue.
 - Detects materialized views and automatically generates correct CTE-wrapped replay queries.
 - Supports resume from checkpoint, cancel, status monitoring, and doctor-style diagnostics.
 - Integrates with [`chkit check`](/cli/check/) for CI enforcement of pending backfills.
@@ -33,7 +34,19 @@ The plugin follows a plan-then-execute lifecycle:
 
 Additional commands: `resume` (continue from checkpoint with optional failed-chunk replay), `cancel` (mark run as cancelled), `doctor` (actionable diagnostics).
 
+To run the plan on a managed backend instead of your own machine, replace `run` with `submit` — see **Execution modes** below.
+
 [`chkit check`](/cli/check/) integration reports pending or failed backfills in CI.
+
+## Execution modes: local vs managed jobs
+
+Backfills run in one of two venues. Both build the identical chunk plan with the same chunking algorithm — only where the chunks execute differs.
+
+**Local execution** (`run`, `resume`) — Opens a direct ClickHouse connection and submits chunks as async queries from your machine, polling for completion. This is the default and requires a `clickhouse` block in your config. Plan and run checkpoint state live on disk under `stateDir`, so `resume`, `status`, `cancel`, and `doctor` operate on local files.
+
+**Managed job** (`submit`) — Builds the same plan and hands the chunks to a managed job backend, which runs them server-side. Nothing streams from your machine and there is no local checkpoint to babysit — the command prints a job ID and a console link to track progress. Today the only managed backend is [ObsessionDB](/obsessiondb/backfills/); `submit` requires an authenticated session with a selected service.
+
+When ObsessionDB is the active target (logged in with a service selected), `plan`, `run`, and `resume` are refused rather than silently opening a direct connection that bypasses ObsessionDB. Use `submit` to run the backfill as a managed job, or pass `--local` to force local execution against a direct ClickHouse connection. See [Backfill Jobs](/obsessiondb/backfills/) for the managed path in detail.
 
 ## Plugin setup
 
@@ -177,7 +190,7 @@ Build a deterministic backfill plan and persist immutable plan state.
 
 ### `chkit plugin backfill submit`
 
-Build the plan with the same chunking algorithm as `run`, then submit it to a managed job backend instead of executing it locally. Requires an authenticated [ObsessionDB](/plugins/overview/) session with a selected service (`chkit obsessiondb login`, then `chkit obsessiondb service select`); without one, the command explains how to set it up or fall back to `run --local`. On success it prints the job ID and a console link to track progress — the backend runs the chunks, so no local polling is needed.
+Build the plan with the same chunking algorithm as `run`, then submit it to a managed job backend instead of executing it locally. Requires an authenticated [ObsessionDB](/obsessiondb/backfills/) session with a selected service (`chkit obsessiondb login`, then `chkit obsessiondb service select`); without one, the command explains how to set it up or fall back to `run --local`. On success it prints the job ID and a console link to track progress — the backend runs the chunks, so no local polling is needed. See [Backfill Jobs](/obsessiondb/backfills/) for the full managed flow.
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -289,6 +302,15 @@ chkit plugin backfill status --plan-id <planId>
 chkit plugin backfill plan --target analytics.events --from 2025-01-01 --to 2025-02-01
 chkit plugin backfill run --plan-id <planId>   # some chunks fail
 chkit plugin backfill resume --plan-id <planId>   # automatically retries failed chunks
+```
+
+**Managed backfill on ObsessionDB:**
+
+```sh
+chkit obsessiondb login
+chkit obsessiondb service select
+chkit plugin backfill submit --target analytics.events --from 2025-01-01 --to 2025-02-01
+# prints a job ID and a console link — the backend runs the chunks server-side
 ```
 
 **CI enforcement:**


### PR DESCRIPTION
## Summary
The `chkit plugin backfill submit` command shipped in #173, but the docs only added a flag table — there was no explanation of the two execution venues, and the "run backfills inside ObsessionDB" story was a single bullet on the overview page. This documents both paths.

- **`plugins/backfill.md`** — new "Execution modes: local vs managed jobs" section explaining local `run` vs managed `submit` (same plan, different venue), the `--local` escape hatch, the guard that refuses `plan`/`run`/`resume` against ObsessionDB, and a managed-backfill workflow example.
- **`obsessiondb/backfills.md`** (new page) — the managed path end to end: prerequisites (login + service select), the `submit` flow, console tracking, remote job `status`/`cancel` via `--job-id`/`--service-slug`, and the local-execution guard.
- Cross-linked the new page from the ObsessionDB **overview** and **services** pages.

## Test plan
- [x] `cd apps/docs && bun run build` — clean build, 33 pages
- [x] New "Backfill Jobs" page appears in `llms.txt` and `_raw/index.md` with correct title/description
- [x] Cross-page anchor `/plugins/backfill/#chkit-plugin-backfill-submit` and all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)