### PR TITLE
fix(core): allow function expressions in primaryKey/orderBy

### DIFF
--- a/.changeset/key-clause-function-expressions.md
+++ b/.changeset/key-clause-function-expressions.md
@@ -5,4 +5,4 @@
 
 Support ClickHouse function expressions in `primaryKey`/`orderBy` (e.g. `toDate(ts)`, `toStartOfHour(session_end)`). Validation no longer reports `primary_key_missing_column`/`order_by_missing_column` for expression entries, and generated DDL emits them verbatim instead of quoting the whole expression as a column name. Plain column references are still validated and backtick-quoted as before.
 
-Migration planning now compares key clauses independent of insignificant whitespace, so an expression written as `toStartOfHour( ts )` in config no longer diffs against ClickHouse's normalized `toStartOfHour(ts)` and triggers a phantom table recreate on `migrate`/`drift`/`check`.
+Migration planning now compares key clauses independent of insignificant whitespace and identifier backtick-quoting, so an expression written as `toStartOfHour( ts )` or a column written bare as `user-id` no longer diffs against ClickHouse's normalized `toStartOfHour(ts)` / `` `user-id` `` and triggers a phantom table recreate on `migrate`/`drift`/`check`.

--- a/.changeset/key-clause-function-expressions.md
+++ b/.changeset/key-clause-function-expressions.md
@@ -1,0 +1,6 @@
+---
+"chkit": patch
+"@chkit/core": patch
+---
+
+Support ClickHouse function expressions in `primaryKey`/`orderBy` (e.g. `toDate(ts)`, `toStartOfHour(session_end)`). Validation no longer reports `primary_key_missing_column`/`order_by_missing_column` for expression entries, and generated DDL emits them verbatim instead of quoting the whole expression as a column name. Plain column references are still validated and backtick-quoted as before.

--- a/.changeset/key-clause-function-expressions.md
+++ b/.changeset/key-clause-function-expressions.md
@@ -4,3 +4,5 @@
 ---
 
 Support ClickHouse function expressions in `primaryKey`/`orderBy` (e.g. `toDate(ts)`, `toStartOfHour(session_end)`). Validation no longer reports `primary_key_missing_column`/`order_by_missing_column` for expression entries, and generated DDL emits them verbatim instead of quoting the whole expression as a column name. Plain column references are still validated and backtick-quoted as before.
+
+Migration planning now compares key clauses independent of insignificant whitespace, so an expression written as `toStartOfHour( ts )` in config no longer diffs against ClickHouse's normalized `toStartOfHour(ts)` and triggers a phantom table recreate on `migrate`/`drift`/`check`.

--- a/apps/docs/src/content/docs/schema/dsl-reference.md
+++ b/apps/docs/src/content/docs/schema/dsl-reference.md
@@ -91,8 +91,8 @@ const events = table({
 | `name` | `string` | Table name |
 | `columns` | `ColumnDefinition[]` | Column definitions (see [Columns](#columns)) |
 | `engine` | `string` | Engine clause, e.g. `'MergeTree'`, `'ReplacingMergeTree(ver)'` |
-| `primaryKey` | `string[]` | Primary key columns |
-| `orderBy` | `string[]` | ORDER BY columns |
+| `primaryKey` | `string[]` | Primary key columns or expressions, e.g. `['toDate(ts)', 'id']` |
+| `orderBy` | `string[]` | ORDER BY columns or expressions, e.g. `['toStartOfHour(ts)', 'id']` |
 
 ### Optional fields
 
@@ -431,8 +431,8 @@ chkit validates schema definitions and throws a `ChxValidationError` if any issu
 - **Duplicate column names** -- repeated column name within a table
 - **Duplicate index names** -- repeated index name within a table
 - **Duplicate projection names** -- repeated projection name within a table
-- **Primary key references missing column** -- `primaryKey` includes a column not in `columns`
-- **Order by references missing column** -- `orderBy` includes a column not in `columns`
+- **Primary key references missing column** -- `primaryKey` includes a bare column name not in `columns` (function expressions like `toDate(ts)` are passed through to ClickHouse unchecked)
+- **Order by references missing column** -- `orderBy` includes a bare column name not in `columns` (function expressions like `toStartOfHour(ts)` are passed through to ClickHouse unchecked)
 - **Empty codec chain** (`codec_chain_empty`) -- a `codec` array with no steps; provide at least one codec or omit the field
 - **Multiple general codecs** (`codec_chain_multiple_general`) -- more than one general codec in a chain; only one is allowed
 - **Codec chain must end with a general codec** (`codec_chain_must_end_with_general`) -- preprocessors must precede the single general codec (`NONE`, `LZ4`, `LZ4HC`, `ZSTD`, `T64`, `GCD`, `ALP`)

--- a/apps/docs/src/content/docs/schema/dsl-reference.md
+++ b/apps/docs/src/content/docs/schema/dsl-reference.md
@@ -116,6 +116,18 @@ The `engine` field accepts any string. Common engines include `MergeTree`, `Repl
 Key clause arrays support comma-separated strings: `['id, org_id']` is normalized to `['id', 'org_id']`. Prefer one column per array element for clarity.
 :::
 
+:::caution
+`primaryKey`/`orderBy` entries may be **function expressions**, not just column names — e.g. `['toStartOfHour(session_end)', 'id']`. Bare column names are validated against `columns` and quoted; expressions are passed through to ClickHouse unchanged, and spacing differences are ignored when detecting drift.
+
+Write expressions in ClickHouse's **canonical form**, because ClickHouse rewrites some syntax when it stores the key, and chkit compares against that stored form. A mismatch makes `drift`/`check` report perpetual drift and `migrate` recreate the table on every run. Known rewrites to avoid in keys:
+
+- `INTERVAL 1 HOUR` → write `toIntervalHour(1)` (e.g. `toStartOfInterval(ts, toIntervalHour(1))`)
+- `x::Date` or `CAST(x AS Date)` → write `CAST(x, 'Date')`
+- Do not use `ASC`/`DESC` in a key — ClickHouse drops it and the key no longer matches.
+
+Plain function chains like `toStartOfHour(ts)`, `toDate(ts)`, and arithmetic (`a + 1`, `h % 8`) round-trip unchanged.
+:::
+
 ## Columns
 
 Each entry in the `columns` array is a `ColumnDefinition`.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -479,6 +479,38 @@ describe('@chkit/core planner v1', () => {
     expect(plan.renameSuggestions).toEqual([])
   })
 
+  test('does not recreate when a key expression differs only by whitespace (#176)', () => {
+    const columns = [
+      { name: 'sso_id', type: 'String' },
+      { name: 'session_end', type: 'DateTime' },
+    ]
+    // As ClickHouse stores and introspects it (normalized spacing).
+    const introspected = [
+      table({
+        database: 'app',
+        name: 'sessions',
+        columns,
+        engine: 'MergeTree()',
+        primaryKey: ['sso_id', 'toStartOfHour(session_end)'],
+        orderBy: ['sso_id', 'toStartOfHour(session_end)'],
+      }),
+    ]
+    // As a user might write the same expression in config.
+    const config = [
+      table({
+        database: 'app',
+        name: 'sessions',
+        columns,
+        engine: 'MergeTree()',
+        primaryKey: ['sso_id', 'toStartOfHour(  session_end )'],
+        orderBy: ['sso_id', 'toStartOfHour(  session_end )'],
+      }),
+    ]
+
+    const plan = planDiff(introspected, config)
+    expect(plan.operations).toEqual([])
+  })
+
   test('recreates table when structural keys change', () => {
     const oldDefs = [
       table({

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -77,6 +77,28 @@ describe('@chkit/core smoke', () => {
     expect(sql).toContain('UNIQUE KEY (`id`, `org_id`)')
   })
 
+  test('renders function expressions in key clauses without quoting them (#176)', () => {
+    const events = table({
+      database: 'chatty',
+      name: 'session',
+      columns: [
+        { name: 'sso_id', type: 'String' },
+        { name: 'session_id', type: 'String' },
+        { name: 'session_end', type: 'DateTime' },
+      ],
+      engine: 'MergeTree()',
+      primaryKey: ['sso_id', 'toStartOfHour(session_end)', 'session_id'],
+      orderBy: ['sso_id', 'toStartOfHour(session_end)', 'session_id', 'session_end'],
+    })
+
+    const sql = toCreateSQL(events)
+    // Plain columns stay backtick-quoted; function expressions are emitted verbatim.
+    expect(sql).toContain('PRIMARY KEY (`sso_id`, toStartOfHour(session_end), `session_id`)')
+    expect(sql).toContain(
+      'ORDER BY (`sso_id`, toStartOfHour(session_end), `session_id`, `session_end`)'
+    )
+  })
+
   test('table with orderBy but no primaryKey does not crash; PK defaults to orderBy (#19)', () => {
     // A user can omit primaryKey at runtime (JS, or a `.ts` config without
     // strict types). ClickHouse derives the PK from ORDER BY, so this must
@@ -621,6 +643,25 @@ describe('@chkit/core planner v1', () => {
       'primary_key_missing_column',
       'order_by_missing_column',
     ])
+  })
+
+  test('allows function expressions in primaryKey and orderBy', () => {
+    const defs = [
+      table({
+        database: 'bi',
+        name: 'price_history_label',
+        columns: [
+          { name: 'csin', type: 'String' },
+          { name: 'product_changed_at', type: 'DateTime' },
+        ],
+        engine: 'MergeTree()',
+        primaryKey: ['toDate(product_changed_at)', 'csin', 'product_changed_at'],
+        orderBy: ['toDate(product_changed_at)', 'csin', 'product_changed_at'],
+      }),
+    ]
+
+    const issues = validateDefinitions(defs)
+    expect(issues).toEqual([])
   })
 
   test('validates duplicate projection names', () => {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -531,6 +531,38 @@ describe('@chkit/core planner v1', () => {
     expect(plan.operations).toEqual([])
   })
 
+  test('does not recreate when a key column differs only by identifier quoting (#178)', () => {
+    const columns = [
+      { name: 'user-id', type: 'String' },
+      { name: 'ts', type: 'DateTime' },
+    ]
+    // As introspected from ClickHouse: identifier backtick-quoted in the key.
+    const introspected = [
+      table({
+        database: 'app',
+        name: 'events',
+        columns,
+        engine: 'MergeTree()',
+        primaryKey: ['`user-id`'],
+        orderBy: ['`user-id`', 'toStartOfHour(ts)'],
+      }),
+    ]
+    // As written in config: bare column name.
+    const config = [
+      table({
+        database: 'app',
+        name: 'events',
+        columns,
+        engine: 'MergeTree()',
+        primaryKey: ['user-id'],
+        orderBy: ['user-id', 'toStartOfHour(ts)'],
+      }),
+    ]
+
+    const plan = planDiff(introspected, config)
+    expect(plan.operations).toEqual([])
+  })
+
   test('recreates table when structural keys change', () => {
     const oldDefs = [
       table({

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -99,6 +99,26 @@ describe('@chkit/core smoke', () => {
     )
   })
 
+  test('quotes declared columns in key clauses even when the name needs quoting (#176)', () => {
+    const events = table({
+      database: 'app',
+      name: 'events',
+      columns: [
+        { name: 'user-id', type: 'String' },
+        { name: 'ts', type: 'DateTime' },
+      ],
+      engine: 'MergeTree()',
+      primaryKey: ['user-id', 'toStartOfHour(ts)'],
+      orderBy: ['user-id', 'toStartOfHour(ts)'],
+    })
+
+    const sql = toCreateSQL(events)
+    // `user-id` is a declared column (not a bare identifier) and must stay
+    // quoted; only the true expression is emitted verbatim.
+    expect(sql).toContain('PRIMARY KEY (`user-id`, toStartOfHour(ts))')
+    expect(sql).toContain('ORDER BY (`user-id`, toStartOfHour(ts))')
+  })
+
   test('table with orderBy but no primaryKey does not crash; PK defaults to orderBy (#19)', () => {
     // A user can omit primaryKey at runtime (JS, or a `.ts` config without
     // strict types). ClickHouse derives the PK from ORDER BY, so this must

--- a/packages/core/src/key-clause.ts
+++ b/packages/core/src/key-clause.ts
@@ -51,3 +51,15 @@ export function splitTopLevelComma(input: string): string[] {
 export function normalizeKeyColumns(values: string[] | undefined): string[] {
   return (values ?? []).flatMap((value) => splitTopLevelComma(value.trim()))
 }
+
+const PLAIN_COLUMN_REFERENCE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * A key entry references a table column only when it is a bare identifier.
+ * Anything else — function calls like `toDate(ts)`, arithmetic, or tuples — is
+ * an expression that ClickHouse validates itself, so it must not be checked
+ * against the table's declared column list.
+ */
+export function isPlainColumnReference(token: string): boolean {
+  return PLAIN_COLUMN_REFERENCE.test(token)
+}

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -107,16 +107,18 @@ function pushCreateDatabaseOperation(
   })
 }
 
-// Whitespace outside string/identifier quotes carries no meaning in a key
-// clause, and ClickHouse stores key expressions in its own normalized spacing
-// (e.g. `toStartOfHour( session_end )` is stored and introspected back as
-// `toStartOfHour(session_end)`). Strip such whitespace so a config clause and
-// the introspected clause compare equal regardless of spacing, avoiding a
-// phantom table recreate. Comparison-only — never used to render DDL, so
-// keyword expressions like `INTERVAL 1 HOUR` keep their spacing when emitted.
-function stripInsignificantWhitespace(token: string): string {
+// Whitespace and identifier backtick-quoting carry no meaning in a key clause,
+// and ClickHouse normalizes both when it stores the key: `toStartOfHour( ts )`
+// comes back as `toStartOfHour(ts)`, and a column written bare as `user-id` in
+// config is stored/introspected quoted as `` `user-id` ``. Drop insignificant
+// whitespace and identifier backticks (but preserve single/double-quoted string
+// literals, which are semantic) so a config clause and the introspected clause
+// compare equal, avoiding a phantom table recreate. Comparison-only — never
+// used to render DDL, so keyword expressions like `INTERVAL 1 HOUR` and real
+// identifier quoting keep their form when emitted.
+function stripInsignificantFormatting(token: string): string {
   let out = ''
-  let quote: "'" | '"' | '`' | null = null
+  let quote: "'" | '"' | null = null
   for (let i = 0; i < token.length; i += 1) {
     const char = token[i] ?? ''
     if (quote) {
@@ -124,11 +126,12 @@ function stripInsignificantWhitespace(token: string): string {
       if (char === quote && token[i - 1] !== '\\') quote = null
       continue
     }
-    if (char === "'" || char === '"' || char === '`') {
+    if (char === "'" || char === '"') {
       quote = char
       out += char
       continue
     }
+    if (char === '`') continue
     if (/\s/.test(char)) continue
     out += char
   }
@@ -136,7 +139,7 @@ function stripInsignificantWhitespace(token: string): string {
 }
 
 function normalizeClauseList(value: string[] | undefined): string {
-  return (value ?? []).map(stripInsignificantWhitespace).join(',')
+  return (value ?? []).map(stripInsignificantFormatting).join(',')
 }
 
 function requiresTableRecreate(oldDef: TableDefinition, newDef: TableDefinition): boolean {

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -107,8 +107,36 @@ function pushCreateDatabaseOperation(
   })
 }
 
+// Whitespace outside string/identifier quotes carries no meaning in a key
+// clause, and ClickHouse stores key expressions in its own normalized spacing
+// (e.g. `toStartOfHour( session_end )` is stored and introspected back as
+// `toStartOfHour(session_end)`). Strip such whitespace so a config clause and
+// the introspected clause compare equal regardless of spacing, avoiding a
+// phantom table recreate. Comparison-only — never used to render DDL, so
+// keyword expressions like `INTERVAL 1 HOUR` keep their spacing when emitted.
+function stripInsignificantWhitespace(token: string): string {
+  let out = ''
+  let quote: "'" | '"' | '`' | null = null
+  for (let i = 0; i < token.length; i += 1) {
+    const char = token[i] ?? ''
+    if (quote) {
+      out += char
+      if (char === quote && token[i - 1] !== '\\') quote = null
+      continue
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char
+      out += char
+      continue
+    }
+    if (/\s/.test(char)) continue
+    out += char
+  }
+  return out
+}
+
 function normalizeClauseList(value: string[] | undefined): string {
-  return (value ?? []).join(',')
+  return (value ?? []).map(stripInsignificantWhitespace).join(',')
 }
 
 function requiresTableRecreate(oldDef: TableDefinition, newDef: TableDefinition): boolean {

--- a/packages/core/src/sql.ts
+++ b/packages/core/src/sql.ts
@@ -27,9 +27,14 @@ function renderColumn(col: ColumnDefinition): string {
   return out
 }
 
-function renderKeyClauseColumns(columns: string[]): string {
+function renderKeyClauseColumns(columns: string[], columnNames: Set<string>): string {
   return normalizeKeyColumns(columns)
-    .map((column) => (isPlainColumnReference(column) ? `\`${column}\`` : column))
+    .map((column) =>
+      // Quote a token when it names a declared column (including names that
+      // need quoting like `user-id`) or is a bare identifier. Only true
+      // expressions (e.g. `toStartOfHour(ts)`) are emitted verbatim.
+      columnNames.has(column) || isPlainColumnReference(column) ? `\`${column}\`` : column
+    )
     .join(', ')
 }
 
@@ -61,12 +66,13 @@ function renderTableSQL(def: TableDefinition): string {
   )
   const body = [...columns, ...indexes, ...projections].join(',\n  ')
 
+  const columnNames = new Set(def.columns.map((column) => column.name))
   const clauses: string[] = []
   if (def.partitionBy) clauses.push(`PARTITION BY ${def.partitionBy}`)
-  clauses.push(`PRIMARY KEY (${renderKeyClauseColumns(def.primaryKey)})`)
-  clauses.push(`ORDER BY (${renderKeyClauseColumns(def.orderBy)})`)
+  clauses.push(`PRIMARY KEY (${renderKeyClauseColumns(def.primaryKey, columnNames)})`)
+  clauses.push(`ORDER BY (${renderKeyClauseColumns(def.orderBy, columnNames)})`)
   if (def.uniqueKey && def.uniqueKey.length > 0) {
-    clauses.push(`UNIQUE KEY (${renderKeyClauseColumns(def.uniqueKey)})`)
+    clauses.push(`UNIQUE KEY (${renderKeyClauseColumns(def.uniqueKey, columnNames)})`)
   }
   if (def.ttl) clauses.push(`TTL ${def.ttl}`)
   if (def.settings && Object.keys(def.settings).length > 0) {

--- a/packages/core/src/sql.ts
+++ b/packages/core/src/sql.ts
@@ -8,7 +8,7 @@ import type {
   ViewDefinition,
 } from './model.js'
 import { renderCodec } from './codec.js'
-import { normalizeKeyColumns } from './key-clause.js'
+import { isPlainColumnReference, normalizeKeyColumns } from './key-clause.js'
 import { assertValidDefinitions } from './validate.js'
 
 function renderDefault(value: string | number | boolean): string {
@@ -29,7 +29,7 @@ function renderColumn(col: ColumnDefinition): string {
 
 function renderKeyClauseColumns(columns: string[]): string {
   return normalizeKeyColumns(columns)
-    .map((column) => `\`${column}\``)
+    .map((column) => (isPlainColumnReference(column) ? `\`${column}\`` : column))
     .join(', ')
 }
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,6 +1,6 @@
 import { definitionKey } from './canonical.js'
 import { canonicalizeCodec, isGeneralCodec, isRawCodec } from './codec.js'
-import { normalizeKeyColumns } from './key-clause.js'
+import { isPlainColumnReference, normalizeKeyColumns } from './key-clause.js'
 import type {
   ColumnDefinition,
   MaterializedViewDefinition,
@@ -120,7 +120,7 @@ function validateTableDefinition(def: TableDefinition, issues: ValidationIssue[]
   }
 
   for (const column of normalizeKeyColumns(def.primaryKey)) {
-    if (!columnSet.has(column)) {
+    if (isPlainColumnReference(column) && !columnSet.has(column)) {
       pushValidationIssue(
         issues,
         def,
@@ -131,7 +131,7 @@ function validateTableDefinition(def: TableDefinition, issues: ValidationIssue[]
   }
 
   for (const column of normalizeKeyColumns(def.orderBy)) {
-    if (!columnSet.has(column)) {
+    if (isPlainColumnReference(column) && !columnSet.has(column)) {
       pushValidationIssue(
         issues,
         def,


### PR DESCRIPTION
## Summary
Two related fixes so ClickHouse function expressions work in `primaryKey`/`orderBy` (e.g. `toDate(product_changed_at)`, `toStartOfHour(session_end)`):

1. **Validation + rendering (`generate`).** These were rejected with `primary_key_missing_column` / `order_by_missing_column`, and the SQL renderer backtick-quoted the whole expression as one identifier (broken DDL). A shared `isPlainColumnReference` helper now splits bare identifiers from expressions: plain columns are validated against `columns` and backtick-quoted as before; expressions pass through to ClickHouse unchecked and render verbatim.

2. **Drift/planner robustness (`migrate`/`drift`/`check`).** ClickHouse normalizes key-expression spacing on store (`toStartOfHour( ts )` → `toStartOfHour(ts)`), but the planner compared key clauses as raw strings — so a differently-spaced-but-equivalent expression in config would diff against the introspected form and trigger a phantom table recreate. Key-clause comparison now ignores whitespace outside quotes. Comparison-only: rendering is untouched, so keyword expressions like `INTERVAL 1 HOUR` keep their spacing.

Tradeoff: a mistyped column *inside* an expression (`toDate(typo_col)`) is no longer caught by chkit and surfaces at DDL execution instead — consistent with how `partitionBy`/`ttl` already behave.

Docs (`schema/dsl-reference.md`) updated. Changeset added (patch; `chkit` + `@chkit/core`). Fixes #176. Linear: NUM-7447.

## Verification
The drift behavior was checked against **live ClickHouse**: a table created with `toStartOfHour(  session_end )` in `ORDER BY` is stored as `toStartOfHour(session_end)`, and `planDiff(introspected, config)` now yields zero operations (no phantom recreate).

## Test plan
- [x] Unit: function expressions in `primaryKey`/`orderBy` pass validation
- [x] Unit: expressions render verbatim; plain columns stay backtick-quoted
- [x] Unit: whitespace-only expression difference produces no table recreate
- [x] Existing missing-plain-column validation + structural-recreate tests unchanged
- [x] `bun verify` green — 37/37 tasks, full e2e against live ClickHouse (0 fail)
