### PR TITLE
refactor(backfill): extract shared SQL scanner in chunking/sql.ts

### DIFF
--- a/.changeset/backfill-sql-scanner.md
+++ b/.changeset/backfill-sql-scanner.md
@@ -1,0 +1,5 @@
+---
+"@chkit/plugin-backfill": patch
+---
+
+Refactor the backfill chunk-SQL rewriter (`chunking/sql.ts`): fold the duplicated quote/paren-aware scan loops into one shared `scanSqlTokens` primitive (with `findTopLevelKeywords`/`splitTopLevel` on top) and split the oversized `rewriteSelectColumns` into focused helpers. Behavior is unchanged — the same customer SQL rewriting is now covered by direct unit tests for quoted-string, escaped-quote, nested-subquery, and missing-FROM edge cases.

--- a/packages/plugin-backfill/src/chunking/sql.test.ts
+++ b/packages/plugin-backfill/src/chunking/sql.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  findTopLevelKeywords,
+  injectSortKeyFilter,
+  rewriteSelectColumns,
+  splitTopLevel,
+} from './sql.js'
+
+describe('findTopLevelKeywords', () => {
+  test('finds keywords at the top level in ascending position order', () => {
+    const hits = findTopLevelKeywords('SELECT a FROM t', ['SELECT', 'FROM'])
+    expect(hits).toEqual([
+      { keyword: 'SELECT', position: 0 },
+      { keyword: 'FROM', position: 9 },
+    ])
+  })
+
+  test('ignores keywords nested inside parentheses', () => {
+    const hits = findTopLevelKeywords('SELECT a, (SELECT b FROM sub) AS x FROM main', [
+      'SELECT',
+      'FROM',
+    ])
+    expect(hits.filter((hit) => hit.keyword === 'SELECT')).toHaveLength(1)
+    expect(hits.filter((hit) => hit.keyword === 'FROM')).toHaveLength(1)
+  })
+
+  test('ignores keywords inside single-quoted string literals', () => {
+    const hits = findTopLevelKeywords("SELECT 'FROM WHERE' FROM t", ['FROM', 'WHERE'])
+    expect(hits).toHaveLength(1)
+    expect(hits[0]?.keyword).toBe('FROM')
+  })
+
+  test('treats a backslash-escaped quote as still inside the string', () => {
+    // The escaped quote does not close the literal, so the WHERE inside it is skipped.
+    const hits = findTopLevelKeywords("SELECT 'a\\' WHERE b' AS c FROM t", ['WHERE', 'FROM'])
+    expect(hits.map((hit) => hit.keyword)).toEqual(['FROM'])
+  })
+
+  test('requires a word boundary so substrings do not match', () => {
+    expect(findTopLevelKeywords('SELECTED FROM t', ['SELECT'])).toEqual([])
+    expect(findTopLevelKeywords('a.WHERE = 1', ['WHERE'])).toEqual([])
+  })
+
+  test('matches case-insensitively', () => {
+    const hits = findTopLevelKeywords('select a from t', ['SELECT', 'FROM'])
+    expect(hits.map((hit) => hit.keyword)).toEqual(['SELECT', 'FROM'])
+  })
+
+  test('matches multi-word keywords like GROUP BY', () => {
+    const hits = findTopLevelKeywords('SELECT * FROM t GROUP BY g', ['GROUP BY'])
+    expect(hits).toHaveLength(1)
+    expect(hits[0]?.keyword).toBe('GROUP BY')
+  })
+})
+
+describe('splitTopLevel', () => {
+  test('splits on top-level delimiters', () => {
+    expect(splitTopLevel('a, b, c', ',').map((s) => s.trim())).toEqual(['a', 'b', 'c'])
+  })
+
+  test('does not split inside parentheses', () => {
+    expect(splitTopLevel('a, f(b, c), d', ',').map((s) => s.trim())).toEqual([
+      'a',
+      'f(b, c)',
+      'd',
+    ])
+  })
+
+  test('does not split inside string literals', () => {
+    expect(splitTopLevel("a, 'x, y', b", ',').map((s) => s.trim())).toEqual(['a', "'x, y'", 'b'])
+  })
+
+  test('keeps a backslash-escaped quote inside the literal', () => {
+    const segments = splitTopLevel("'a\\', b', c", ',')
+    expect(segments).toHaveLength(2)
+    expect(segments[0]?.trim()).toBe("'a\\', b'")
+    expect(segments[1]?.trim()).toBe('c')
+  })
+
+  test('returns the whole string when no delimiter is present', () => {
+    expect(splitTopLevel('a b c', ',')).toEqual(['a b c'])
+  })
+})
+
+describe('rewriteSelectColumns', () => {
+  test('reorders projection items to match target column order', () => {
+    const rewritten = rewriteSelectColumns('SELECT a AS x, b AS y FROM t', ['y', 'x'])
+    expect(rewritten).toContain('SELECT b AS y, a AS x')
+    expect(rewritten).toContain('FROM t')
+  })
+
+  test('does not confuse SELECT/FROM keywords inside string literals', () => {
+    const rewritten = rewriteSelectColumns(
+      "SELECT 'has FROM inside' AS note, id FROM t",
+      ['id', 'note'],
+    )
+    expect(rewritten).toContain("id, 'has FROM inside' AS note")
+    expect(rewritten).toContain('FROM t')
+  })
+
+  test('handles backslash-escaped quotes with commas inside a projection item', () => {
+    const rewritten = rewriteSelectColumns("SELECT 'a\\', b' AS label, id FROM t", ['id', 'label'])
+    expect(rewritten).toContain("id, 'a\\', b' AS label")
+    expect(rewritten).toContain('FROM t')
+  })
+
+  test('keeps a nested-paren subquery projection item intact', () => {
+    const rewritten = rewriteSelectColumns(
+      'SELECT id, (SELECT max(v) FROM sub WHERE k = a) AS mx FROM main',
+      ['mx', 'id'],
+    )
+    expect(rewritten).toContain('(SELECT max(v) FROM sub WHERE k = a) AS mx, id')
+    expect(rewritten).toContain('FROM main')
+  })
+
+  test('preserves trailing clauses after FROM', () => {
+    const rewritten = rewriteSelectColumns(
+      'SELECT a AS x, b FROM t WHERE c = 1 GROUP BY d',
+      ['b', 'x'],
+    )
+    expect(rewritten).toContain('SELECT b, a AS x')
+    expect(rewritten).toContain('FROM t WHERE c = 1 GROUP BY d')
+  })
+
+  test('falls through unmatched target columns as bare column references', () => {
+    const rewritten = rewriteSelectColumns('SELECT event_time AS ts FROM t', ['ts', 'ingested_at'])
+    expect(rewritten).toContain('SELECT event_time AS ts, ingested_at')
+  })
+
+  test('returns the query unchanged when FROM is missing', () => {
+    expect(rewriteSelectColumns('SELECT a, b', ['b', 'a'])).toBe('SELECT a, b')
+  })
+
+  test('returns the query unchanged when SELECT is missing', () => {
+    expect(rewriteSelectColumns('DELETE FROM t', ['a'])).toBe('DELETE FROM t')
+  })
+
+  test('preserves a leading DISTINCT', () => {
+    const rewritten = rewriteSelectColumns('SELECT DISTINCT a AS x, b AS y FROM t', ['y', 'x'])
+    expect(rewritten).toContain('SELECT DISTINCT b AS y, a AS x')
+  })
+})
+
+describe('injectSortKeyFilter', () => {
+  test('adds a WHERE clause when none exists', () => {
+    const sql = injectSortKeyFilter('SELECT * FROM t', 'ts', 'numeric', '1', '5')
+    expect(sql).toContain("WHERE ts >= '1'")
+    expect(sql).toContain("AND ts < '5'")
+  })
+
+  test('appends with AND when a WHERE already exists', () => {
+    const sql = injectSortKeyFilter('SELECT * FROM t WHERE x = 1', 'ts', 'numeric', '1', '5')
+    expect(sql).toContain('WHERE x = 1')
+    expect(sql).toContain("AND ts >= '1'")
+  })
+
+  test('inserts the filter before a trailing clause', () => {
+    const sql = injectSortKeyFilter('SELECT * FROM t GROUP BY g', 'ts', 'numeric', '1', '5')
+    expect(sql.indexOf('WHERE ts')).toBeLessThan(sql.indexOf('GROUP BY g'))
+    expect(sql).toContain('GROUP BY g')
+  })
+
+  test('ignores a trailing-clause keyword that lives inside a string literal', () => {
+    const sql = injectSortKeyFilter(
+      "SELECT * FROM t WHERE label = 'GROUP BY hack'",
+      'ts',
+      'numeric',
+      '1',
+      '5',
+    )
+    expect(sql).toContain("label = 'GROUP BY hack'")
+    expect(sql).toContain("AND ts >= '1'")
+    // No fresh WHERE was inserted; the existing one was extended.
+    expect(sql.match(/WHERE/g)).toHaveLength(1)
+  })
+})

--- a/packages/plugin-backfill/src/chunking/sql.ts
+++ b/packages/plugin-backfill/src/chunking/sql.ts
@@ -8,74 +8,23 @@ import type {
   TableProfile,
 } from './types.js'
 
+/**
+ * Top-level clause keywords, in the order they may legally follow a
+ * projection. `injectWhereCondition` uses this both to detect an existing
+ * `WHERE` and to find the first trailing clause a new condition must be
+ * inserted before.
+ */
+const TRAILING_CLAUSE_KEYWORDS = [
+  'WHERE',
+  'GROUP BY',
+  'HAVING',
+  'ORDER BY',
+  'QUALIFY',
+  'LIMIT',
+  'SETTINGS',
+] as const
 
-function quoteSqlString(value: string): string {
-  return `'${value.replaceAll('\\', '\\\\').replaceAll('\'', '\\\'')}'`
-}
-
-function formatBound(value: string, sortKey: SortKey): string {
-  if (sortKey.category === 'datetime') {
-    return `parseDateTimeBestEffort(${quoteSqlString(value)})`
-  }
-
-  if (sortKey.category === 'string') {
-    return `unhex('${Buffer.from(value, 'latin1').toString('hex')}')`
-  }
-
-  return quoteSqlString(value)
-}
-
-export function buildWhereClauseFromRanges(
-  partitionId: string,
-  ranges: ChunkRange[],
-  sortKeys: SortKey[],
-): string {
-  const conditions = [`_partition_id = ${quoteSqlString(partitionId)}`]
-
-  for (const range of ranges) {
-    const sortKey = sortKeys[range.dimensionIndex]
-    if (!sortKey) continue
-
-    if (range.from !== undefined) {
-      conditions.push(`${sortKey.name} >= ${formatBound(range.from, sortKey)}`)
-    }
-    if (range.to !== undefined) {
-      conditions.push(`${sortKey.name} < ${formatBound(range.to, sortKey)}`)
-    }
-  }
-
-  return conditions.join('\n  AND ')
-}
-
-export function buildWhereClauseFromChunk(
-  chunk: Pick<Chunk, 'partitionId' | 'ranges'>,
-  table: Pick<TableProfile, 'sortKeys'>,
-): string {
-  return buildWhereClauseFromRanges(chunk.partitionId, chunk.ranges, table.sortKeys)
-}
-
-function buildSettingsClause(token: string): string {
-  if (token) {
-    return `SETTINGS async_insert=0, insert_deduplication_token='${token}'`
-  }
-  return 'SETTINGS async_insert=0'
-}
-
-function buildChunkConditions(chunk: Pick<Chunk, 'ranges'>, sortKeys: SortKey[]): string[] {
-  return chunk.ranges.flatMap((range) => {
-    const sortKey = sortKeys[range.dimensionIndex]
-    if (!sortKey) return []
-
-    const conditions: string[] = []
-    if (range.from !== undefined) {
-      conditions.push(`${sortKey.name} >= ${formatBound(range.from, sortKey)}`)
-    }
-    if (range.to !== undefined) {
-      conditions.push(`${sortKey.name} < ${formatBound(range.to, sortKey)}`)
-    }
-    return conditions
-  })
-}
+// ── Chunk execution SQL ──────────────────────────────────────────────────────
 
 export function buildChunkExecutionSql(input: {
   planId: string
@@ -119,6 +68,31 @@ export function buildChunkExecutionSql(input: {
   return lines.join('\n')
 }
 
+// ── WHERE-clause builders ────────────────────────────────────────────────────
+
+export function buildWhereClauseFromRanges(
+  partitionId: string,
+  ranges: ChunkRange[],
+  sortKeys: SortKey[],
+): string {
+  const conditions = [`_partition_id = ${quoteSqlString(partitionId)}`]
+
+  for (const range of ranges) {
+    const sortKey = sortKeys[range.dimensionIndex]
+    if (!sortKey) continue
+    conditions.push(...buildRangeBoundConditions(range, sortKey))
+  }
+
+  return conditions.join('\n  AND ')
+}
+
+export function buildWhereClauseFromChunk(
+  chunk: Pick<Chunk, 'partitionId' | 'ranges'>,
+  table: Pick<TableProfile, 'sortKeys'>,
+): string {
+  return buildWhereClauseFromRanges(chunk.partitionId, chunk.ranges, table.sortKeys)
+}
+
 export function buildEstimateSql(
   filter: EstimateFilter,
   sortKeys: SortKey[],
@@ -140,34 +114,30 @@ export function buildCountSql(
   return `SELECT count() AS cnt FROM ${context.database}.${context.table} WHERE ${buildWhereClauseFromFilter(filter, sortKeys)}`
 }
 
-function buildWhereClauseFromFilter(
-  filter: EstimateFilter,
-  sortKeys: SortKey[],
-): string {
-  const conditions = [`_partition_id = ${quoteSqlString(filter.partitionId)}`]
+// ── Materialized-view query rewriting ────────────────────────────────────────
 
-  for (const range of filter.ranges) {
-    const sortKey = sortKeys[range.dimensionIndex]
-    if (!sortKey) continue
+/**
+ * Reorder a materialized-view `SELECT ... FROM ...` projection to match the
+ * target table's column order. Projection items are matched to target columns
+ * by their alias (`expr AS alias`); unmatched target columns fall through as
+ * bare column references. Returns the query untouched when no top-level
+ * `SELECT`/`FROM` pair is found (e.g. a non-SELECT statement).
+ */
+export function rewriteSelectColumns(query: string, targetColumns: string[]): string {
+  const trimmed = query.trimEnd()
 
-    if (filter.exactDimensionIndex === range.dimensionIndex && filter.exactValue !== undefined) {
-      conditions.push(`${sortKey.name} = ${formatBound(filter.exactValue, sortKey)}`)
-      continue
-    }
+  const bounds = findSelectProjectionBounds(trimmed)
+  if (!bounds) return query
 
-    if (range.from !== undefined) {
-      conditions.push(`${sortKey.name} >= ${formatBound(range.from, sortKey)}`)
-    }
-    if (range.to !== undefined) {
-      conditions.push(`${sortKey.name} < ${formatBound(range.to, sortKey)}`)
-    }
-  }
+  const projectionStart = bounds.selectPos + 'SELECT'.length
+  const rawProjection = trimmed.slice(projectionStart, bounds.fromPos).trim()
+  const { prefix, projection } = splitProjectionPrefix(rawProjection)
 
-  return conditions.join(' AND ')
-}
+  const items = splitTopLevel(projection, ',').map((item) => item.trim())
+  const aliasMap = buildAliasMap(items)
 
-function injectPartitionFilter(query: string, partitionId: string): string {
-  return injectWhereCondition(query, `_partition_id = ${quoteSqlString(partitionId)}`)
+  const rewritten = targetColumns.map((column) => aliasMap.get(column) ?? column)
+  return `${trimmed.slice(0, projectionStart)} ${prefix}${rewritten.join(', ')}\n${trimmed.slice(bounds.fromPos)}`
 }
 
 export function injectSortKeyFilter(
@@ -196,50 +166,64 @@ export function injectSortKeyFilter(
   return injectWhereCondition(query, condition)
 }
 
+/** Locate the top-level `SELECT` and the first top-level `FROM` after it. */
+function findSelectProjectionBounds(
+  sql: string,
+): { selectPos: number; fromPos: number } | null {
+  const hits = findTopLevelKeywords(sql, ['SELECT', 'FROM'])
+
+  const selectPos = hits.find((hit) => hit.keyword === 'SELECT')?.position ?? -1
+  if (selectPos === -1) return null
+
+  const fromPos =
+    hits.find((hit) => hit.keyword === 'FROM' && hit.position > selectPos)?.position ?? -1
+  if (fromPos === -1) return null
+
+  return { selectPos, fromPos }
+}
+
+/** Peel a leading `DISTINCT` off a projection so it survives the rewrite. */
+function splitProjectionPrefix(rawProjection: string): { prefix: string; projection: string } {
+  const distinctMatch = rawProjection.match(/^DISTINCT\b\s*/i)
+  if (!distinctMatch) return { prefix: '', projection: rawProjection }
+
+  const prefix = distinctMatch[0] ?? ''
+  return { prefix, projection: rawProjection.slice(prefix.length).trim() }
+}
+
+/** Map each aliased projection item (`expr AS alias`) to its full source text. */
+function buildAliasMap(items: string[]): Map<string, string> {
+  const aliasMap = new Map<string, string>()
+
+  for (const item of items) {
+    if (item === '*') continue
+    const alias = findColumnAlias(item)
+    if (alias !== undefined) aliasMap.set(alias, item)
+  }
+
+  return aliasMap
+}
+
+/** Return the alias of a projection item, i.e. the text after its last top-level `AS`. */
+function findColumnAlias(item: string): string | undefined {
+  const asHit = findTopLevelKeywords(item, ['AS']).at(-1)
+  if (!asHit) return undefined
+  return item.slice(asHit.position + 'AS'.length).trim()
+}
+
+function injectPartitionFilter(query: string, partitionId: string): string {
+  return injectWhereCondition(query, `_partition_id = ${quoteSqlString(partitionId)}`)
+}
+
+/**
+ * Insert `condition` into `query`'s WHERE clause, appending with `AND` when a
+ * top-level `WHERE` already exists and inserting a fresh `WHERE` otherwise. The
+ * condition is placed before the first trailing clause (GROUP BY, ORDER BY, …)
+ * so it always lands inside the WHERE.
+ */
 function injectWhereCondition(query: string, condition: string): string {
   const trimmed = query.trimEnd()
-  const upper = trimmed.toUpperCase()
-
-  interface KeywordHit {
-    keyword: string
-    position: number
-  }
-
-  const hits: KeywordHit[] = []
-  let depth = 0
-
-  for (let index = 0; index < trimmed.length; index++) {
-    const char = trimmed[index]
-    if (char === '(') {
-      depth += 1
-      continue
-    }
-    if (char === ')') {
-      depth -= 1
-      continue
-    }
-    if (char === '\'') {
-      index += 1
-      while (index < trimmed.length && trimmed[index] !== '\'') {
-        if (trimmed[index] === '\\') index += 1
-        index += 1
-      }
-      continue
-    }
-    if (depth !== 0) continue
-    if (index > 0 && /\S/.test(trimmed[index - 1] ?? '')) continue
-
-    const rest = upper.slice(index)
-    for (const keyword of ['WHERE', 'GROUP BY', 'HAVING', 'ORDER BY', 'QUALIFY', 'LIMIT', 'SETTINGS']) {
-      if (
-        rest.startsWith(keyword) &&
-        (index + keyword.length >= trimmed.length || /\s/.test(trimmed[index + keyword.length] ?? ''))
-      ) {
-        hits.push({ keyword, position: index })
-        break
-      }
-    }
-  }
+  const hits = findTopLevelKeywords(trimmed, TRAILING_CLAUSE_KEYWORDS)
 
   const whereHit = hits.find((hit) => hit.keyword === 'WHERE')
   const firstTrailing = hits
@@ -257,16 +241,36 @@ function injectWhereCondition(query: string, condition: string): string {
   return `${before}\nWHERE ${condition}${after ? `\n${after}` : ''}`
 }
 
-export function rewriteSelectColumns(query: string, targetColumns: string[]): string {
-  const trimmed = query.trimEnd()
-  const upper = trimmed.toUpperCase()
+// ── SQL string scanner (shared low-level) ────────────────────────────────────
+//
+// `findTopLevelKeywords` and `splitTopLevel` are exported for direct unit
+// testing of the quote/paren-skipping scan they share. They are intentionally
+// NOT re-exported through the package entry point (`sdk.ts`) — the package's
+// public API is unchanged.
 
-  let selectPos = -1
-  let fromPos = -1
+export interface KeywordHit {
+  keyword: string
+  position: number
+}
+
+/**
+ * Walk `sql` character by character, tracking parenthesis depth and skipping
+ * single-quoted string literals (with backslash escapes). `visit` is invoked
+ * for every character that lies outside a string literal and is not a
+ * parenthesis, receiving the current paren `depth`.
+ *
+ * This is the one primitive behind every SQL-structure scan in this module:
+ * top-level keyword detection and top-level delimiter splitting both build on
+ * it so the quote/paren bookkeeping lives in exactly one place.
+ */
+function scanSqlTokens(
+  sql: string,
+  visit: (char: string, index: number, depth: number) => void,
+): void {
   let depth = 0
 
-  for (let index = 0; index < trimmed.length; index++) {
-    const char = trimmed[index]
+  for (let index = 0; index < sql.length; index++) {
+    const char = sql[index]
     if (char === '(') {
       depth += 1
       continue
@@ -277,117 +281,121 @@ export function rewriteSelectColumns(query: string, targetColumns: string[]): st
     }
     if (char === '\'') {
       index += 1
-      while (index < trimmed.length && trimmed[index] !== '\'') {
-        if (trimmed[index] === '\\') index += 1
+      while (index < sql.length && sql[index] !== '\'') {
+        if (sql[index] === '\\') index += 1
         index += 1
       }
       continue
     }
-    if (depth !== 0) continue
-    if (index > 0 && /\S/.test(trimmed[index - 1] ?? '')) continue
+    visit(char ?? '', index, depth)
+  }
+}
 
-    const rest = upper.slice(index)
-    if (
-      selectPos === -1 &&
-      rest.startsWith('SELECT') &&
-      (index + 6 >= trimmed.length || /\s/.test(trimmed[index + 6] ?? ''))
-    ) {
-      selectPos = index
-    } else if (
-      selectPos !== -1 &&
-      fromPos === -1 &&
-      rest.startsWith('FROM') &&
-      (index + 4 >= trimmed.length || /\s/.test(trimmed[index + 4] ?? ''))
-    ) {
-      fromPos = index
+/**
+ * Find each occurrence of `keywords` that starts at the top level (paren depth
+ * 0), on a word boundary (preceded by whitespace or start-of-string and
+ * followed by whitespace or end-of-string). Matching is case-insensitive;
+ * hits are returned in ascending position order.
+ */
+export function findTopLevelKeywords(sql: string, keywords: readonly string[]): KeywordHit[] {
+  const upper = sql.toUpperCase()
+  const hits: KeywordHit[] = []
+
+  scanSqlTokens(sql, (_char, index, depth) => {
+    if (depth !== 0) return
+    if (index > 0 && /\S/.test(sql[index - 1] ?? '')) return
+
+    const keyword = keywords.find((candidate) => keywordStartsAt(sql, upper, index, candidate))
+    if (keyword) hits.push({ keyword, position: index })
+  })
+
+  return hits
+}
+
+/** Whether `keyword` starts at `index` on a trailing word boundary (case-insensitive). */
+function keywordStartsAt(sql: string, upper: string, index: number, keyword: string): boolean {
+  if (!upper.startsWith(keyword, index)) return false
+  const after = index + keyword.length
+  return after >= sql.length || /\s/.test(sql[after] ?? '')
+}
+
+/** Split `sql` on every top-level (paren depth 0) occurrence of `delimiter`. */
+export function splitTopLevel(sql: string, delimiter: string): string[] {
+  const segments: string[] = []
+  let start = 0
+
+  scanSqlTokens(sql, (char, index, depth) => {
+    if (depth === 0 && char === delimiter) {
+      segments.push(sql.slice(start, index))
+      start = index + 1
     }
+  })
+  segments.push(sql.slice(start))
+
+  return segments
+}
+
+// ── Value formatting & condition helpers ─────────────────────────────────────
+
+function quoteSqlString(value: string): string {
+  return `'${value.replaceAll('\\', '\\\\').replaceAll('\'', '\\\'')}'`
+}
+
+function formatBound(value: string, sortKey: SortKey): string {
+  if (sortKey.category === 'datetime') {
+    return `parseDateTimeBestEffort(${quoteSqlString(value)})`
   }
 
-  if (selectPos === -1 || fromPos === -1) return query
-
-  const projectionStart = selectPos + 6
-  const rawProjection = trimmed.slice(projectionStart, fromPos).trim()
-  let projectionPrefix = ''
-  let projection = rawProjection
-
-  const distinctMatch = rawProjection.match(/^DISTINCT\b\s*/i)
-  if (distinctMatch) {
-    projectionPrefix = distinctMatch[0] ?? ''
-    projection = rawProjection.slice(projectionPrefix.length).trim()
+  if (sortKey.category === 'string') {
+    return `unhex('${Buffer.from(value, 'latin1').toString('hex')}')`
   }
 
-  const items: string[] = []
-  let itemStart = 0
-  depth = 0
+  return quoteSqlString(value)
+}
 
-  for (let index = 0; index < projection.length; index++) {
-    const char = projection[index]
-    if (char === '(') {
-      depth += 1
+/** Build the `>= from` / `< to` conditions for a single range on `sortKey`. */
+function buildRangeBoundConditions(range: ChunkRange, sortKey: SortKey): string[] {
+  const conditions: string[] = []
+
+  if (range.from !== undefined) {
+    conditions.push(`${sortKey.name} >= ${formatBound(range.from, sortKey)}`)
+  }
+  if (range.to !== undefined) {
+    conditions.push(`${sortKey.name} < ${formatBound(range.to, sortKey)}`)
+  }
+
+  return conditions
+}
+
+function buildSettingsClause(token: string): string {
+  if (token) {
+    return `SETTINGS async_insert=0, insert_deduplication_token='${token}'`
+  }
+  return 'SETTINGS async_insert=0'
+}
+
+function buildChunkConditions(chunk: Pick<Chunk, 'ranges'>, sortKeys: SortKey[]): string[] {
+  return chunk.ranges.flatMap((range) => {
+    const sortKey = sortKeys[range.dimensionIndex]
+    if (!sortKey) return []
+    return buildRangeBoundConditions(range, sortKey)
+  })
+}
+
+function buildWhereClauseFromFilter(filter: EstimateFilter, sortKeys: SortKey[]): string {
+  const conditions = [`_partition_id = ${quoteSqlString(filter.partitionId)}`]
+
+  for (const range of filter.ranges) {
+    const sortKey = sortKeys[range.dimensionIndex]
+    if (!sortKey) continue
+
+    if (filter.exactDimensionIndex === range.dimensionIndex && filter.exactValue !== undefined) {
+      conditions.push(`${sortKey.name} = ${formatBound(filter.exactValue, sortKey)}`)
       continue
     }
-    if (char === ')') {
-      depth -= 1
-      continue
-    }
-    if (char === '\'') {
-      index += 1
-      while (index < projection.length && projection[index] !== '\'') {
-        if (projection[index] === '\\') index += 1
-        index += 1
-      }
-      continue
-    }
-    if (depth === 0 && char === ',') {
-      items.push(projection.slice(itemStart, index).trim())
-      itemStart = index + 1
-    }
-  }
-  items.push(projection.slice(itemStart).trim())
 
-  const aliasMap = new Map<string, string>()
-  for (const item of items) {
-    if (item === '*') continue
-
-    const itemUpper = item.toUpperCase()
-    let asPos = -1
-    let itemDepth = 0
-
-    for (let index = 0; index < item.length; index++) {
-      const char = item[index]
-      if (char === '(') {
-        itemDepth += 1
-        continue
-      }
-      if (char === ')') {
-        itemDepth -= 1
-        continue
-      }
-      if (char === '\'') {
-        index += 1
-        while (index < item.length && item[index] !== '\'') {
-          if (item[index] === '\\') index += 1
-          index += 1
-        }
-        continue
-      }
-      if (itemDepth !== 0) continue
-      if (index > 0 && /\S/.test(item[index - 1] ?? '')) continue
-
-      const rest = itemUpper.slice(index)
-      if (
-        rest.startsWith('AS') &&
-        (index + 2 >= item.length || /\s/.test(item[index + 2] ?? ''))
-      ) {
-        asPos = index
-      }
-    }
-
-    if (asPos !== -1) {
-      aliasMap.set(item.slice(asPos + 2).trim(), item)
-    }
+    conditions.push(...buildRangeBoundConditions(range, sortKey))
   }
 
-  const rewrittenProjection = targetColumns.map((column) => aliasMap.get(column) ?? column)
-  return `${trimmed.slice(0, projectionStart)} ${projectionPrefix}${rewrittenProjection.join(', ')}\n${trimmed.slice(fromPos)}`
+  return conditions.join(' AND ')
 }


### PR DESCRIPTION
## Summary
- Fold the four cloned quote/paren-skipping scan loops in `packages/plugin-backfill/src/chunking/sql.ts` into one shared `scanSqlTokens` primitive, with `findTopLevelKeywords` and `splitTopLevel` built on top — the quote/escape/paren bookkeeping now lives in exactly one place.
- Split the repo's worst function, `rewriteSelectColumns` (cyclomatic 54 / cognitive 92), into single-purpose helpers (`findSelectProjectionBounds`, `splitProjectionPrefix`, `buildAliasMap`, `findColumnAlias`) and dedupe the range→condition builders via `buildRangeBoundConditions`.
- This is behavior-preserving: it rewrites customer SQL for backfill chunk execution, so no output changes — only structure. The module's public API (via `sdk.ts`) is unchanged; `findTopLevelKeywords`/`splitTopLevel` are exported from the module for direct unit testing only.
- Add focused unit tests (`sql.test.ts`) for the scanner and `rewriteSelectColumns` edge cases: quoted strings containing SELECT/FROM, backslash-escaped quotes, nested-paren subqueries, missing FROM/SELECT, and trailing clauses.

## Test plan
- [x] `doppler run --project chkit --config ci -- bun test packages/plugin-backfill` — 110 pass / 0 fail (incl. live-ClickHouse smart-chunking integration + e2e)
- [x] `bun run verify` — 37/37 turbo tasks (typecheck, lint, test, build) pass
- [x] `bunx fallow` — `rewriteSelectColumns` no longer flagged, no CRITICAL functions and no clone groups remain in `sql.ts`