### PR TITLE
refactor(pull): split renderSchemaFile into per-object renderers; test(core): cover sql-splitter

### DIFF
--- a/packages/core/src/sql-splitter.test.ts
+++ b/packages/core/src/sql-splitter.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test'
+
+import { extractExecutableStatements, splitSqlStatements } from './sql-splitter.js'
+
+describe('splitSqlStatements', () => {
+  test('splits multiple statements and re-appends the terminating semicolon', () => {
+    expect(splitSqlStatements('SELECT 1; SELECT 2;')).toEqual(['SELECT 1;', 'SELECT 2;'])
+  })
+
+  test('appends a semicolon to a trailing statement that lacks one', () => {
+    expect(splitSqlStatements('SELECT 1; SELECT 2')).toEqual(['SELECT 1;', 'SELECT 2;'])
+  })
+
+  test('trims surrounding whitespace around each statement', () => {
+    expect(splitSqlStatements('  SELECT 1 ;\n\n  SELECT 2  ')).toEqual(['SELECT 1;', 'SELECT 2;'])
+  })
+
+  test('drops empty statements produced by repeated semicolons', () => {
+    expect(splitSqlStatements('SELECT 1;;;SELECT 2;')).toEqual(['SELECT 1;', 'SELECT 2;'])
+  })
+
+  test('returns an empty array for empty input', () => {
+    expect(splitSqlStatements('')).toEqual([])
+  })
+
+  test('returns an empty array for whitespace-only input', () => {
+    expect(splitSqlStatements('   \n\t  \n')).toEqual([])
+  })
+
+  test('does not split on a semicolon inside a single-quoted string', () => {
+    expect(splitSqlStatements("INSERT INTO t VALUES ('a;b');")).toEqual([
+      "INSERT INTO t VALUES ('a;b');",
+    ])
+  })
+
+  test('keeps doubled single-quote escapes and their semicolons intact', () => {
+    expect(splitSqlStatements("SELECT 'it''s; fine';")).toEqual(["SELECT 'it''s; fine';"])
+  })
+
+  test('does not split on a semicolon inside a double-quoted identifier', () => {
+    expect(splitSqlStatements('SELECT "a;b" FROM t;')).toEqual(['SELECT "a;b" FROM t;'])
+  })
+
+  test('does not split on a semicolon inside a backtick-quoted identifier', () => {
+    expect(splitSqlStatements('SELECT `a;b` FROM t;')).toEqual(['SELECT `a;b` FROM t;'])
+  })
+
+  test('does not split on a semicolon inside a block comment', () => {
+    expect(splitSqlStatements('SELECT 1 /* a; b */; SELECT 2;')).toEqual([
+      'SELECT 1 /* a; b */;',
+      'SELECT 2;',
+    ])
+  })
+})
+
+describe('extractExecutableStatements', () => {
+  test('splits multiple statements like the underlying splitter', () => {
+    expect(extractExecutableStatements('SELECT 1; SELECT 2;')).toEqual(['SELECT 1;', 'SELECT 2;'])
+  })
+
+  test('appends a semicolon to a trailing statement that lacks one', () => {
+    expect(extractExecutableStatements('SELECT 1')).toEqual(['SELECT 1;'])
+  })
+
+  test('returns an empty array for empty input', () => {
+    expect(extractExecutableStatements('')).toEqual([])
+  })
+
+  test('returns an empty array for whitespace-only input', () => {
+    expect(extractExecutableStatements('   \n\t  ')).toEqual([])
+  })
+
+  test('strips a line comment and does not split on a semicolon inside it', () => {
+    expect(extractExecutableStatements('-- meta: x; y\nSELECT 1;')).toEqual(['SELECT 1;'])
+  })
+
+  test('returns an empty array when input is only line comments', () => {
+    expect(extractExecutableStatements('-- just a comment; not a statement\n')).toEqual([])
+  })
+
+  test('preserves a "--" sequence that appears inside a string literal', () => {
+    expect(extractExecutableStatements("SELECT 'a -- b';")).toEqual(["SELECT 'a -- b';"])
+  })
+
+  test('preserves block comments and does not split on a semicolon inside them', () => {
+    expect(extractExecutableStatements('/* keep; me */ SELECT 1;')).toEqual([
+      '/* keep; me */ SELECT 1;',
+    ])
+  })
+
+  test('does not split on a semicolon inside a single-quoted string', () => {
+    expect(extractExecutableStatements("INSERT INTO t VALUES ('a;b');")).toEqual([
+      "INSERT INTO t VALUES ('a;b');",
+    ])
+  })
+
+  // Contract relied on by migrate/apply.ts: `-- operation:` / `-- chkit-*`
+  // metadata comments are consumed separately (extractMigrationOperationSummaries
+  // reads the raw SQL); the executable stream must contain only real statements,
+  // with string-literal semicolons preserved.
+  test('drops migration-metadata comments and returns only executable statements', () => {
+    const migration = [
+      '-- chkit-migration-format: v1',
+      '-- operation: create_table key=table:app.users risk=safe',
+      'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id;',
+      '',
+      '-- operation: alter_table_add_column key=table:app.users risk=safe',
+      "ALTER TABLE app.users ADD COLUMN email String DEFAULT 'a;b@example.com';",
+    ].join('\n')
+
+    expect(extractExecutableStatements(migration)).toEqual([
+      'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id;',
+      "ALTER TABLE app.users ADD COLUMN email String DEFAULT 'a;b@example.com';",
+    ])
+  })
+})

--- a/packages/plugin-pull/src/index.test.ts
+++ b/packages/plugin-pull/src/index.test.ts
@@ -28,6 +28,125 @@ describe('@chkit/plugin-pull options', () => {
 })
 
 describe('@chkit/plugin-pull renderSchemaFile', () => {
+  test('renders a full table + view + refreshable MV schema byte-for-byte', () => {
+    const content = renderSchemaFile([
+      {
+        kind: 'table',
+        database: 'app',
+        name: 'events',
+        engine: 'MergeTree()',
+        columns: [
+          { name: 'id', type: 'UInt64', codec: { kind: 'ZSTD', level: 3 } },
+          { name: 'received_at', type: 'DateTime64(3)', default: 'fn:now64(3)' },
+          { name: 'source', type: 'String', nullable: true, comment: 'origin' },
+          {
+            name: 'payload',
+            type: 'String',
+            codec: [{ kind: 'Delta', size: 4 }, { kind: 'raw', expression: 'LZ4' }, { kind: 'ZSTD' }],
+          },
+        ],
+        primaryKey: ['id'],
+        orderBy: ['id', 'received_at'],
+        uniqueKey: ['id'],
+        partitionBy: 'toYYYYMM(received_at)',
+        ttl: 'received_at + INTERVAL 30 DAY',
+        settings: { index_granularity: 8192, ttl_only_drop_parts: 1 },
+        indexes: [
+          { name: 'idx_source', expression: 'source', type: 'set', maxRows: 0, granularity: 1 },
+          {
+            name: 'idx_body',
+            expression: 'payload',
+            type: 'tokenbf_v1',
+            sizeBytes: 256,
+            hashFunctions: 2,
+            randomSeed: 0,
+            granularity: 1,
+          },
+        ],
+        projections: [{ name: 'proj_by_source', query: 'SELECT source, count() GROUP BY source' }],
+      },
+      {
+        kind: 'view',
+        database: 'app',
+        name: 'events_view',
+        as: 'SELECT id FROM app.events',
+      },
+      {
+        kind: 'materialized_view',
+        database: 'analytics',
+        name: 'daily_mv',
+        to: { database: 'analytics', name: 'daily_rollup' },
+        refresh: {
+          every: '1 HOUR',
+          randomize: '30 SECOND',
+          dependsOn: [{ database: 'analytics', name: 'upstream' }],
+          settings: { refresh_retries: 3 },
+          append: true,
+        },
+        as: 'SELECT toDate(received_at) AS day, count() AS c FROM app.events GROUP BY day',
+      },
+    ])
+
+    expect(content).toBe(`import { schema, table, view, materializedView, codec } from '@chkit/core'
+
+// Pulled from live ClickHouse metadata via chkit plugin pull schema
+
+const app_events = table({
+  database: "app",
+  name: "events",
+  engine: "MergeTree()",
+  columns: [
+    { name: "id", type: "UInt64", codec: { kind: "ZSTD", level: 3 } },
+    { name: "received_at", type: "DateTime64(3)", default: "fn:now64(3)" },
+    { name: "source", type: "String", nullable: true, comment: "origin" },
+    { name: "payload", type: "String", codec: [{ kind: "Delta", size: 4 }, codec.raw("LZ4"), { kind: "ZSTD", level: 1 }] },
+  ],
+  primaryKey: ["id"],
+  orderBy: ["id", "received_at"],
+  uniqueKey: ["id"],
+  partitionBy: "toYYYYMM(received_at)",
+  ttl: "received_at + INTERVAL 30 DAY",
+  settings: {
+    index_granularity: 8192,
+    ttl_only_drop_parts: 1,
+  },
+  indexes: [
+    { name: "idx_body", expression: "payload", type: "tokenbf_v1", sizeBytes: 256, hashFunctions: 2, randomSeed: 0, granularity: 1 },
+    { name: "idx_source", expression: "source", type: "set", maxRows: 0, granularity: 1 },
+  ],
+  projections: [
+    { name: "proj_by_source", query: "SELECT source, count() GROUP BY source" },
+  ],
+})
+
+const app_events_view = view({
+  database: "app",
+  name: "events_view",
+  as: "SELECT id FROM app.events",
+})
+
+const analytics_daily_mv = materializedView({
+  database: "analytics",
+  name: "daily_mv",
+  to: { database: "analytics", name: "daily_rollup" },
+  refresh: {
+    every: "1 HOUR",
+    randomize: "30 SECOND",
+    dependsOn: [
+      { database: "analytics", name: "upstream" },
+    ],
+    settings: {
+      refresh_retries: 3,
+    },
+    append: true,
+  },
+  as: "SELECT toDate(received_at) AS day, count() AS c FROM app.events GROUP BY day",
+})
+
+export default schema(app_events, app_events_view, analytics_daily_mv)
+`)
+  })
+
   test('renders deterministic table definitions', () => {
     const content = renderSchemaFile([
       {

--- a/packages/plugin-pull/src/render-schema.ts
+++ b/packages/plugin-pull/src/render-schema.ts
@@ -3,13 +3,40 @@ import {
   isRawCodec,
   type ColumnCodec,
   type ColumnCodecSpec,
+  type ColumnDefinition,
+  type MaterializedViewDefinition,
   type MaterializedViewRefresh,
+  type ProjectionDefinition,
   type SchemaDefinition,
+  type SkipIndexDefinition,
+  type TableDefinition,
+  type ViewDefinition,
 } from '@chkit/core'
 
 export function renderSchemaFile(definitions: SchemaDefinition[]): string {
   const canonical = canonicalizeDefinitions(definitions)
   const declarationNames = new Map<string, number>()
+  const lines: string[] = [
+    renderImportStatement(canonical),
+    '',
+    '// Pulled from live ClickHouse metadata via chkit plugin pull schema',
+    '',
+  ]
+
+  const references: string[] = []
+
+  for (const definition of canonical) {
+    const variableName = resolveTableVariableName(definition.database, definition.name, declarationNames)
+    references.push(variableName)
+    lines.push(...renderDefinition(definition, variableName))
+    lines.push('')
+  }
+
+  lines.push(`export default schema(${references.join(', ')})`)
+  return `${lines.join('\n')}\n`
+}
+
+function renderImportStatement(canonical: SchemaDefinition[]): string {
   const hasTable = canonical.some((definition) => definition.kind === 'table')
   const hasView = canonical.some((definition) => definition.kind === 'view')
   const hasMaterializedView = canonical.some((definition) => definition.kind === 'materialized_view')
@@ -23,131 +50,188 @@ export function renderSchemaFile(definitions: SchemaDefinition[]): string {
   if (hasView) imports.push('view')
   if (hasMaterializedView) imports.push('materializedView')
   if (hasRawCodec) imports.push('codec')
-  const lines: string[] = [
-    `import { ${imports.join(', ')} } from '@chkit/core'`,
-    '',
-    '// Pulled from live ClickHouse metadata via chkit plugin pull schema',
-    '',
-  ]
+  return `import { ${imports.join(', ')} } from '@chkit/core'`
+}
 
-  const references: string[] = []
-
-  for (const definition of canonical) {
-    const variableName = resolveTableVariableName(definition.database, definition.name, declarationNames)
-    references.push(variableName)
-
-    if (definition.kind === 'table') {
-      lines.push(`const ${variableName} = table({`)
-      lines.push(`  database: ${renderString(definition.database)},`)
-      lines.push(`  name: ${renderString(definition.name)},`)
-      lines.push(`  engine: ${renderString(definition.engine)},`)
-      lines.push('  columns: [')
-
-      for (const column of definition.columns) {
-        const parts: string[] = [
-          `name: ${renderString(column.name)}`,
-          `type: ${renderString(column.type)}`,
-        ]
-        if (column.nullable) parts.push('nullable: true')
-        if (column.default !== undefined) parts.push(`default: ${renderLiteral(column.default)}`)
-        if (column.comment) parts.push(`comment: ${renderString(column.comment)}`)
-        if (column.codec) parts.push(`codec: ${renderCodecSource(column.codec)}`)
-        lines.push(`    { ${parts.join(', ')} },`)
-      }
-
-      lines.push('  ],')
-      lines.push(`  primaryKey: ${renderStringArray(definition.primaryKey)},`)
-      lines.push(`  orderBy: ${renderStringArray(definition.orderBy)},`)
-      if (definition.uniqueKey && definition.uniqueKey.length > 0) {
-        lines.push(`  uniqueKey: ${renderStringArray(definition.uniqueKey)},`)
-      }
-      if (definition.partitionBy) {
-        lines.push(`  partitionBy: ${renderString(definition.partitionBy)},`)
-      }
-      if (definition.ttl) {
-        lines.push(`  ttl: ${renderString(definition.ttl)},`)
-      }
-      if (definition.settings && Object.keys(definition.settings).length > 0) {
-        lines.push('  settings: {')
-        for (const key of Object.keys(definition.settings).sort()) {
-          const value = definition.settings[key]
-          if (value === undefined) continue
-          lines.push(`    ${renderKey(key)}: ${renderLiteral(value)},`)
-        }
-        lines.push('  },')
-      }
-      if (definition.indexes && definition.indexes.length > 0) {
-        lines.push('  indexes: [')
-        for (const index of definition.indexes) {
-          const parts = [
-            `name: ${renderString(index.name)}`,
-            `expression: ${renderString(index.expression)}`,
-            `type: ${renderString(index.type)}`,
-          ]
-          switch (index.type) {
-            case 'minmax':
-              break
-            case 'set':
-              parts.push(`maxRows: ${index.maxRows}`)
-              break
-            case 'bloom_filter':
-              if (index.falsePositiveRate !== undefined) {
-                parts.push(`falsePositiveRate: ${index.falsePositiveRate}`)
-              }
-              break
-            case 'tokenbf_v1':
-              parts.push(
-                `sizeBytes: ${index.sizeBytes}`,
-                `hashFunctions: ${index.hashFunctions}`,
-                `randomSeed: ${index.randomSeed}`
-              )
-              break
-            case 'ngrambf_v1':
-              parts.push(
-                `ngramSize: ${index.ngramSize}`,
-                `sizeBytes: ${index.sizeBytes}`,
-                `hashFunctions: ${index.hashFunctions}`,
-                `randomSeed: ${index.randomSeed}`
-              )
-              break
-          }
-          parts.push(`granularity: ${index.granularity}`)
-          lines.push(`    { ${parts.join(', ')} },`)
-        }
-        lines.push('  ],')
-      }
-      if (definition.projections && definition.projections.length > 0) {
-        lines.push('  projections: [')
-        for (const projection of definition.projections) {
-          lines.push(
-            `    { name: ${renderString(projection.name)}, query: ${renderString(projection.query)} },`
-          )
-        }
-        lines.push('  ],')
-      }
-      lines.push('})')
-    } else if (definition.kind === 'view') {
-      lines.push(`const ${variableName} = view({`)
-      lines.push(`  database: ${renderString(definition.database)},`)
-      lines.push(`  name: ${renderString(definition.name)},`)
-      lines.push(`  as: ${renderString(definition.as)},`)
-      lines.push('})')
-    } else {
-      lines.push(`const ${variableName} = materializedView({`)
-      lines.push(`  database: ${renderString(definition.database)},`)
-      lines.push(`  name: ${renderString(definition.name)},`)
-      lines.push(`  to: { database: ${renderString(definition.to.database)}, name: ${renderString(definition.to.name)} },`)
-      if (definition.refresh) {
-        lines.push(...renderRefreshLines(definition.refresh))
-      }
-      lines.push(`  as: ${renderString(definition.as)},`)
-      lines.push('})')
-    }
-    lines.push('')
+function renderDefinition(definition: SchemaDefinition, variableName: string): string[] {
+  switch (definition.kind) {
+    case 'table':
+      return renderTableDefinition(definition, variableName)
+    case 'view':
+      return renderViewDefinition(definition, variableName)
+    default:
+      return renderMaterializedViewDefinition(definition, variableName)
   }
+}
 
-  lines.push(`export default schema(${references.join(', ')})`)
-  return `${lines.join('\n')}\n`
+function renderTableDefinition(definition: TableDefinition, variableName: string): string[] {
+  const lines = renderDeclarationHeader('table', variableName, definition.database, definition.name)
+  lines.push(`  engine: ${renderString(definition.engine)},`)
+  lines.push('  columns: [')
+  for (const column of definition.columns) {
+    lines.push(`    ${renderColumn(column)},`)
+  }
+  lines.push('  ],')
+  lines.push(`  primaryKey: ${renderStringArray(definition.primaryKey)},`)
+  lines.push(`  orderBy: ${renderStringArray(definition.orderBy)},`)
+  if (definition.uniqueKey && definition.uniqueKey.length > 0) {
+    lines.push(`  uniqueKey: ${renderStringArray(definition.uniqueKey)},`)
+  }
+  if (definition.partitionBy) {
+    lines.push(`  partitionBy: ${renderString(definition.partitionBy)},`)
+  }
+  if (definition.ttl) {
+    lines.push(`  ttl: ${renderString(definition.ttl)},`)
+  }
+  if (definition.settings && Object.keys(definition.settings).length > 0) {
+    lines.push(...renderSettingsLines(definition.settings, '  '))
+  }
+  if (definition.indexes && definition.indexes.length > 0) {
+    lines.push(...renderIndexLines(definition.indexes))
+  }
+  if (definition.projections && definition.projections.length > 0) {
+    lines.push(...renderProjectionLines(definition.projections))
+  }
+  lines.push('})')
+  return lines
+}
+
+function renderViewDefinition(definition: ViewDefinition, variableName: string): string[] {
+  const lines = renderDeclarationHeader('view', variableName, definition.database, definition.name)
+  lines.push(`  as: ${renderString(definition.as)},`)
+  lines.push('})')
+  return lines
+}
+
+function renderMaterializedViewDefinition(
+  definition: MaterializedViewDefinition,
+  variableName: string
+): string[] {
+  const lines = renderDeclarationHeader('materializedView', variableName, definition.database, definition.name)
+  lines.push(`  to: { database: ${renderString(definition.to.database)}, name: ${renderString(definition.to.name)} },`)
+  if (definition.refresh) {
+    lines.push(...renderRefreshLines(definition.refresh))
+  }
+  lines.push(`  as: ${renderString(definition.as)},`)
+  lines.push('})')
+  return lines
+}
+
+function renderDeclarationHeader(
+  factory: string,
+  variableName: string,
+  database: string,
+  name: string
+): string[] {
+  return [
+    `const ${variableName} = ${factory}({`,
+    `  database: ${renderString(database)},`,
+    `  name: ${renderString(name)},`,
+  ]
+}
+
+function renderColumn(column: ColumnDefinition): string {
+  const parts: string[] = [
+    `name: ${renderString(column.name)}`,
+    `type: ${renderString(column.type)}`,
+  ]
+  if (column.nullable) parts.push('nullable: true')
+  if (column.default !== undefined) parts.push(`default: ${renderLiteral(column.default)}`)
+  if (column.comment) parts.push(`comment: ${renderString(column.comment)}`)
+  if (column.codec) parts.push(`codec: ${renderCodecSource(column.codec)}`)
+  return `{ ${parts.join(', ')} }`
+}
+
+function renderIndexLines(indexes: SkipIndexDefinition[]): string[] {
+  const lines: string[] = ['  indexes: [']
+  for (const index of indexes) {
+    lines.push(`    ${renderIndex(index)},`)
+  }
+  lines.push('  ],')
+  return lines
+}
+
+function renderIndex(index: SkipIndexDefinition): string {
+  const parts = [
+    `name: ${renderString(index.name)}`,
+    `expression: ${renderString(index.expression)}`,
+    `type: ${renderString(index.type)}`,
+  ]
+  switch (index.type) {
+    case 'minmax':
+      break
+    case 'set':
+      parts.push(`maxRows: ${index.maxRows}`)
+      break
+    case 'bloom_filter':
+      if (index.falsePositiveRate !== undefined) {
+        parts.push(`falsePositiveRate: ${index.falsePositiveRate}`)
+      }
+      break
+    case 'tokenbf_v1':
+      parts.push(
+        `sizeBytes: ${index.sizeBytes}`,
+        `hashFunctions: ${index.hashFunctions}`,
+        `randomSeed: ${index.randomSeed}`
+      )
+      break
+    case 'ngrambf_v1':
+      parts.push(
+        `ngramSize: ${index.ngramSize}`,
+        `sizeBytes: ${index.sizeBytes}`,
+        `hashFunctions: ${index.hashFunctions}`,
+        `randomSeed: ${index.randomSeed}`
+      )
+      break
+  }
+  parts.push(`granularity: ${index.granularity}`)
+  return `{ ${parts.join(', ')} }`
+}
+
+function renderProjectionLines(projections: ProjectionDefinition[]): string[] {
+  const lines: string[] = ['  projections: [']
+  for (const projection of projections) {
+    lines.push(`    { name: ${renderString(projection.name)}, query: ${renderString(projection.query)} },`)
+  }
+  lines.push('  ],')
+  return lines
+}
+
+function renderRefreshLines(refresh: MaterializedViewRefresh): string[] {
+  const lines: string[] = []
+  lines.push('  refresh: {')
+  if (refresh.every) lines.push(`    every: ${renderString(refresh.every)},`)
+  if (refresh.after) lines.push(`    after: ${renderString(refresh.after)},`)
+  if (refresh.offset) lines.push(`    offset: ${renderString(refresh.offset)},`)
+  if (refresh.randomize) lines.push(`    randomize: ${renderString(refresh.randomize)},`)
+  if (refresh.dependsOn && refresh.dependsOn.length > 0) {
+    lines.push('    dependsOn: [')
+    for (const dep of refresh.dependsOn) {
+      lines.push(`      { database: ${renderString(dep.database)}, name: ${renderString(dep.name)} },`)
+    }
+    lines.push('    ],')
+  }
+  if (refresh.settings && Object.keys(refresh.settings).length > 0) {
+    lines.push(...renderSettingsLines(refresh.settings, '    '))
+  }
+  if (refresh.append) lines.push('    append: true,')
+  if (refresh.empty) lines.push('    empty: true,')
+  lines.push('  },')
+  return lines
+}
+
+function renderSettingsLines(
+  settings: Record<string, string | number | boolean>,
+  indent: string
+): string[] {
+  const lines: string[] = [`${indent}settings: {`]
+  for (const key of Object.keys(settings).sort()) {
+    const value = settings[key]
+    if (value === undefined) continue
+    lines.push(`${indent}  ${renderKey(key)}: ${renderLiteral(value)},`)
+  }
+  lines.push(`${indent}},`)
+  return lines
 }
 
 function resolveTableVariableName(
@@ -180,37 +264,6 @@ function renderStringArray(values: string[]): string {
 function renderLiteral(value: string | number | boolean): string {
   if (typeof value === 'string') return renderString(value)
   return String(value)
-}
-
-function renderRefreshLines(refresh: MaterializedViewRefresh): string[] {
-  const lines: string[] = []
-  lines.push('  refresh: {')
-  if (refresh.every) lines.push(`    every: ${renderString(refresh.every)},`)
-  if (refresh.after) lines.push(`    after: ${renderString(refresh.after)},`)
-  if (refresh.offset) lines.push(`    offset: ${renderString(refresh.offset)},`)
-  if (refresh.randomize) lines.push(`    randomize: ${renderString(refresh.randomize)},`)
-  if (refresh.dependsOn && refresh.dependsOn.length > 0) {
-    lines.push('    dependsOn: [')
-    for (const dep of refresh.dependsOn) {
-      lines.push(
-        `      { database: ${renderString(dep.database)}, name: ${renderString(dep.name)} },`
-      )
-    }
-    lines.push('    ],')
-  }
-  if (refresh.settings && Object.keys(refresh.settings).length > 0) {
-    lines.push('    settings: {')
-    for (const key of Object.keys(refresh.settings).sort()) {
-      const value = refresh.settings[key]
-      if (value === undefined) continue
-      lines.push(`      ${renderKey(key)}: ${renderLiteral(value)},`)
-    }
-    lines.push('    },')
-  }
-  if (refresh.append) lines.push('    append: true,')
-  if (refresh.empty) lines.push('    empty: true,')
-  lines.push('  },')
-  return lines
 }
 
 function renderKey(value: string): string {


### PR DESCRIPTION
## Summary
Two behavior-preserving code-health changes from a fallow analysis, in one PR with separate commits.

- **`refactor(pull)`** — `renderSchemaFile` (cognitive 81 / cyclomatic 34) is split into per-object renderers (table / view / materialized view) plus shared helpers for the duplicated fragments (declaration header, column, index, projection, settings, codec). This removes the internal clone fallow flagged as `dup:daccb395`. Generated output is **byte-identical** — a full table + view + refreshable MV fixture in `index.test.ts` asserts exact output as the safety net.
- **`test(core)`** — adds `sql-splitter.test.ts` covering `splitSqlStatements` and `extractExecutableStatements`: multi-statement input, semicolons inside single/double/backtick quotes and comments (`--` and `/* */`), statements without trailing semicolons, empty/whitespace-only input, and the migration-metadata comment contract relied on by `migrate/apply.ts`. Tests only — the splitter is unchanged (safety net for a later refactor).

No user-facing change: pulled-schema output is identical, so no changeset and no docs updates.

## Test plan
- [x] `doppler run --project chkit --config ci -- bun test packages/plugin-pull packages/core` (incl. live-ClickHouse `pull.e2e`) — 307 pass
- [x] `bun run verify` (typecheck / lint / test / build) — 37/37 tasks pass
- [x] `bunx fallow` — `renderSchemaFile` no longer flagged; `dup:daccb395` gone