### PR TITLE
fix(backfill): replay every MV feeding the target, not just the first (NUM-7480)

### DIFF
--- a/.changeset/backfill-replay-all-mvs.md
+++ b/.changeset/backfill-replay-all-mvs.md
@@ -1,0 +1,6 @@
+---
+"@chkit/plugin-backfill": patch
+"@chkit/plugin-obsessiondb": patch
+---
+
+Fix `backfill` mv_replay so it rebuilds **every** materialized view feeding the target table, not just the first. ClickHouse allows several MVs to share one destination table; previously only the first-declared MV was replayed and the rest were silently dropped, leaving the backfill incomplete. Each chunk now runs one `INSERT INTO target … SELECT … UNION ALL SELECT …` covering all matching MVs, so a single query id and idempotency token still cover the chunk. Single-MV plans are unchanged.

--- a/apps/docs/src/content/docs/plugins/backfill.md
+++ b/apps/docs/src/content/docs/plugins/backfill.md
@@ -100,7 +100,7 @@ The plugin supports two strategies for backfilling data, chosen automatically ba
 
 **Table backfill** (`table` strategy): For direct table targets, inserts data by selecting from the same table within the time window. This is the most common case.
 
-**Materialized view replay** (`mv_replay` strategy): When the target is a materialized view's `to` table, the plugin detects the view's aggregation query and wraps it in a CTE (Common Table Expression). This re-materializes the aggregation for each chunk window, ensuring correctness for aggregate backfills. Requires `requireIdempotencyToken: true` for safe resumable retries.
+**Materialized view replay** (`mv_replay` strategy): When the target is the `to` table of one or more materialized views, the plugin replays each view's aggregation query over every chunk window, re-materializing the aggregation for that window and ensuring correctness for aggregate backfills. A target fed by several materialized views replays them all in a single `INSERT … SELECT … UNION ALL …` per chunk, so no view's rows are missed. Requires `requireIdempotencyToken: true` for safe resumable retries.
 
 ## Time column resolution
 

--- a/packages/plugin-backfill/src/chunking/sql.ts
+++ b/packages/plugin-backfill/src/chunking/sql.ts
@@ -32,7 +32,7 @@ export function buildChunkExecutionSql(input: {
   target: string
   table: Pick<TableProfile, 'sortKeys'>
   sourceTarget?: string
-  mvAsQuery?: string
+  mvReplayQueries?: string[]
   targetColumns?: string[]
   idempotencyToken?: string
 }): string {
@@ -41,15 +41,20 @@ export function buildChunkExecutionSql(input: {
   const settings = buildSettingsClause(input.idempotencyToken ?? '')
   const chunkConditions = buildChunkConditions(input.chunk, input.table.sortKeys)
 
-  if (input.mvAsQuery) {
-    let filtered = injectPartitionFilter(input.mvAsQuery, input.chunk.partitionId)
-    for (const condition of chunkConditions) {
-      filtered = injectWhereCondition(filtered, condition)
-    }
-    if (input.targetColumns?.length) {
-      filtered = rewriteSelectColumns(filtered, input.targetColumns)
-    }
-    return [header, `INSERT INTO ${input.target}`, filtered, settings].join('\n')
+  if (input.mvReplayQueries?.length) {
+    // Each MV feeding the target becomes a filtered SELECT; UNION ALL replays
+    // them in one INSERT so a single query_id and dedup token cover the chunk.
+    const selects = input.mvReplayQueries.map((query) => {
+      let filtered = injectPartitionFilter(query, input.chunk.partitionId)
+      for (const condition of chunkConditions) {
+        filtered = injectWhereCondition(filtered, condition)
+      }
+      if (input.targetColumns?.length) {
+        filtered = rewriteSelectColumns(filtered, input.targetColumns)
+      }
+      return filtered
+    })
+    return [header, `INSERT INTO ${input.target}`, selects.join('\nUNION ALL\n'), settings].join('\n')
   }
 
   const lines = [

--- a/packages/plugin-backfill/src/detect.test.ts
+++ b/packages/plugin-backfill/src/detect.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { table, materializedView } from '@chkit/core'
 import type { SchemaDefinition } from '@chkit/core'
 
-import { detectCandidatesFromTable, extractSchemaTimeColumn, findMvForTarget, findTableForTarget } from './detect.js'
+import { detectCandidatesFromTable, extractSchemaTimeColumn, findMvsForTarget, findTableForTarget } from './detect.js'
 
 describe('@chkit/plugin-backfill detect', () => {
   test('finds DateTime column in ORDER BY as top candidate', () => {
@@ -234,7 +234,7 @@ describe('@chkit/plugin-backfill detect', () => {
     expect(extractSchemaTimeColumn(def)).toBeUndefined()
   })
 
-  test('findMvForTarget returns MV matching target to.database and to.name', () => {
+  test('findMvsForTarget returns MV matching target to.database and to.name', () => {
     const mv = materializedView({
       database: 'app',
       name: 'events_mv',
@@ -253,14 +253,14 @@ describe('@chkit/plugin-backfill detect', () => {
       mv,
     ]
 
-    const found = findMvForTarget(definitions, 'app', 'events_agg')
+    const found = findMvsForTarget(definitions, 'app', 'events_agg')
 
-    expect(found).toBeDefined()
-    expect(found?.name).toBe('events_mv')
-    expect(found?.as).toBe('SELECT count() FROM app.events')
+    expect(found).toHaveLength(1)
+    expect(found[0]?.name).toBe('events_mv')
+    expect(found[0]?.as).toBe('SELECT count() FROM app.events')
   })
 
-  test('findMvForTarget returns undefined when no MV targets the table', () => {
+  test('findMvsForTarget returns an empty array when no MV targets the table', () => {
     const definitions: SchemaDefinition[] = [
       table({
         database: 'app',
@@ -272,10 +272,10 @@ describe('@chkit/plugin-backfill detect', () => {
       }),
     ]
 
-    expect(findMvForTarget(definitions, 'app', 'events')).toBeUndefined()
+    expect(findMvsForTarget(definitions, 'app', 'events')).toEqual([])
   })
 
-  test('findMvForTarget returns first MV when multiple target the same table', () => {
+  test('findMvsForTarget returns ALL MVs when multiple target the same table', () => {
     const mv1 = materializedView({
       database: 'app',
       name: 'hourly_mv',
@@ -290,9 +290,8 @@ describe('@chkit/plugin-backfill detect', () => {
     })
     const definitions: SchemaDefinition[] = [mv1, mv2]
 
-    const found = findMvForTarget(definitions, 'app', 'events_agg')
+    const found = findMvsForTarget(definitions, 'app', 'events_agg')
 
-    expect(found).toBeDefined()
-    expect(found?.name).toBe('hourly_mv')
+    expect(found.map((mv) => mv.name)).toEqual(['hourly_mv', 'daily_mv'])
   })
 })

--- a/packages/plugin-backfill/src/detect.ts
+++ b/packages/plugin-backfill/src/detect.ts
@@ -21,21 +21,23 @@ function isDateTimeType(type: string): boolean {
   return false
 }
 
-export function findMvForTarget(
+/**
+ * Return every materialized view whose `to` target is `database.table`.
+ * ClickHouse allows several MVs to feed the same destination table, so an
+ * mv_replay backfill must replay all of them — returning only the first would
+ * silently drop the rest.
+ */
+export function findMvsForTarget(
   definitions: SchemaDefinition[],
   database: string,
   table: string
-): MaterializedViewDefinition | undefined {
-  for (const def of definitions) {
-    if (
+): MaterializedViewDefinition[] {
+  return definitions.filter(
+    (def): def is MaterializedViewDefinition =>
       def.kind === 'materialized_view' &&
       def.to.database === database &&
       def.to.name === table
-    ) {
-      return def
-    }
-  }
-  return undefined
+  )
 }
 
 export function findTableForTarget(

--- a/packages/plugin-backfill/src/planner.test.ts
+++ b/packages/plugin-backfill/src/planner.test.ts
@@ -228,7 +228,7 @@ export const events_mv = {
           target: output.plan.target,
           sourceTarget: output.plan.execution.sourceTarget,
           table: output.plan.chunkPlan.table,
-          mvAsQuery: output.plan.execution.mvAsQuery,
+          mvReplayQueries: output.plan.execution.mvReplayQueries,
           targetColumns: output.plan.execution.targetColumns,
           idempotencyToken: generateIdempotencyToken(output.plan.planId, chunk.id),
         })
@@ -240,6 +240,79 @@ export const events_mv = {
       expect(sql).toContain('GROUP BY event_time')
       expect(sql).toContain('SETTINGS async_insert=0')
       expect(sql).not.toContain('FROM app.events_agg')
+      // Single MV: no UNION ALL, output identical to prior behavior.
+      expect(sql).not.toContain('UNION ALL')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('replays every MV feeding the target via UNION ALL when multiple MVs exist', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chkit-backfill-plugin-'))
+    const configPath = join(dir, 'clickhouse.config.ts')
+    const schemaPath = join(dir, 'schema.ts')
+
+    try {
+      await writeFile(
+        schemaPath,
+        `export const events_target = {
+  kind: 'table',
+  database: 'app',
+  name: 'events_agg',
+  columns: [
+    { name: 'event_time', type: 'DateTime' },
+    { name: 'count', type: 'UInt64' },
+  ],
+  engine: 'MergeTree',
+  primaryKey: ['event_time'],
+  orderBy: ['event_time'],
+}
+export const web_mv = {
+  kind: 'materialized_view',
+  database: 'app',
+  name: 'web_mv',
+  to: { database: 'app', name: 'events_agg' },
+  as: 'SELECT toStartOfHour(event_time) AS event_time, count() AS count FROM app.web_events GROUP BY event_time',
+}
+export const api_mv = {
+  kind: 'materialized_view',
+  database: 'app',
+  name: 'api_mv',
+  to: { database: 'app', name: 'events_agg' },
+  as: 'SELECT toStartOfHour(event_time) AS event_time, count() AS count FROM app.api_events GROUP BY event_time',
+}
+`
+      )
+
+      const config = resolveConfig({
+        schema: './schema.ts',
+        metaDir: './chkit/meta',
+      })
+      const opts = PlanSchema.parse({ target: 'app.events_agg' })
+      const output = await buildBackfillPlan({ opts, configPath, config, clickhouseQuery: createMockQuery() })
+
+      expect(output.plan.execution.mode).toBe('mv_replay')
+      expect(output.plan.execution.mvReplayQueries).toHaveLength(2)
+
+      const chunk = output.plan.chunkPlan.chunks[0]
+      const sql = chunk
+        ? buildChunkExecutionSql({
+          planId: output.plan.planId,
+          chunk,
+          target: output.plan.target,
+          sourceTarget: output.plan.execution.sourceTarget,
+          table: output.plan.chunkPlan.table,
+          mvReplayQueries: output.plan.execution.mvReplayQueries,
+          targetColumns: output.plan.execution.targetColumns,
+          idempotencyToken: generateIdempotencyToken(output.plan.planId, chunk.id),
+        })
+        : ''
+
+      // Both source tables are replayed, joined by a single UNION ALL, under one INSERT.
+      expect(sql.match(/INSERT INTO app\.events_agg/g)).toHaveLength(1)
+      expect(sql).toContain('FROM app.web_events')
+      expect(sql).toContain('FROM app.api_events')
+      expect(sql.match(/UNION ALL/g)).toHaveLength(1)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/packages/plugin-backfill/src/planner.ts
+++ b/packages/plugin-backfill/src/planner.ts
@@ -5,7 +5,7 @@ import { loadSchemaDefinitions } from '@chkit/core/schema-loader'
 
 import { encodeChunkPlanForPersistence } from './chunking/boundary-codec.js'
 import { generateChunkPlan } from './chunking/planner.js'
-import { findMvForTarget } from './detect.js'
+import { findMvsForTarget } from './detect.js'
 import { BackfillConfigError } from './errors.js'
 import type { PlanOptions } from './options.js'
 import {
@@ -61,16 +61,16 @@ export async function buildBackfillPlan(input: {
   const stateDir = computeBackfillStateDir(input.config, input.configPath, opts.stateDir)
   const paths = backfillPaths(stateDir, chunkPlan.planId)
 
-  let mvAsQuery: string | undefined
+  let mvReplayQueries: string[] | undefined
   let targetColumns: string[] | undefined
 
   try {
     const definitions = await loadSchemaDefinitions(input.config.schema, {
       cwd: dirname(input.configPath),
     })
-    const mv = findMvForTarget(definitions, database, table)
-    if (mv) {
-      mvAsQuery = mv.as
+    const mvs = findMvsForTarget(definitions, database, table)
+    if (mvs.length > 0) {
+      mvReplayQueries = mvs.map((mv) => mv.as)
       const tableDef = definitions.find(
         (definition) => definition.kind === 'table' && definition.database === database && definition.name === table
       )
@@ -91,9 +91,9 @@ export async function buildBackfillPlan(input: {
     to: derivedTo,
     chunkPlan,
     execution: {
-      mode: mvAsQuery ? 'mv_replay' as const : 'copy' as const,
+      mode: mvReplayQueries ? 'mv_replay' as const : 'copy' as const,
       sourceTarget: opts.target,
-      ...(mvAsQuery ? { mvAsQuery } : {}),
+      ...(mvReplayQueries ? { mvReplayQueries } : {}),
       ...(targetColumns ? { targetColumns } : {}),
       requireIdempotencyToken: opts.requireIdempotencyToken,
     },

--- a/packages/plugin-backfill/src/plugin.ts
+++ b/packages/plugin-backfill/src/plugin.ts
@@ -140,7 +140,7 @@ async function runBackfill(input: {
           target: plan.target,
           sourceTarget: plan.execution.sourceTarget,
           table: plan.chunkPlan.table,
-          mvAsQuery: plan.execution.mvAsQuery,
+          mvReplayQueries: plan.execution.mvReplayQueries,
           targetColumns: plan.execution.targetColumns,
           idempotencyToken: plan.execution.requireIdempotencyToken
             ? generateIdempotencyToken(plan.planId, planChunk.id)

--- a/packages/plugin-backfill/src/types.ts
+++ b/packages/plugin-backfill/src/types.ts
@@ -25,7 +25,11 @@ export type BackfillPlanStatus = 'planned' | 'running' | 'paused' | 'completed' 
 interface BackfillExecutionPlan {
   mode: 'copy' | 'mv_replay'
   sourceTarget: string
-  mvAsQuery?: string
+  /**
+   * One `SELECT` per materialized view feeding the target table. mv_replay
+   * inserts all of them (via `UNION ALL`) so every MV's rows are rebuilt.
+   */
+  mvReplayQueries?: string[]
   targetColumns?: string[]
   requireIdempotencyToken: boolean
 }

--- a/packages/plugin-obsessiondb/src/backfill/submit.test.ts
+++ b/packages/plugin-obsessiondb/src/backfill/submit.test.ts
@@ -108,6 +108,26 @@ describe('buildSubmitTasks', () => {
 		const [first] = buildSubmitTasks(makePlan(false))
 		expect(first?.sql).not.toContain('insert_deduplication_token=')
 	})
+
+	test('replays every MV via UNION ALL for an mv_replay plan', () => {
+		const plan = makePlan()
+		plan.execution = {
+			mode: 'mv_replay',
+			sourceTarget: 'app.events',
+			mvReplayQueries: [
+				'SELECT id FROM app.web_events',
+				'SELECT id FROM app.api_events',
+			],
+			targetColumns: ['id'],
+			requireIdempotencyToken: true,
+		}
+
+		const [first] = buildSubmitTasks(plan)
+		expect(first?.sql.match(/INSERT INTO app\.events/g)).toHaveLength(1)
+		expect(first?.sql).toContain('FROM app.web_events')
+		expect(first?.sql).toContain('FROM app.api_events')
+		expect(first?.sql.match(/UNION ALL/g)).toHaveLength(1)
+	})
 })
 
 describe('parseSubmitInput', () => {

--- a/packages/plugin-obsessiondb/src/backfill/submit.ts
+++ b/packages/plugin-obsessiondb/src/backfill/submit.ts
@@ -38,7 +38,7 @@ export function buildSubmitTasks(plan: BackfillPlanState): SubmitTask[] {
 			target: plan.target,
 			sourceTarget: plan.execution.sourceTarget,
 			table: plan.chunkPlan.table,
-			mvAsQuery: plan.execution.mvAsQuery,
+			mvReplayQueries: plan.execution.mvReplayQueries,
 			targetColumns: plan.execution.targetColumns,
 			idempotencyToken: plan.execution.requireIdempotencyToken
 				? generateIdempotencyToken(plan.planId, chunk.id)


### PR DESCRIPTION
## Summary
Fixes **NUM-7480**. `backfill` mv_replay rebuilt a target table from only the *first* materialized view whose `to` matched it. ClickHouse allows several MVs to share one destination table, so the rest were silently dropped and the backfill came out incomplete.

- `detect.ts`: `findMvForTarget` → `findMvsForTarget` — returns **every** MV feeding the target.
- `planner.ts` / `types.ts`: the plan now carries `mvReplayQueries: string[]` (renamed from `mvAsQuery`).
- `chunking/sql.ts`: `buildChunkExecutionSql` replays all MV queries in a single `INSERT INTO target SELECT … UNION ALL SELECT …` per chunk, so one deterministic `query_id` and one `insert_deduplication_token` still cover the chunk (separate statements would break query-id tracking and dedup-drop every insert after the first). Single-MV plans emit byte-identical SQL.
- Threaded through both execution venues: local `run` (`plugin.ts`) and managed `submit` (`plugin-obsessiondb`).
- Docs: clarified the `mv_replay` strategy description for multi-MV targets.

Clean rename with no back-compat shim — `@chkit/plugin-backfill` is `0.1.2-beta`, plans are ephemeral/regenerated and read via plain `JSON.parse`.

## Test plan
- [x] New unit coverage: `findMvsForTarget` returns **all** matching MVs; planner produces a 2-element `mvReplayQueries` + `UNION ALL` SQL; managed `submit` path does the same.
- [x] `typecheck`, `lint`, `build` pass; `@chkit/plugin-backfill` and `@chkit/plugin-obsessiondb` test tasks (incl. live e2e) pass under `bun verify`.
- [x] Eyeballed generated multi-MV SQL: valid ClickHouse — correct per-branch `WHERE` injection, preserved `GROUP BY`s, single trailing `SETTINGS`/dedup token.
- [x] Optional: live multi-MV backfill against a real ObsessionDB service.

> Note: the only `bun verify` failures are pre-existing live-cluster **auth** errors in `packages/cli` (untouched by this PR) — no code-path connection to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)