### PR TITLE
docs: link ObsessionDB Jobs page from the backfill jobs guide

### DIFF
--- a/apps/docs/src/content/docs/obsessiondb/backfills.md
+++ b/apps/docs/src/content/docs/obsessiondb/backfills.md
@@ -39,7 +39,7 @@ The backend runs the chunks server-side, so there is no local checkpoint and not
 
 ## Track progress
 
-The console link from `submit` is the primary way to watch a job. From the CLI, the remote job commands query the backend directly — they take a `--job-id` or `--service-slug` instead of a local `--plan-id`:
+The console link from `submit` is the primary way to watch a job. It opens the job in the ObsessionDB console under Service → Jobs, with live progress and controls to pause, retry, or cancel the run. The [Jobs docs](https://obsessiondb.com/docs/jobs) cover that view in full. From the CLI, the remote job commands query the backend directly — they take a `--job-id` or `--service-slug` instead of a local `--plan-id`:
 
 ```sh
 # Status of one job


### PR DESCRIPTION
## Summary
- The ObsessionDB Jobs docs page (https://obsessiondb.com/docs/jobs) just went live. It documents the console view where managed backfills appear as jobs.
- Added a brief mention in the **Track progress** section of `obsessiondb/backfills.md` linking to it, so readers submitting a managed backfill can find the full console walkthrough.

## Test plan
- [x] `cd apps/docs && bun run build` succeeds (34 raw pages, llms.txt regenerated)
- [x] External link resolves (HTTP 200)