### PR TITLE
fix(release): regenerate lockfile after version bump and guard it

### DIFF
--- a/scripts/manual-release.ts
+++ b/scripts/manual-release.ts
@@ -8,7 +8,8 @@
  *        - default:   enters beta prerelease mode if needed
  *        - --stable:  exits prerelease mode so versions graduate to GA
  *   3. Applies pending changesets (version bump) if they exist,
- *      or detects already-bumped versions from a prior run
+ *      or detects already-bumped versions from a prior run, then
+ *      regenerates the lockfile so it matches the bumped versions
  *   4. Runs quality gates (typecheck, lint, test, build)
  *   5. Runs release guards (internal workspace deps + packed tarballs)
  *   6. Publishes all public workspace packages via `bun publish`:
@@ -192,6 +193,15 @@ function applyPendingChangesets(dryRun: boolean, stable: boolean): boolean {
 	}
 
 	runCommand('bun', ['run', 'version-packages'])
+
+	// `changeset version` rewrites package.json versions but never touches the
+	// lockfile. examples/* pin sibling chkit packages to exact published betas,
+	// so once the workspace version moves past that pin bun can no longer dedupe
+	// them onto the local copies and must record fresh registry resolutions.
+	// Regenerate the lockfile here so the release commit carries them; otherwise
+	// CI's `bun install --frozen-lockfile` rejects the stale lockfile on main.
+	runCommand('bun', ['install', '--lockfile-only'])
+
 	return true
 }
 
@@ -595,8 +605,12 @@ function runQualityGates(): void {
  */
 function runReleaseGuards(): void {
 	logLine(
-		'Running release guards (internal workspace deps + packed tarballs)...',
+		'Running release guards (lockfile + internal workspace deps + packed tarballs)...',
 	)
+	// Fail here if the committed lockfile does not satisfy the bumped versions —
+	// the same check CI runs on main. This catches a stale lockfile before the
+	// release is pushed rather than after.
+	runCommand('bun', ['install', '--frozen-lockfile'])
 	runCommand('bun', ['run', 'check:workspace-deps'])
 	runCommand('bun', ['run', 'check:packed-deps'])
 }


### PR DESCRIPTION
## Summary

Main CI went red on the `chore: version packages` commit with `bun install --frozen-lockfile` failing (`lockfile had changes, but lockfile is frozen`). Root cause: `scripts/manual-release.ts` runs `changeset version` (which bumps every `package.json`) but **never regenerates the lockfile**, then commits with `git add -A`. `examples/clickbench` pins its chkit deps to exact published betas; while the workspace version equals that pin, bun dedupes those deps onto the local workspace copies and the stale lockfile passes. Once a release bumps the workspace *past* the pin (beta.2 → beta.4), bun must resolve those packages from the registry — resolutions absent from the committed lockfile — so frozen install fails. Both existing lockfile guards live in CI *after* the push, so nothing stopped the bad lockfile from landing on main.

This PR fixes the release script:

- Run `bun install --lockfile-only` right after `version-packages` so the release commit carries the updated resolutions.
- Add `bun install --frozen-lockfile` to `runReleaseGuards()` so a stale lockfile fails the release locally before it is pushed.

The already-broken lockfile on `main` was regenerated separately in `a3c7006` (main is green again); this PR prevents recurrence.

## Test plan

- [x] `bun run typecheck` passes
- [x] `biome check scripts/manual-release.ts` clean
- [ ] Next release runs cleanly and the `chore: version packages` commit passes CI's frozen-install step