### PR TITLE
ci: restrict GITHUB_TOKEN permissions in chkit-py publish workflow

### DIFF
--- a/.github/workflows/publish-chkit-py.yml
+++ b/.github/workflows/publish-chkit-py.yml
@@ -9,6 +9,11 @@ on:
     tags:
       - "chkit-py-v*"
 
+# Minimal default for every job; the publish job overrides with the
+# id-token permission OIDC needs.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a workflow-level `permissions: contents: read` to `publish-chkit-py.yml`, resolving the CodeQL / Advanced Security finding ("Workflow does not contain permissions"). The `publish` job keeps its explicit `id-token: write` block for PyPI trusted publishing.

## Test plan
- [x] Workflow-only change; the build job needs nothing beyond checkout (contents: read)